### PR TITLE
refactor(frontend): decouple shared chat draft persistence

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
@@ -361,19 +361,25 @@ describe("AgentChatComposer attachments", () => {
     typeIntoComposer(container, "send once");
     await flushAgentChatDraft(identity);
     fireEvent.click(screen.getByRole("button", { name: "Send message" }));
-    await waitFor(() => {
-      expect(onSend).toHaveBeenCalledTimes(1);
-      expect(getEditorRoot(container).textContent).not.toContain("send once");
-    });
+    await waitFor(
+      () => {
+        expect(onSend).toHaveBeenCalledTimes(1);
+        expect(getEditorRoot(container).textContent).not.toContain("send once");
+      },
+      { timeout: 2_000 },
+    );
 
     rerender(<AgentChatComposer model={buildPersistedModel()} />);
     expect(getEditorRoot(container).textContent).not.toContain("send once");
 
     sendResult.resolve(true);
-    await waitFor(() => {
-      expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toBeNull();
-      expect(getEditorRoot(container).textContent).not.toContain("send once");
-    });
+    await waitFor(
+      () => {
+        expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toBeNull();
+        expect(getEditorRoot(container).textContent).not.toContain("send once");
+      },
+      { timeout: 2_000 },
+    );
   });
 
   test("clears a successfully sent attachment draft when staging resolves during send", async () => {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
@@ -123,6 +123,7 @@ const sessionIdentity = (
 const persistedDraftScope = (key: string, identity: AgentChatDraftSessionIdentity) => ({
   key,
   persistence: {
+    targetKey: toAgentChatDraftStorageKey(identity),
     hydrate: () => hydrateAgentChatDraft(identity, "task-1"),
     set: (draft: Parameters<typeof setAgentChatDraft>[2]) =>
       setAgentChatDraft(identity, "task-1", draft),
@@ -340,6 +341,38 @@ describe("AgentChatComposer attachments", () => {
     await waitFor(() => {
       expect(onSend).toHaveBeenCalledTimes(1);
       expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toBeNull();
+    });
+  });
+
+  test("keeps the composer empty when equivalent persistence refreshes during send", async () => {
+    const storage = createMemoryStorage();
+    const identity = sessionIdentity("session-a");
+    const sendResult = createDeferred<boolean>();
+    const onSend = mock(() => sendResult.promise);
+    setAgentChatDraftStorageForTests(storage);
+    const buildPersistedModel = () => ({
+      ...buildModel(),
+      onSend,
+      displayedSessionKey: "session-a",
+      draftScope: persistedDraftScope("draft-a", identity),
+    });
+    const { container, rerender } = render(<AgentChatComposer model={buildPersistedModel()} />);
+
+    typeIntoComposer(container, "send once");
+    await flushAgentChatDraft(identity);
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledTimes(1);
+      expect(getEditorRoot(container).textContent).not.toContain("send once");
+    });
+
+    rerender(<AgentChatComposer model={buildPersistedModel()} />);
+    expect(getEditorRoot(container).textContent).not.toContain("send once");
+
+    sendResult.resolve(true);
+    await waitFor(() => {
+      expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toBeNull();
+      expect(getEditorRoot(container).textContent).not.toContain("send once");
     });
   });
 

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
@@ -8,8 +8,12 @@ import {
   writeAgentChatDraftToStorage,
 } from "./agent-chat-draft-storage";
 import {
+  clearAgentChatDraft,
   flushAgentChatDraft,
+  hydrateAgentChatDraft,
+  readAgentChatDraftVersion,
   resetAgentChatDraftStoreForTests,
+  setAgentChatDraft,
   setAgentChatDraftAttachmentStagerForTests,
   setAgentChatDraftStorageForTests,
 } from "./agent-chat-draft-store";
@@ -27,14 +31,15 @@ const SHARED_CALLBACKS = {
 };
 
 const buildModel = () => ({
-  taskId: "task-1",
   displayedSessionKey: "session-1",
   isInteractionEnabled: true,
   isReadOnly: false,
   readOnlyReason: null,
   busySendBlockedReason: null,
-  draftStateKey: "draft-1",
-  draftPersistenceIdentity: null,
+  draftScope: {
+    key: "draft-1",
+    persistence: null,
+  },
   onSend: SHARED_CALLBACKS.onSend,
   isSending: false,
   isStarting: false,
@@ -115,6 +120,19 @@ const sessionIdentity = (
   workingDirectory,
 });
 
+const persistedDraftScope = (key: string, identity: AgentChatDraftSessionIdentity) => ({
+  key,
+  persistence: {
+    hydrate: () => hydrateAgentChatDraft(identity, "task-1"),
+    set: (draft: Parameters<typeof setAgentChatDraft>[2]) =>
+      setAgentChatDraft(identity, "task-1", draft),
+    readVersion: () => readAgentChatDraftVersion(identity),
+    clear: (options?: Parameters<typeof clearAgentChatDraft>[1]) =>
+      clearAgentChatDraft(identity, options),
+    flush: () => flushAgentChatDraft(identity),
+  },
+});
+
 const createDeferred = <T,>() => {
   let resolve: ((value: T) => void) | null = null;
   const promise = new Promise<T>((res) => {
@@ -191,8 +209,7 @@ describe("AgentChatComposer attachments", () => {
         model={{
           ...buildModel(),
           displayedSessionKey: "session-a",
-          draftStateKey: "draft-a",
-          draftPersistenceIdentity: sessionA,
+          draftScope: persistedDraftScope("draft-a", sessionA),
         }}
       />,
     );
@@ -203,8 +220,7 @@ describe("AgentChatComposer attachments", () => {
         model={{
           ...buildModel(),
           displayedSessionKey: "session-b",
-          draftStateKey: "draft-b",
-          draftPersistenceIdentity: sessionB,
+          draftScope: persistedDraftScope("draft-b", sessionB),
         }}
       />,
     );
@@ -218,8 +234,7 @@ describe("AgentChatComposer attachments", () => {
         model={{
           ...buildModel(),
           displayedSessionKey: "session-a",
-          draftStateKey: "draft-a",
-          draftPersistenceIdentity: sessionA,
+          draftScope: persistedDraftScope("draft-a", sessionA),
         }}
       />,
     );
@@ -242,8 +257,7 @@ describe("AgentChatComposer attachments", () => {
         model={{
           ...buildModel(),
           displayedSessionKey: "session-a",
-          draftStateKey: "draft-a",
-          draftPersistenceIdentity: sessionA,
+          draftScope: persistedDraftScope("draft-a", sessionA),
         }}
       />,
     );
@@ -252,8 +266,7 @@ describe("AgentChatComposer attachments", () => {
         model={{
           ...buildModel(),
           displayedSessionKey: "session-b",
-          draftStateKey: "draft-b",
-          draftPersistenceIdentity: sessionB,
+          draftScope: persistedDraftScope("draft-b", sessionB),
         }}
       />,
     );
@@ -262,8 +275,7 @@ describe("AgentChatComposer attachments", () => {
         model={{
           ...buildModel(),
           displayedSessionKey: "session-a",
-          draftStateKey: "draft-a",
-          draftPersistenceIdentity: sessionA,
+          draftScope: persistedDraftScope("draft-a", sessionA),
         }}
       />,
     );
@@ -293,8 +305,7 @@ describe("AgentChatComposer attachments", () => {
         model={{
           ...buildModel(),
           displayedSessionKey: "session-a",
-          draftStateKey: "draft-a",
-          draftPersistenceIdentity: identity,
+          draftScope: persistedDraftScope("draft-a", identity),
         }}
       />,
     );
@@ -315,8 +326,7 @@ describe("AgentChatComposer attachments", () => {
           ...buildModel(),
           onSend,
           displayedSessionKey: "session-a",
-          draftStateKey: "draft-a",
-          draftPersistenceIdentity: identity,
+          draftScope: persistedDraftScope("draft-a", identity),
         }}
       />,
     );
@@ -348,8 +358,7 @@ describe("AgentChatComposer attachments", () => {
           ...buildModel(),
           onSend,
           displayedSessionKey: "session-a",
-          draftStateKey: "draft-a",
-          draftPersistenceIdentity: identity,
+          draftScope: persistedDraftScope("draft-a", identity),
           selectedModelDescriptor: {
             id: "openai/gpt-5.3-codex",
             providerId: "openai",
@@ -415,8 +424,7 @@ describe("AgentChatComposer attachments", () => {
           ...buildModel(),
           onSend,
           displayedSessionKey: "session-a",
-          draftStateKey: "draft-a",
-          draftPersistenceIdentity: identity,
+          draftScope: persistedDraftScope("draft-a", identity),
         }}
       />,
     );
@@ -578,7 +586,10 @@ describe("AgentChatComposer attachments", () => {
       <AgentChatComposer
         model={{
           ...initialModel,
-          draftStateKey: "draft-2",
+          draftScope: {
+            key: "draft-2",
+            persistence: null,
+          },
           displayedSessionKey: "session-2",
         }}
       />,

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.test.ts
@@ -5,14 +5,15 @@ import { AgentChatComposer } from "./agent-chat-composer";
 import { buildModelSelection } from "./agent-chat-test-fixtures";
 
 const buildModel = () => ({
-  taskId: "task-1",
   displayedSessionKey: "session-1",
   isInteractionEnabled: true,
   isReadOnly: false,
   readOnlyReason: null,
   busySendBlockedReason: null,
-  draftStateKey: "draft-1",
-  draftPersistenceIdentity: null,
+  draftScope: {
+    key: "draft-1",
+    persistence: null,
+  },
   onSend: async () => true,
   isSending: false,
   isStarting: false,
@@ -227,7 +228,10 @@ describe("AgentChatComposer", () => {
           ...buildModel(),
           isSending: true,
           isSessionWorking: true,
-          draftStateKey: "queued-followup-ready",
+          draftScope: {
+            key: "queued-followup-ready",
+            persistence: null,
+          },
         },
       }),
     );
@@ -388,7 +392,10 @@ describe("AgentChatComposer", () => {
           ...buildModel(),
           busySendBlockedReason:
             "Current runtime does not support queued messages while the session is working.",
-          draftStateKey: "busy-send-visible",
+          draftScope: {
+            key: "busy-send-visible",
+            persistence: null,
+          },
           isSessionWorking: true,
         },
       }),

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.tsx
@@ -537,15 +537,13 @@ export function AgentChatComposer({
   ref?: Ref<AgentChatComposerHandle>;
 }): ReactElement {
   const {
-    taskId,
     displayedSessionKey,
     isInteractionEnabled,
     isReadOnly,
     readOnlyReason,
     busySendBlockedReason,
     pendingSendItems,
-    draftStateKey,
-    draftPersistenceIdentity,
+    draftScope,
     onSend,
     isSending,
     isStarting,
@@ -573,9 +571,7 @@ export function AgentChatComposer({
     clearSubmittedDraft,
     restoreSubmittedDraft,
   } = useAgentChatComposerDraftState({
-    draftStateKey,
-    persistenceIdentity: draftPersistenceIdentity,
-    taskId,
+    scope: draftScope,
   });
   const latestDraftRef = useRef<AgentChatComposerDraft>(draft);
   const latestSendDisabledRef = useRef(false);
@@ -678,7 +674,6 @@ export function AgentChatComposer({
     isReadOnly ||
     hasBlockingAttachments ||
     hasSlashAttachmentConflict ||
-    !taskId ||
     !hasComposerSendContent(draft, pendingSendItems) ||
     !isInteractionEnabled;
 
@@ -703,7 +698,7 @@ export function AgentChatComposer({
   }, [attachmentLayoutKey, syncBottomAfterComposerLayoutRef]);
 
   const selectorDisabled =
-    !taskId || isSelectionCatalogLoading || isSubmitting || !isInteractionEnabled || isReadOnly;
+    isSelectionCatalogLoading || isSubmitting || !isInteractionEnabled || isReadOnly;
 
   const scheduleComposerFocus = useAgentChatComposerFocus({
     composerEditorRef,

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-scope.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-scope.test.ts
@@ -18,6 +18,7 @@ describe("agent chat draft scope", () => {
     const scope = {
       key: "caller-owned",
       persistence: {
+        targetKey: "caller-owned:persistence",
         hydrate: () => draft,
         set: () => 1,
         readVersion: () => 1,

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-scope.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-scope.test.ts
@@ -1,59 +1,31 @@
 import { describe, expect, test } from "bun:test";
-import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
-import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
-import {
-  type AgentChatDraftScope,
-  agentChatDraftScopeKey,
-  didAgentChatDraftScopeSwitchSessionOnly,
-} from "./agent-chat-draft-scope";
+import { createEmptyComposerDraft } from "./agent-chat-composer-draft";
+import type { AgentChatDraftScope } from "./agent-chat-draft-scope";
 
-const session = (externalSessionId: string): AgentSessionIdentity => ({
-  externalSessionId,
-  runtimeKind: "opencode",
-  workingDirectory: "/repo",
-});
+describe("agent chat draft scope", () => {
+  test("accepts an opaque non-task identity without persistence", () => {
+    const scope = {
+      key: "repository-chat:conversation/42",
+      persistence: null,
+    } satisfies AgentChatDraftScope;
 
-const scope = (overrides: Partial<AgentChatDraftScope> = {}): AgentChatDraftScope => ({
-  taskId: "task-1",
-  role: "planner",
-  session: null,
-  ...overrides,
-});
-
-describe("agent-chat-draft-scope", () => {
-  test("builds the stable composer draft key from the selected session identity", () => {
-    const selectedSession = session("session-1");
-
-    expect(agentChatDraftScopeKey(scope({ session: selectedSession }))).toBe(
-      `task-1:planner:${agentSessionIdentityKey(selectedSession)}`,
-    );
+    expect(scope.key).toBe("repository-chat:conversation/42");
+    expect(scope.persistence).toBeNull();
   });
 
-  test("uses a new-session key when no session is selected", () => {
-    expect(agentChatDraftScopeKey(scope())).toBe("task-1:planner:new");
-  });
+  test("accepts caller-owned persistence behavior", () => {
+    const draft = createEmptyComposerDraft();
+    const scope = {
+      key: "caller-owned",
+      persistence: {
+        hydrate: () => draft,
+        set: () => 1,
+        readVersion: () => 1,
+        clear: () => true,
+        flush: async () => {},
+      },
+    } satisfies AgentChatDraftScope;
 
-  test("recognizes same task and role switches between session scopes", () => {
-    expect(
-      didAgentChatDraftScopeSwitchSessionOnly(
-        scope({ session: session("session-1") }),
-        scope({ session: session("session-2") }),
-      ),
-    ).toBe(true);
-  });
-
-  test("does not treat task or role changes as session-only transitions", () => {
-    expect(
-      didAgentChatDraftScopeSwitchSessionOnly(
-        scope({ session: session("session-1") }),
-        scope({ taskId: "task-2", session: session("session-2") }),
-      ),
-    ).toBe(false);
-    expect(
-      didAgentChatDraftScopeSwitchSessionOnly(
-        scope({ session: session("session-1") }),
-        scope({ role: "build", session: session("session-2") }),
-      ),
-    ).toBe(false);
+    expect(scope.persistence.hydrate()).toBe(draft);
   });
 });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-scope.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-scope.ts
@@ -1,6 +1,7 @@
 import type { AgentChatComposerDraft } from "./agent-chat-composer-draft";
 
 export type AgentChatDraftPersistence = {
+  targetKey: string;
   hydrate: () => AgentChatComposerDraft;
   set: (draft: AgentChatComposerDraft) => number;
   readVersion: () => number | null;

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-scope.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-scope.ts
@@ -1,6 +1,7 @@
 import type { AgentChatComposerDraft } from "./agent-chat-composer-draft";
 
 export type AgentChatDraftPersistence = {
+  /** Equivalent adapter wrappers must share this key; different persistence targets must not. */
   targetKey: string;
   hydrate: () => AgentChatComposerDraft;
   set: (draft: AgentChatComposerDraft) => number;

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-scope.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-scope.ts
@@ -1,25 +1,14 @@
-import type { AgentRole } from "@openducktor/core";
-import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
-import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
+import type { AgentChatComposerDraft } from "./agent-chat-composer-draft";
 
-export type AgentChatDraftScope = {
-  taskId: string;
-  role: AgentRole;
-  session: AgentSessionIdentity | null;
+export type AgentChatDraftPersistence = {
+  hydrate: () => AgentChatComposerDraft;
+  set: (draft: AgentChatComposerDraft) => number;
+  readVersion: () => number | null;
+  clear: (options?: { onlyIfVersion?: number | null }) => boolean;
+  flush: () => Promise<void>;
 };
 
-const NEW_SESSION_DRAFT_SCOPE = "new";
-
-const sessionScopeKey = (session: AgentSessionIdentity | null): string =>
-  session ? agentSessionIdentityKey(session) : NEW_SESSION_DRAFT_SCOPE;
-
-export const agentChatDraftScopeKey = ({ taskId, role, session }: AgentChatDraftScope): string =>
-  [taskId, role, sessionScopeKey(session)].join(":");
-
-export const didAgentChatDraftScopeSwitchSessionOnly = (
-  previous: AgentChatDraftScope,
-  next: AgentChatDraftScope,
-): boolean =>
-  previous.taskId === next.taskId &&
-  previous.role === next.role &&
-  sessionScopeKey(previous.session) !== sessionScopeKey(next.session);
+export type AgentChatDraftScope = {
+  key: string;
+  persistence: AgentChatDraftPersistence | null;
+};

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.ts
@@ -430,12 +430,6 @@ export const flushAgentChatDraft = (identity: AgentChatDraftSessionIdentity): Pr
   return flushPromise;
 };
 
-export const flushAllAgentChatDrafts = async (): Promise<void> => {
-  await Promise.all(
-    Array.from(draftEntries.values(), (entry) => flushAgentChatDraft(entry.identity)),
-  );
-};
-
 export const clearAgentChatDraftsForTargets = (targets: AgentChatDraftCleanupTarget[]): void => {
   const uniqueIdentities = new Map<string, AgentChatDraftSessionIdentity>();
   for (const target of targets) {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat.attachments.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat.attachments.test.tsx
@@ -44,14 +44,15 @@ const buildModel = () => ({
     syncBottomAfterComposerLayoutRef: { current: null } as { current: (() => void) | null },
   }),
   composer: {
-    taskId: "task-1",
     displayedSessionKey: "session-1",
     isInteractionEnabled: true,
     isReadOnly: false,
     readOnlyReason: null,
     busySendBlockedReason: null,
-    draftStateKey: "draft-1",
-    draftPersistenceIdentity: null,
+    draftScope: {
+      key: "draft-1",
+      persistence: null,
+    },
     onSend: async () => true,
     isSending: false,
     isStarting: false,

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat.test.ts
@@ -47,14 +47,15 @@ const buildModel = () => ({
     syncBottomAfterComposerLayoutRef: { current: null } as { current: (() => void) | null },
   }),
   composer: {
-    taskId: "task-1",
     displayedSessionKey: "session-1",
     isInteractionEnabled: true,
     isReadOnly: false,
     readOnlyReason: null,
     busySendBlockedReason: null,
-    draftStateKey: "draft-1",
-    draftPersistenceIdentity: null,
+    draftScope: {
+      key: "draft-1",
+      persistence: null,
+    },
     onSend: async () => true,
     isSending: false,
     isStarting: false,

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat.types.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat.types.ts
@@ -25,7 +25,7 @@ import type {
   SessionMessagesState,
 } from "@/types/agent-orchestrator";
 import type { AgentSessionActivityState } from "@/types/agent-session-activity";
-import type { AgentChatDraftSessionIdentity } from "./agent-chat-draft-storage";
+import type { AgentChatDraftScope } from "./agent-chat-draft-scope";
 
 export type AgentRoleOption = {
   role: AgentRole;
@@ -106,15 +106,13 @@ export type AgentChatPendingSendItems = {
 };
 
 export type AgentChatComposerModel = {
-  taskId: string;
   displayedSessionKey: string | null;
   isInteractionEnabled: boolean;
   isReadOnly: boolean;
   readOnlyReason: string | null;
   busySendBlockedReason: string | null;
   pendingSendItems?: AgentChatPendingSendItems;
-  draftStateKey: string;
-  draftPersistenceIdentity: AgentChatDraftSessionIdentity | null;
+  draftScope: AgentChatDraftScope;
   onSend: (draft: import("./agent-chat-composer-draft").AgentChatComposerDraft) => Promise<boolean>;
   isSending: boolean;
   isStarting: boolean;

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.test.ts
@@ -72,6 +72,55 @@ afterEach(() => {
 });
 
 describe("useAgentChatComposerDraftState", () => {
+  test("adopts fresh equivalent persistence wrappers without scheduling another render", async () => {
+    const adapters: AgentChatDraftPersistence[] = [];
+    const useInlinePersistenceDraftState = (_props: { render: number }) => {
+      const adapter: AgentChatDraftPersistence = {
+        targetKey: "equivalent-target",
+        hydrate: createEmptyComposerDraft,
+        set: mock(() => 1),
+        readVersion: () => 0,
+        clear: () => true,
+        flush: mock(async () => {}),
+      };
+      adapters.push(adapter);
+      return useAgentChatComposerDraftState({
+        scope: {
+          key: "conversation:equivalent-wrapper",
+          persistence: adapter,
+        },
+      });
+    };
+    const harness = createHookHarness(useInlinePersistenceDraftState, { render: 0 });
+
+    await harness.mount();
+    expect(adapters).toHaveLength(1);
+
+    await harness.update({ render: 1 });
+    expect(adapters).toHaveLength(2);
+    const adoptedAdapter = adapters[1];
+    if (!adoptedAdapter) {
+      throw new Error("Expected the rerendered persistence adapter.");
+    }
+
+    const updatedDraft = buildDraft("updated through adopted wrapper");
+    await harness.run((value) => {
+      value.commitDraft(updatedDraft);
+    });
+    expect(adoptedAdapter.set).toHaveBeenCalledWith(updatedDraft);
+    expect(adapters).toHaveLength(3);
+
+    const latestAdapter = adapters[2];
+    if (!latestAdapter) {
+      throw new Error("Expected the latest persistence adapter.");
+    }
+    window.dispatchEvent(new Event("pagehide"));
+    expect(latestAdapter.flush).toHaveBeenCalledTimes(1);
+
+    await harness.unmount();
+    expect(latestAdapter.flush).toHaveBeenCalledTimes(2);
+  });
+
   test("keeps an opaque non-task draft identity in memory without persistence", async () => {
     const harness = await mountHarness({
       key: "repository-chat:conversation/42",

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.test.ts
@@ -92,6 +92,124 @@ describe("useAgentChatComposerDraftState", () => {
     await harness.unmount();
   });
 
+  test("adopts persistence for the same key and hydrates an empty in-memory draft", async () => {
+    const persistence = createFakePersistence(buildDraft("persisted"));
+    const harness = await mountHarness({
+      key: "conversation:late-persistence",
+      persistence: null,
+    });
+
+    await harness.update({
+      scope: {
+        key: "conversation:late-persistence",
+        persistence: persistence.adapter,
+      },
+    });
+
+    expect(harness.getLatest().draft.segments[0]).toEqual(
+      expect.objectContaining({ text: "persisted" }),
+    );
+    await harness.run((value) => {
+      value.commitDraft(buildDraft("updated"));
+    });
+    expect(persistence.readDraft().segments[0]).toEqual(
+      expect.objectContaining({ text: "updated" }),
+    );
+
+    window.dispatchEvent(new Event("pagehide"));
+    expect(persistence.adapter.flush).toHaveBeenCalledTimes(1);
+    await harness.unmount();
+    expect(persistence.adapter.flush).toHaveBeenCalledTimes(2);
+  });
+
+  test("persists newer in-memory input when adding persistence for the same key", async () => {
+    const persistence = createFakePersistence(buildDraft("older persisted draft"));
+    const harness = await mountHarness({
+      key: "conversation:late-persistence",
+      persistence: null,
+    });
+
+    await harness.run((value) => {
+      value.commitDraft(buildDraft("newer in-memory input"));
+    });
+    await harness.update({
+      scope: {
+        key: "conversation:late-persistence",
+        persistence: persistence.adapter,
+      },
+    });
+
+    expect(harness.getLatest().draft.segments[0]).toEqual(
+      expect.objectContaining({ text: "newer in-memory input" }),
+    );
+    expect(persistence.readDraft().segments[0]).toEqual(
+      expect.objectContaining({ text: "newer in-memory input" }),
+    );
+
+    await harness.unmount();
+    expect(persistence.adapter.flush).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps newer input when replacing persistence for the same key", async () => {
+    const first = createFakePersistence();
+    const second = createFakePersistence(buildDraft("older persisted draft"));
+    const harness = await mountHarness({
+      key: "conversation:replacement",
+      persistence: first.adapter,
+    });
+
+    await harness.run((value) => {
+      value.commitDraft(buildDraft("newer input"));
+    });
+    await harness.update({
+      scope: {
+        key: "conversation:replacement",
+        persistence: second.adapter,
+      },
+    });
+
+    expect(first.adapter.flush).toHaveBeenCalledTimes(1);
+    expect(harness.getLatest().draft.segments[0]).toEqual(
+      expect.objectContaining({ text: "newer input" }),
+    );
+    expect(second.readDraft().segments[0]).toEqual(
+      expect.objectContaining({ text: "newer input" }),
+    );
+
+    let snapshot: ReturnType<HookResult["createSubmittedDraftSnapshot"]> | null = null;
+    await harness.run((value) => {
+      const updatedDraft = buildDraft("replacement updated");
+      value.commitDraft(updatedDraft);
+      snapshot = value.createSubmittedDraftSnapshot(updatedDraft);
+    });
+    expect(second.readDraft().segments[0]).toEqual(
+      expect.objectContaining({ text: "replacement updated" }),
+    );
+
+    await harness.run((value) => {
+      if (!snapshot) {
+        throw new Error("Expected submitted draft snapshot.");
+      }
+      value.clearSubmittedDraft(snapshot);
+      value.setDisplayedDraft(createEmptyComposerDraft());
+    });
+    await harness.run((value) => {
+      if (!snapshot) {
+        throw new Error("Expected submitted draft snapshot.");
+      }
+      value.restoreSubmittedDraft(snapshot);
+    });
+    expect(first.clear).not.toHaveBeenCalled();
+    expect(second.clear).toHaveBeenCalledWith({ onlyIfVersion: 2 });
+    expect(second.readDraft().segments[0]).toEqual(
+      expect.objectContaining({ text: "replacement updated" }),
+    );
+
+    await harness.unmount();
+    expect(first.adapter.flush).toHaveBeenCalledTimes(1);
+    expect(second.adapter.flush).toHaveBeenCalledTimes(1);
+  });
+
   test("flushes the old persistence adapter before switching identities", async () => {
     const pendingFlush = createDeferred();
     const first = createFakePersistence(buildDraft("first"), () => pendingFlush.promise);

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.test.ts
@@ -1,123 +1,259 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { createHookHarness } from "@/test-utils/react-hook-harness";
 import {
   type AgentChatComposerDraft,
   createEmptyComposerDraft,
   createTextSegment,
+  draftHasMeaningfulContent,
 } from "./agent-chat-composer-draft";
-import {
-  type AgentChatDraftSessionIdentity,
-  toAgentChatDraftStorageKey,
-} from "./agent-chat-draft-storage";
-import {
-  flushAgentChatDraft,
-  resetAgentChatDraftStoreForTests,
-  setAgentChatDraftStorageForTests,
-} from "./agent-chat-draft-store";
+import type { AgentChatDraftPersistence, AgentChatDraftScope } from "./agent-chat-draft-scope";
 import { useAgentChatComposerDraftState } from "./use-agent-chat-composer-draft-state";
 
-type TestStorage = Pick<Storage, "length" | "key" | "getItem" | "setItem" | "removeItem">;
 type HookArgs = Parameters<typeof useAgentChatComposerDraftState>[0];
 type HookResult = ReturnType<typeof useAgentChatComposerDraftState>;
-
-const createMemoryStorage = (): TestStorage => {
-  const store = new Map<string, string>();
-  return {
-    get length() {
-      return store.size;
-    },
-    key: (index) => Array.from(store.keys())[index] ?? null,
-    getItem: (key) => store.get(key) ?? null,
-    setItem: (key, value) => {
-      store.set(key, value);
-    },
-    removeItem: (key) => {
-      store.delete(key);
-    },
-  };
-};
-
-const identity: AgentChatDraftSessionIdentity = {
-  workspaceId: "workspace",
-  externalSessionId: "session-a",
-  runtimeKind: "opencode",
-  workingDirectory: "/repo",
-};
 
 const buildDraft = (text: string): AgentChatComposerDraft => ({
   segments: [createTextSegment(text, "text-1")],
   attachments: [],
 });
 
-const mountHarness = async (args: Partial<HookArgs> = {}) => {
+const createDeferred = () => {
+  let resolvePromise: () => void = () => {};
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: resolvePromise };
+};
+
+const createFakePersistence = (
+  initialDraft: AgentChatComposerDraft = createEmptyComposerDraft(),
+  flush: () => Promise<void> = async () => {},
+) => {
+  let draft = initialDraft;
+  let version = 0;
+  const clear = mock((options?: { onlyIfVersion?: number | null }) => {
+    if (typeof options?.onlyIfVersion === "number" && options.onlyIfVersion !== version) {
+      return false;
+    }
+    draft = createEmptyComposerDraft();
+    return true;
+  });
+  const adapter: AgentChatDraftPersistence = {
+    hydrate: () => draft,
+    set: (nextDraft) => {
+      draft = nextDraft;
+      version += 1;
+      return version;
+    },
+    readVersion: () => version,
+    clear,
+    flush: mock(flush),
+  };
+  return {
+    adapter,
+    clear,
+    readDraft: () => draft,
+  };
+};
+
+const mountHarness = async (scope: AgentChatDraftScope) => {
   const harness = createHookHarness<HookArgs, HookResult>(useAgentChatComposerDraftState, {
-    draftStateKey: "composer-key",
-    persistenceIdentity: identity,
-    taskId: "task-1",
-    ...args,
+    scope,
   });
   await harness.mount();
   return harness;
 };
 
 afterEach(() => {
-  resetAgentChatDraftStoreForTests();
+  document.body.innerHTML = "";
 });
 
 describe("useAgentChatComposerDraftState", () => {
-  test("rehydrates the draft entry when only the task id changes", async () => {
-    const storage = createMemoryStorage();
-    setAgentChatDraftStorageForTests(storage);
-    const harness = await mountHarness();
+  test("keeps an opaque non-task draft identity in memory without persistence", async () => {
+    const harness = await mountHarness({
+      key: "repository-chat:conversation/42",
+      persistence: null,
+    });
+
+    await harness.run((value) => {
+      value.commitDraft(buildDraft("local only"));
+    });
+    expect(harness.getLatest().draft.segments[0]).toEqual(
+      expect.objectContaining({ text: "local only" }),
+    );
+
+    await harness.update({
+      scope: {
+        key: "repository-chat:conversation/43",
+        persistence: null,
+      },
+    });
+    expect(draftHasMeaningfulContent(harness.getLatest().draft)).toBe(false);
+    await harness.unmount();
+  });
+
+  test("flushes the old persistence adapter before switching identities", async () => {
+    const pendingFlush = createDeferred();
+    const first = createFakePersistence(buildDraft("first"), () => pendingFlush.promise);
+    const second = createFakePersistence(buildDraft("second"));
+    const harness = await mountHarness({
+      key: "conversation:first",
+      persistence: first.adapter,
+    });
     const stableCommitDraft = harness.getLatest().commitDraft;
 
     await harness.update({
-      draftStateKey: "composer-key",
-      persistenceIdentity: identity,
-      taskId: "task-2",
+      scope: {
+        key: "conversation:second",
+        persistence: second.adapter,
+      },
     });
-    await harness.run(() => {
-      stableCommitDraft(buildDraft("rehydrated task"));
-    });
-    await flushAgentChatDraft(identity);
 
-    const raw = storage.getItem(toAgentChatDraftStorageKey(identity));
-    expect(raw).not.toBeNull();
-    expect(JSON.parse(raw ?? "{}")).toEqual(
-      expect.objectContaining({ taskId: "task-2", draft: buildDraft("rehydrated task") }),
+    expect(first.adapter.flush).toHaveBeenCalledTimes(1);
+    expect(harness.getLatest().draft.segments[0]).toEqual(
+      expect.objectContaining({ text: "second" }),
+    );
+    await harness.run(() => {
+      stableCommitDraft(buildDraft("second updated"));
+    });
+    expect(second.readDraft().segments[0]).toEqual(
+      expect.objectContaining({ text: "second updated" }),
+    );
+    expect(first.readDraft().segments[0]).toEqual(expect.objectContaining({ text: "first" }));
+
+    pendingFlush.resolve();
+    await harness.unmount();
+  });
+
+  test("clears only the submitted persisted version", async () => {
+    const persistence = createFakePersistence();
+    const harness = await mountHarness({
+      key: "conversation:versioned",
+      persistence: persistence.adapter,
+    });
+    let snapshot: ReturnType<HookResult["createSubmittedDraftSnapshot"]> | null = null;
+
+    await harness.run((value) => {
+      value.commitDraft(buildDraft("submitted"));
+      snapshot = value.createSubmittedDraftSnapshot(buildDraft("submitted"));
+      value.commitDraft(buildDraft("new input"));
+    });
+    await harness.run((value) => {
+      if (!snapshot) {
+        throw new Error("Expected submitted draft snapshot.");
+      }
+      value.clearSubmittedDraft(snapshot);
+    });
+
+    expect(persistence.clear).toHaveBeenCalledWith({ onlyIfVersion: 1 });
+    expect(persistence.readDraft().segments[0]).toEqual(
+      expect.objectContaining({ text: "new input" }),
     );
     await harness.unmount();
   });
 
-  test("persists a failed-send restoration when the visible draft is empty", async () => {
-    const storage = createMemoryStorage();
-    setAgentChatDraftStorageForTests(storage);
-    const harness = await mountHarness();
+  test("restores a failed submission when the active draft is still empty", async () => {
+    const persistence = createFakePersistence();
+    const harness = await mountHarness({
+      key: "conversation:failed-send",
+      persistence: persistence.adapter,
+    });
     const submittedDraft = buildDraft("restore me");
     let snapshot: ReturnType<HookResult["createSubmittedDraftSnapshot"]> | null = null;
 
     await harness.run((value) => {
       value.commitDraft(submittedDraft);
-      const nextSnapshot = value.createSubmittedDraftSnapshot(submittedDraft);
-      snapshot = nextSnapshot;
-      value.clearSubmittedDraft(nextSnapshot);
+      snapshot = value.createSubmittedDraftSnapshot(submittedDraft);
       value.setDisplayedDraft(createEmptyComposerDraft());
     });
-
-    expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toBeNull();
     await harness.run((value) => {
       if (!snapshot) {
-        throw new Error("Expected submitted draft snapshot");
+        throw new Error("Expected submitted draft snapshot.");
       }
       value.restoreSubmittedDraft(snapshot);
     });
-    await flushAgentChatDraft(identity);
 
-    const raw = storage.getItem(toAgentChatDraftStorageKey(identity));
     expect(harness.getLatest().draft.segments[0]).toEqual(
       expect.objectContaining({ text: "restore me" }),
     );
-    expect(raw).toContain("restore me");
+    expect(persistence.readDraft().segments[0]).toEqual(
+      expect.objectContaining({ text: "restore me" }),
+    );
     await harness.unmount();
+  });
+
+  test("keeps new input instead of restoring an older submitted draft", async () => {
+    const persistence = createFakePersistence();
+    const harness = await mountHarness({
+      key: "conversation:new-input",
+      persistence: persistence.adapter,
+    });
+    const submittedDraft = buildDraft("submitted");
+    let snapshot: ReturnType<HookResult["createSubmittedDraftSnapshot"]> | null = null;
+
+    await harness.run((value) => {
+      value.commitDraft(submittedDraft);
+      snapshot = value.createSubmittedDraftSnapshot(submittedDraft);
+      value.setDisplayedDraft(createEmptyComposerDraft());
+      value.commitDraft(buildDraft("new input"));
+    });
+    await harness.run((value) => {
+      if (!snapshot) {
+        throw new Error("Expected submitted draft snapshot.");
+      }
+      value.restoreSubmittedDraft(snapshot);
+    });
+
+    expect(harness.getLatest().draft.segments[0]).toEqual(
+      expect.objectContaining({ text: "new input" }),
+    );
+    await harness.unmount();
+  });
+
+  test("ignores a late restore for a no-longer-active identity", async () => {
+    const first = createFakePersistence();
+    const second = createFakePersistence();
+    const harness = await mountHarness({
+      key: "conversation:first",
+      persistence: first.adapter,
+    });
+    const submittedDraft = buildDraft("first submission");
+    let snapshot: ReturnType<HookResult["createSubmittedDraftSnapshot"]> | null = null;
+
+    await harness.run((value) => {
+      value.commitDraft(submittedDraft);
+      snapshot = value.createSubmittedDraftSnapshot(submittedDraft);
+      value.setDisplayedDraft(createEmptyComposerDraft());
+    });
+    await harness.update({
+      scope: {
+        key: "conversation:second",
+        persistence: second.adapter,
+      },
+    });
+    await harness.run((value) => {
+      if (!snapshot) {
+        throw new Error("Expected submitted draft snapshot.");
+      }
+      value.restoreSubmittedDraft(snapshot);
+    });
+
+    expect(draftHasMeaningfulContent(harness.getLatest().draft)).toBe(false);
+    expect(draftHasMeaningfulContent(second.readDraft())).toBe(false);
+    await harness.unmount();
+  });
+
+  test("flushes active persistence on page hide and unmount", async () => {
+    const persistence = createFakePersistence();
+    const harness = await mountHarness({
+      key: "conversation:page-lifecycle",
+      persistence: persistence.adapter,
+    });
+
+    window.dispatchEvent(new Event("pagehide"));
+    expect(persistence.adapter.flush).toHaveBeenCalledTimes(1);
+
+    await harness.unmount();
+    expect(persistence.adapter.flush).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.test.ts
@@ -25,6 +25,8 @@ const createDeferred = () => {
   return { promise, resolve: resolvePromise };
 };
 
+let fakePersistenceId = 0;
+
 const createFakePersistence = (
   initialDraft: AgentChatComposerDraft = createEmptyComposerDraft(),
   flush: () => Promise<void> = async () => {},
@@ -39,6 +41,7 @@ const createFakePersistence = (
     return true;
   });
   const adapter: AgentChatDraftPersistence = {
+    targetKey: `fake-persistence:${fakePersistenceId++}`,
     hydrate: () => draft,
     set: (nextDraft) => {
       draft = nextDraft;

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.test.ts
@@ -74,10 +74,11 @@ afterEach(() => {
 describe("useAgentChatComposerDraftState", () => {
   test("adopts fresh equivalent persistence wrappers without scheduling another render", async () => {
     const adapters: AgentChatDraftPersistence[] = [];
+    const hydrate = mock(createEmptyComposerDraft);
     const useInlinePersistenceDraftState = (_props: { render: number }) => {
       const adapter: AgentChatDraftPersistence = {
         targetKey: "equivalent-target",
-        hydrate: createEmptyComposerDraft,
+        hydrate,
         set: mock(() => 1),
         readVersion: () => 0,
         clear: () => true,
@@ -98,6 +99,7 @@ describe("useAgentChatComposerDraftState", () => {
 
     await harness.update({ render: 1 });
     expect(adapters).toHaveLength(2);
+    expect(hydrate).toHaveBeenCalledTimes(1);
     const adoptedAdapter = adapters[1];
     if (!adoptedAdapter) {
       throw new Error("Expected the rerendered persistence adapter.");
@@ -263,9 +265,18 @@ describe("useAgentChatComposerDraftState", () => {
   });
 
   test("flushes the old persistence adapter before switching identities", async () => {
+    const events: string[] = [];
     const pendingFlush = createDeferred();
-    const first = createFakePersistence(buildDraft("first"), () => pendingFlush.promise);
+    const first = createFakePersistence(buildDraft("first"), () => {
+      events.push("flush:first");
+      return pendingFlush.promise;
+    });
     const second = createFakePersistence(buildDraft("second"));
+    const hydrateSecond = second.adapter.hydrate;
+    second.adapter.hydrate = () => {
+      events.push("hydrate:second");
+      return hydrateSecond();
+    };
     const harness = await mountHarness({
       key: "conversation:first",
       persistence: first.adapter,
@@ -280,6 +291,7 @@ describe("useAgentChatComposerDraftState", () => {
     });
 
     expect(first.adapter.flush).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(["flush:first", "hydrate:second"]);
     expect(harness.getLatest().draft.segments[0]).toEqual(
       expect.objectContaining({ text: "second" }),
     );

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.ts
@@ -55,7 +55,16 @@ export function useAgentChatComposerDraftState({
 
   useLayoutEffect(() => {
     const current = latestStateRef.current;
-    if (current.key === nextKey && current.persistence === nextPersistence) {
+    const isSameDraft = current.key === nextKey;
+    const isSamePersistenceTarget = current.persistence?.targetKey === nextPersistence?.targetKey;
+    if (isSameDraft && isSamePersistenceTarget) {
+      if (current.persistence !== nextPersistence) {
+        setState({
+          key: current.key,
+          persistence: nextPersistence,
+          draft: current.draft,
+        });
+      }
       return;
     }
 
@@ -63,7 +72,7 @@ export function useAgentChatComposerDraftState({
       void current.persistence.flush();
     }
 
-    if (current.key === nextKey) {
+    if (isSameDraft) {
       const hasCurrentDraft = draftHasMeaningfulContent(current.draft);
       const nextDraft = hasCurrentDraft
         ? current.draft

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.ts
@@ -4,36 +4,21 @@ import {
   createEmptyComposerDraft,
   draftHasMeaningfulContent,
 } from "./agent-chat-composer-draft";
-import {
-  type AgentChatDraftSessionIdentity,
-  toAgentChatDraftStorageKey,
-} from "./agent-chat-draft-storage";
-import {
-  clearAgentChatDraft,
-  flushAgentChatDraft,
-  flushAllAgentChatDrafts,
-  hydrateAgentChatDraft,
-  readAgentChatDraftVersion,
-  setAgentChatDraft,
-} from "./agent-chat-draft-store";
+import type { AgentChatDraftPersistence, AgentChatDraftScope } from "./agent-chat-draft-scope";
 
 type ComposerDraftState = {
   key: string;
-  identity: AgentChatDraftSessionIdentity | null;
-  taskId: string;
+  persistence: AgentChatDraftPersistence | null;
   draft: AgentChatComposerDraft;
 };
 
 type UseAgentChatComposerDraftStateArgs = {
-  draftStateKey: string;
-  persistenceIdentity: AgentChatDraftSessionIdentity | null;
-  taskId: string;
+  scope: AgentChatDraftScope;
 };
 
 type SubmittedDraftSnapshot = {
   key: string;
-  identity: AgentChatDraftSessionIdentity | null;
-  taskId: string;
+  persistence: AgentChatDraftPersistence | null;
   version: number | null;
   draft: AgentChatComposerDraft;
 };
@@ -47,43 +32,22 @@ type UseAgentChatComposerDraftStateResult = {
   restoreSubmittedDraft: (snapshot: SubmittedDraftSnapshot) => void;
 };
 
-const toComposerDraftStateKey = (
-  draftStateKey: string,
-  identity: AgentChatDraftSessionIdentity | null,
-): string => (identity ? toAgentChatDraftStorageKey(identity) : draftStateKey);
-
-const areIdentitiesEqual = (
-  left: AgentChatDraftSessionIdentity | null,
-  right: AgentChatDraftSessionIdentity | null,
-): boolean =>
-  left === right ||
-  (left !== null &&
-    right !== null &&
-    toAgentChatDraftStorageKey(left) === toAgentChatDraftStorageKey(right));
-
 const createInitialDraftState = ({
-  draftStateKey,
-  persistenceIdentity,
-  taskId,
-}: UseAgentChatComposerDraftStateArgs): ComposerDraftState => ({
-  key: toComposerDraftStateKey(draftStateKey, persistenceIdentity),
-  identity: persistenceIdentity,
-  taskId,
-  draft: persistenceIdentity
-    ? hydrateAgentChatDraft(persistenceIdentity, taskId)
-    : createEmptyComposerDraft(),
+  key,
+  persistence,
+}: AgentChatDraftScope): ComposerDraftState => ({
+  key,
+  persistence,
+  draft: persistence?.hydrate() ?? createEmptyComposerDraft(),
 });
 
 export function useAgentChatComposerDraftState({
-  draftStateKey,
-  persistenceIdentity,
-  taskId,
+  scope,
 }: UseAgentChatComposerDraftStateArgs): UseAgentChatComposerDraftStateResult {
-  const [state, setState] = useState<ComposerDraftState>(() =>
-    createInitialDraftState({ draftStateKey, persistenceIdentity, taskId }),
-  );
+  const [state, setState] = useState<ComposerDraftState>(() => createInitialDraftState(scope));
   const latestStateRef = useRef(state);
-  const nextStateKey = toComposerDraftStateKey(draftStateKey, persistenceIdentity);
+  const nextKey = scope.key;
+  const nextPersistence = scope.persistence;
 
   useLayoutEffect(() => {
     latestStateRef.current = state;
@@ -91,64 +55,50 @@ export function useAgentChatComposerDraftState({
 
   useLayoutEffect(() => {
     const current = latestStateRef.current;
-    if (
-      current.key === nextStateKey &&
-      current.taskId === taskId &&
-      areIdentitiesEqual(current.identity, persistenceIdentity)
-    ) {
+    if (current.key === nextKey) {
       return;
     }
 
-    if (current.identity) {
-      void flushAgentChatDraft(current.identity);
+    if (current.persistence) {
+      void current.persistence.flush();
     }
 
-    const nextDraft = persistenceIdentity
-      ? hydrateAgentChatDraft(persistenceIdentity, taskId)
-      : createEmptyComposerDraft();
-    setState({
-      key: nextStateKey,
-      identity: persistenceIdentity,
-      taskId,
-      draft: nextDraft,
-    });
-  }, [nextStateKey, persistenceIdentity, taskId]);
+    setState(createInitialDraftState({ key: nextKey, persistence: nextPersistence }));
+  }, [nextKey, nextPersistence]);
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof document === "undefined") {
       return;
     }
 
-    const flushDrafts = (): void => {
-      void flushAllAgentChatDrafts();
+    const flushDraft = (): void => {
+      const persistence = latestStateRef.current.persistence;
+      if (persistence) {
+        void persistence.flush();
+      }
     };
     const handleVisibilityChange = (): void => {
       if (document.visibilityState === "hidden") {
-        flushDrafts();
+        flushDraft();
       }
     };
 
-    window.addEventListener("pagehide", flushDrafts);
+    window.addEventListener("pagehide", flushDraft);
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
-      window.removeEventListener("pagehide", flushDrafts);
+      window.removeEventListener("pagehide", flushDraft);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
-      flushDrafts();
+      flushDraft();
     };
   }, []);
 
   const commitDraft = useCallback((nextDraft: AgentChatComposerDraft): void => {
-    const activeIdentity = latestStateRef.current.identity;
-    const activeKey = latestStateRef.current.key;
-    const activeTaskId = latestStateRef.current.taskId;
-    if (activeIdentity) {
-      setAgentChatDraft(activeIdentity, activeTaskId, nextDraft);
-    }
+    const current = latestStateRef.current;
+    current.persistence?.set(nextDraft);
     setState({
-      key: activeKey,
-      identity: activeIdentity,
-      taskId: activeTaskId,
+      key: current.key,
+      persistence: current.persistence,
       draft: nextDraft,
     });
   }, []);
@@ -157,8 +107,7 @@ export function useAgentChatComposerDraftState({
     const current = latestStateRef.current;
     setState({
       key: current.key,
-      identity: current.identity,
-      taskId: current.taskId,
+      persistence: current.persistence,
       draft: nextDraft,
     });
   }, []);
@@ -168,9 +117,8 @@ export function useAgentChatComposerDraftState({
       const current = latestStateRef.current;
       return {
         key: current.key,
-        identity: current.identity,
-        taskId: current.taskId,
-        version: current.identity ? readAgentChatDraftVersion(current.identity) : null,
+        persistence: current.persistence,
+        version: current.persistence?.readVersion() ?? null,
         draft,
       };
     },
@@ -178,36 +126,26 @@ export function useAgentChatComposerDraftState({
   );
 
   const clearSubmittedDraft = useCallback((snapshot: SubmittedDraftSnapshot): void => {
-    if (!snapshot.identity) {
-      return;
-    }
-    clearAgentChatDraft(snapshot.identity, { onlyIfVersion: snapshot.version });
+    snapshot.persistence?.clear({ onlyIfVersion: snapshot.version });
   }, []);
 
   const restoreSubmittedDraft = useCallback((snapshot: SubmittedDraftSnapshot): void => {
     const current = latestStateRef.current;
-    if (
-      current.key !== snapshot.key ||
-      current.taskId !== snapshot.taskId ||
-      draftHasMeaningfulContent(current.draft)
-    ) {
+    if (current.key !== snapshot.key || draftHasMeaningfulContent(current.draft)) {
       return;
     }
 
-    if (current.identity) {
-      setAgentChatDraft(current.identity, current.taskId, snapshot.draft);
-    }
+    current.persistence?.set(snapshot.draft);
     setState({
       key: current.key,
-      identity: current.identity,
-      taskId: current.taskId,
+      persistence: current.persistence,
       draft: snapshot.draft,
     });
   }, []);
 
   return useMemo(
     () => ({
-      draft: state.key === nextStateKey ? state.draft : createEmptyComposerDraft(),
+      draft: state.key === nextKey ? state.draft : createEmptyComposerDraft(),
       commitDraft,
       setDisplayedDraft,
       createSubmittedDraftSnapshot,
@@ -218,8 +156,8 @@ export function useAgentChatComposerDraftState({
       clearSubmittedDraft,
       commitDraft,
       createSubmittedDraftSnapshot,
-      nextStateKey,
       restoreSubmittedDraft,
+      nextKey,
       setDisplayedDraft,
       state.draft,
       state.key,

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.ts
@@ -59,6 +59,8 @@ export function useAgentChatComposerDraftState({
     const isSamePersistenceTarget = current.persistence?.targetKey === nextPersistence?.targetKey;
     if (isSameDraft && isSamePersistenceTarget) {
       if (current.persistence !== nextPersistence) {
+        // Equivalent wrappers may be recreated every render. Updating state here would loop;
+        // callbacks and lifecycle handlers read this ref until the next state update catches up.
         latestStateRef.current = {
           key: current.key,
           persistence: nextPersistence,

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.ts
@@ -59,11 +59,11 @@ export function useAgentChatComposerDraftState({
     const isSamePersistenceTarget = current.persistence?.targetKey === nextPersistence?.targetKey;
     if (isSameDraft && isSamePersistenceTarget) {
       if (current.persistence !== nextPersistence) {
-        setState({
+        latestStateRef.current = {
           key: current.key,
           persistence: nextPersistence,
           draft: current.draft,
-        });
+        };
       }
       return;
     }

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.ts
@@ -55,12 +55,28 @@ export function useAgentChatComposerDraftState({
 
   useLayoutEffect(() => {
     const current = latestStateRef.current;
-    if (current.key === nextKey) {
+    if (current.key === nextKey && current.persistence === nextPersistence) {
       return;
     }
 
     if (current.persistence) {
       void current.persistence.flush();
+    }
+
+    if (current.key === nextKey) {
+      const hasCurrentDraft = draftHasMeaningfulContent(current.draft);
+      const nextDraft = hasCurrentDraft
+        ? current.draft
+        : (nextPersistence?.hydrate() ?? current.draft);
+      if (hasCurrentDraft) {
+        nextPersistence?.set(current.draft);
+      }
+      setState({
+        key: current.key,
+        persistence: nextPersistence,
+        draft: nextDraft,
+      });
+      return;
     }
 
     setState(createInitialDraftState({ key: nextKey, persistence: nextPersistence }));

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-model.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-model.test.tsx
@@ -12,7 +12,6 @@ import {
 const buildComposerConfig = (
   onSend: AgentChatComposerConfig["onSend"],
 ): AgentChatComposerConfig => ({
-  taskId: "task-1",
   displayedSessionKey: null,
   selectedSession: null,
   isSessionModelCatalogLoading: false,
@@ -24,8 +23,10 @@ const buildComposerConfig = (
   stopAgentSession: async () => {},
   isReadOnly: false,
   readOnlyReason: null,
-  draftStateKey: "task-1:build:new",
-  draftPersistenceIdentity: null,
+  draftScope: {
+    key: "task-1:build:new",
+    persistence: null,
+  },
   onSend,
   isSending: false,
   isStarting: false,

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-model.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-model.ts
@@ -10,7 +10,7 @@ import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
 import type { AgentChatComposerModel } from "./agent-chat.types";
 import type { AgentChatComposerDraft } from "./agent-chat-composer-draft";
 import { deriveAgentChatComposerModelState } from "./agent-chat-composer-model-state";
-import type { AgentChatDraftSessionIdentity } from "./agent-chat-draft-storage";
+import type { AgentChatDraftScope } from "./agent-chat-draft-scope";
 
 type StopAgentSession = (session: AgentSessionIdentity) => Promise<void>;
 type AgentChatComposerSelectedSession = AgentSessionIdentity & {
@@ -28,7 +28,6 @@ export const invokeStopAgentSession = (
 };
 
 export type AgentChatComposerConfig = {
-  taskId: string;
   displayedSessionKey: string | null;
   selectedSession: AgentChatComposerSelectedSession | null;
   isSessionModelCatalogLoading: boolean;
@@ -41,8 +40,7 @@ export type AgentChatComposerConfig = {
   isReadOnly: boolean;
   readOnlyReason: string | null;
   pendingSendItems?: AgentChatComposerModel["pendingSendItems"];
-  draftStateKey: string;
-  draftPersistenceIdentity: AgentChatDraftSessionIdentity | null;
+  draftScope: AgentChatDraftScope;
   onSend: (draft: AgentChatComposerDraft) => Promise<boolean>;
   isSending: boolean;
   isStarting: boolean;
@@ -123,15 +121,13 @@ export function useAgentChatComposerModel({
     }
 
     return {
-      taskId: composer.taskId,
       displayedSessionKey: composer.displayedSessionKey,
       isInteractionEnabled: composerState?.isInteractionEnabled ?? false,
       isReadOnly: composer.isReadOnly,
       readOnlyReason: composer.readOnlyReason,
       busySendBlockedReason: composer.busySendBlockedReason,
       ...(composer.pendingSendItems ? { pendingSendItems: composer.pendingSendItems } : {}),
-      draftStateKey: composer.draftStateKey,
-      draftPersistenceIdentity: composer.draftPersistenceIdentity,
+      draftScope: composer.draftScope,
       onSend: async (draft: AgentChatComposerDraft): Promise<boolean> => {
         scrollToBottomOnSendRef.current?.();
         return composer.onSend(draft);

--- a/packages/frontend/src/pages/agents/agent-studio-chat-draft.test.ts
+++ b/packages/frontend/src/pages/agents/agent-studio-chat-draft.test.ts
@@ -85,6 +85,31 @@ describe("Agent Studio chat draft adapter", () => {
     ).toBe(false);
   });
 
+  test("uses stable persistence targets for equivalent session identities", () => {
+    const selectedSession = session("session-1");
+    const first = createAgentStudioChatDraftPersistence({
+      workspaceId: "workspace",
+      taskId: "task-1",
+      session: selectedSession,
+    });
+    const refreshed = createAgentStudioChatDraftPersistence({
+      workspaceId: "workspace",
+      taskId: "task-1",
+      session: { ...selectedSession },
+    });
+    const otherWorkspace = createAgentStudioChatDraftPersistence({
+      workspaceId: "other-workspace",
+      taskId: "task-1",
+      session: selectedSession,
+    });
+
+    expect(first?.targetKey).toBe(refreshed?.targetKey);
+    expect(first?.targetKey).not.toBe(otherWorkspace?.targetKey);
+    expect(first?.targetKey).toBe(
+      toAgentChatDraftStorageKey({ workspaceId: "workspace", ...selectedSession }),
+    );
+  });
+
   test("reads an existing version 2 payload without migration", () => {
     const storage = createMemoryStorage();
     const selectedSession = session("session-1");

--- a/packages/frontend/src/pages/agents/agent-studio-chat-draft.test.ts
+++ b/packages/frontend/src/pages/agents/agent-studio-chat-draft.test.ts
@@ -55,13 +55,21 @@ afterEach(() => {
 });
 
 describe("Agent Studio chat draft adapter", () => {
-  test("keeps the task, role, and session draft key shape", () => {
+  test("keeps the workspace, task, role, and session draft key shape", () => {
     const selectedSession = session("session-1");
 
-    expect(agentStudioChatDraftScopeKey(scope({ session: selectedSession }))).toBe(
-      `task-1:planner:${agentSessionIdentityKey(selectedSession)}`,
+    expect(agentStudioChatDraftScopeKey("workspace", scope({ session: selectedSession }))).toBe(
+      `workspace:task-1:planner:${agentSessionIdentityKey(selectedSession)}`,
     );
-    expect(agentStudioChatDraftScopeKey(scope())).toBe("task-1:planner:new");
+    expect(agentStudioChatDraftScopeKey("workspace", scope())).toBe("workspace:task-1:planner:new");
+  });
+
+  test("isolates the same draft scope across workspaces", () => {
+    const selectedScope = scope({ session: session("session-1") });
+
+    expect(agentStudioChatDraftScopeKey("workspace-a", selectedScope)).not.toBe(
+      agentStudioChatDraftScopeKey("workspace-b", selectedScope),
+    );
   });
 
   test("recognizes only session changes within the same task and role", () => {

--- a/packages/frontend/src/pages/agents/agent-studio-chat-draft.test.ts
+++ b/packages/frontend/src/pages/agents/agent-studio-chat-draft.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createTextSegment } from "@/components/features/agents/agent-chat/agent-chat-composer-draft";
+import {
+  toAgentChatDraftStorageKey,
+  writeAgentChatDraftToStorage,
+} from "@/components/features/agents/agent-chat/agent-chat-draft-storage";
+import {
+  resetAgentChatDraftStoreForTests,
+  setAgentChatDraftNowProviderForTests,
+  setAgentChatDraftStorageForTests,
+} from "@/components/features/agents/agent-chat/agent-chat-draft-store";
+import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
+import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
+import {
+  type AgentStudioChatDraftScope,
+  agentStudioChatDraftScopeKey,
+  createAgentStudioChatDraftPersistence,
+  didAgentStudioChatDraftScopeSwitchSessionOnly,
+} from "./agent-studio-chat-draft";
+
+type TestStorage = Pick<Storage, "length" | "key" | "getItem" | "setItem" | "removeItem">;
+
+const createMemoryStorage = (): TestStorage => {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => {
+      values.set(key, value);
+    },
+    removeItem: (key) => {
+      values.delete(key);
+    },
+  };
+};
+
+const session = (externalSessionId: string): AgentSessionIdentity => ({
+  externalSessionId,
+  runtimeKind: "opencode",
+  workingDirectory: "/repo",
+});
+
+const scope = (overrides: Partial<AgentStudioChatDraftScope> = {}): AgentStudioChatDraftScope => ({
+  taskId: "task-1",
+  role: "planner",
+  session: null,
+  ...overrides,
+});
+
+afterEach(() => {
+  resetAgentChatDraftStoreForTests();
+});
+
+describe("Agent Studio chat draft adapter", () => {
+  test("keeps the task, role, and session draft key shape", () => {
+    const selectedSession = session("session-1");
+
+    expect(agentStudioChatDraftScopeKey(scope({ session: selectedSession }))).toBe(
+      `task-1:planner:${agentSessionIdentityKey(selectedSession)}`,
+    );
+    expect(agentStudioChatDraftScopeKey(scope())).toBe("task-1:planner:new");
+  });
+
+  test("recognizes only session changes within the same task and role", () => {
+    expect(
+      didAgentStudioChatDraftScopeSwitchSessionOnly(
+        scope({ session: session("session-1") }),
+        scope({ session: session("session-2") }),
+      ),
+    ).toBe(true);
+    expect(
+      didAgentStudioChatDraftScopeSwitchSessionOnly(
+        scope({ session: session("session-1") }),
+        scope({ taskId: "task-2", session: session("session-2") }),
+      ),
+    ).toBe(false);
+    expect(
+      didAgentStudioChatDraftScopeSwitchSessionOnly(
+        scope({ session: session("session-1") }),
+        scope({ role: "build", session: session("session-2") }),
+      ),
+    ).toBe(false);
+  });
+
+  test("reads an existing version 2 payload without migration", () => {
+    const storage = createMemoryStorage();
+    const selectedSession = session("session-1");
+    const identity = { workspaceId: "workspace", ...selectedSession };
+    const draft = {
+      segments: [createTextSegment("persisted", "text-1")],
+      attachments: [],
+    };
+    setAgentChatDraftStorageForTests(storage);
+    setAgentChatDraftNowProviderForTests(() => new Date("2026-07-08T10:00:01.000Z"));
+    writeAgentChatDraftToStorage({
+      storage,
+      identity,
+      taskId: "task-1",
+      draft,
+      updatedAt: "2026-07-08T10:00:00.000Z",
+    });
+    const existingPayload = storage.getItem(toAgentChatDraftStorageKey(identity));
+
+    const persistence = createAgentStudioChatDraftPersistence({
+      workspaceId: "workspace",
+      taskId: "task-1",
+      session: selectedSession,
+    });
+
+    expect(persistence?.hydrate()).toEqual(draft);
+    expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toBe(existingPayload);
+  });
+});

--- a/packages/frontend/src/pages/agents/agent-studio-chat-draft.test.ts
+++ b/packages/frontend/src/pages/agents/agent-studio-chat-draft.test.ts
@@ -103,6 +103,9 @@ describe("Agent Studio chat draft adapter", () => {
       session: selectedSession,
     });
 
+    expect(first).not.toBeNull();
+    expect(refreshed).not.toBeNull();
+    expect(otherWorkspace).not.toBeNull();
     expect(first?.targetKey).toBe(refreshed?.targetKey);
     expect(first?.targetKey).not.toBe(otherWorkspace?.targetKey);
     expect(first?.targetKey).toBe(

--- a/packages/frontend/src/pages/agents/agent-studio-chat-draft.ts
+++ b/packages/frontend/src/pages/agents/agent-studio-chat-draft.ts
@@ -25,11 +25,10 @@ const NEW_SESSION_DRAFT_SCOPE = "new";
 const sessionScopeKey = (session: AgentSessionIdentity | null): string =>
   session ? agentSessionIdentityKey(session) : NEW_SESSION_DRAFT_SCOPE;
 
-export const agentStudioChatDraftScopeKey = ({
-  taskId,
-  role,
-  session,
-}: AgentStudioChatDraftScope): string => [taskId, role, sessionScopeKey(session)].join(":");
+export const agentStudioChatDraftScopeKey = (
+  workspaceId: string | null,
+  { taskId, role, session }: AgentStudioChatDraftScope,
+): string => [workspaceId ?? "", taskId, role, sessionScopeKey(session)].join(":");
 
 export const didAgentStudioChatDraftScopeSwitchSessionOnly = (
   previous: AgentStudioChatDraftScope,

--- a/packages/frontend/src/pages/agents/agent-studio-chat-draft.ts
+++ b/packages/frontend/src/pages/agents/agent-studio-chat-draft.ts
@@ -1,0 +1,76 @@
+import type { AgentRole } from "@openducktor/core";
+import type { AgentChatDraftPersistence } from "@/components/features/agents/agent-chat/agent-chat-draft-scope";
+import type { AgentChatDraftSessionIdentity } from "@/components/features/agents/agent-chat/agent-chat-draft-storage";
+import {
+  clearAgentChatDraft,
+  flushAgentChatDraft,
+  hydrateAgentChatDraft,
+  readAgentChatDraftVersion,
+  setAgentChatDraft,
+} from "@/components/features/agents/agent-chat/agent-chat-draft-store";
+import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
+import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
+
+export type AgentStudioChatDraftScope = {
+  taskId: string;
+  role: AgentRole;
+  session: AgentSessionIdentity | null;
+};
+
+const NEW_SESSION_DRAFT_SCOPE = "new";
+
+const sessionScopeKey = (session: AgentSessionIdentity | null): string =>
+  session ? agentSessionIdentityKey(session) : NEW_SESSION_DRAFT_SCOPE;
+
+export const agentStudioChatDraftScopeKey = ({
+  taskId,
+  role,
+  session,
+}: AgentStudioChatDraftScope): string => [taskId, role, sessionScopeKey(session)].join(":");
+
+export const didAgentStudioChatDraftScopeSwitchSessionOnly = (
+  previous: AgentStudioChatDraftScope,
+  next: AgentStudioChatDraftScope,
+): boolean =>
+  previous.taskId === next.taskId &&
+  previous.role === next.role &&
+  sessionScopeKey(previous.session) !== sessionScopeKey(next.session);
+
+const toPersistenceIdentity = (
+  workspaceId: string | null,
+  session: AgentSessionIdentity | null,
+): AgentChatDraftSessionIdentity | null => {
+  if (!workspaceId || !session) {
+    return null;
+  }
+
+  return {
+    workspaceId,
+    externalSessionId: session.externalSessionId,
+    runtimeKind: session.runtimeKind,
+    workingDirectory: session.workingDirectory,
+  };
+};
+
+export const createAgentStudioChatDraftPersistence = ({
+  workspaceId,
+  taskId,
+  session,
+}: {
+  workspaceId: string | null;
+  taskId: string;
+  session: AgentSessionIdentity | null;
+}): AgentChatDraftPersistence | null => {
+  const identity = toPersistenceIdentity(workspaceId, session);
+  if (!identity) {
+    return null;
+  }
+
+  return {
+    hydrate: () => hydrateAgentChatDraft(identity, taskId),
+    set: (draft) => setAgentChatDraft(identity, taskId, draft),
+    readVersion: () => readAgentChatDraftVersion(identity),
+    clear: (options) => clearAgentChatDraft(identity, options),
+    flush: () => flushAgentChatDraft(identity),
+  };
+};

--- a/packages/frontend/src/pages/agents/agent-studio-chat-draft.ts
+++ b/packages/frontend/src/pages/agents/agent-studio-chat-draft.ts
@@ -1,6 +1,9 @@
 import type { AgentRole } from "@openducktor/core";
 import type { AgentChatDraftPersistence } from "@/components/features/agents/agent-chat/agent-chat-draft-scope";
-import type { AgentChatDraftSessionIdentity } from "@/components/features/agents/agent-chat/agent-chat-draft-storage";
+import {
+  type AgentChatDraftSessionIdentity,
+  toAgentChatDraftStorageKey,
+} from "@/components/features/agents/agent-chat/agent-chat-draft-storage";
 import {
   clearAgentChatDraft,
   flushAgentChatDraft,
@@ -67,6 +70,7 @@ export const createAgentStudioChatDraftPersistence = ({
   }
 
   return {
+    targetKey: toAgentChatDraftStorageKey(identity),
     hydrate: () => hydrateAgentChatDraft(identity, taskId),
     set: (draft) => setAgentChatDraft(identity, taskId, draft),
     readVersion: () => readAgentChatDraftVersion(identity),

--- a/packages/frontend/src/pages/agents/agent-studio-chat-surface-state.test.ts
+++ b/packages/frontend/src/pages/agents/agent-studio-chat-surface-state.test.ts
@@ -23,15 +23,17 @@ const transcriptState = (
 
 describe("deriveAgentStudioChatSurfaceState", () => {
   test("prompts for a task before Agent Studio has a task context", () => {
-    expect(
-      deriveAgentStudioChatSurfaceState({
-        ...baseSurfaceInput,
-        taskId: "",
-        transcriptState: transcriptState("empty"),
-      }).emptyState,
-    ).toEqual({
+    const state = deriveAgentStudioChatSurfaceState({
+      ...baseSurfaceInput,
+      taskId: "",
+      transcriptState: transcriptState("empty"),
+    });
+
+    expect(state.emptyState).toEqual({
       title: "Select a task to begin.",
     });
+    expect(state.composerReadOnly).toBe(true);
+    expect(state.composerReadOnlyReason).toBe("Select a task to begin.");
   });
 
   test("hides the kickoff empty state while transcript state is not empty", () => {

--- a/packages/frontend/src/pages/agents/agent-studio-chat-surface-state.ts
+++ b/packages/frontend/src/pages/agents/agent-studio-chat-surface-state.ts
@@ -83,7 +83,12 @@ export const deriveAgentStudioChatSurfaceState = ({
   kickoffLabel,
   startLaunchKickoff,
 }: DeriveAgentStudioChatSurfaceStateInput): AgentStudioChatSurfaceState => {
-  const composerReadOnly = selectedSessionKey === null && !workflow.selectedRoleAvailable;
+  const hasTask = taskId.length > 0;
+  const composerReadOnly =
+    !hasTask || (selectedSessionKey === null && !workflow.selectedRoleAvailable);
+  const composerReadOnlyReason = hasTask
+    ? workflow.selectedRoleReadOnlyReason
+    : "Select a task to begin.";
 
   return {
     emptyState: deriveAgentStudioChatEmptyState({
@@ -95,6 +100,6 @@ export const deriveAgentStudioChatSurfaceState = ({
       startLaunchKickoff,
     }),
     composerReadOnly,
-    composerReadOnlyReason: composerReadOnly ? workflow.selectedRoleReadOnlyReason : null,
+    composerReadOnlyReason: composerReadOnly ? composerReadOnlyReason : null,
   };
 };

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-orchestration-shell-model.ts
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-orchestration-shell-model.ts
@@ -1,8 +1,8 @@
 import { type RefObject, useCallback, useMemo } from "react";
-import type { AgentChatDraftScope } from "@/components/features/agents/agent-chat/agent-chat-draft-scope";
 import type { RunSessionStartWorkflow } from "@/features/session-start";
 import type { useAgentOperations, useTasksState } from "@/state/app-state-provider";
 import type { RepoSettingsInput } from "@/types/state-slices";
+import type { AgentStudioChatDraftScope } from "../agent-studio-chat-draft";
 import { useAgentStudioOrchestrationController } from "../use-agent-studio-orchestration-controller";
 import { useAgentStudioRebaseConflictResolution } from "../use-agent-studio-rebase-conflict-resolution";
 import type { AgentStudioGitConflictQuickActionContext } from "../use-agents-page-right-panel-model";
@@ -68,7 +68,7 @@ export function useAgentsPageOrchestrationShellModel({
   const { selection, scheduleQueryUpdate, selectAgentStudioSelection } = routeSession;
 
   const composer = useMemo(
-    (): { draftScope: AgentChatDraftScope; workspaceId: string | null } => ({
+    (): { draftScope: AgentStudioChatDraftScope; workspaceId: string | null } => ({
       workspaceId: activeWorkspaceId,
       draftScope: {
         taskId: selection.view.taskId,

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { DEFAULT_AGENT_RUNTIMES } from "@openducktor/contracts";
 import type { PropsWithChildren, ReactElement } from "react";
-import { agentChatDraftScopeKey } from "@/components/features/agents/agent-chat/agent-chat-draft-scope";
 import type { SessionStartModalModel } from "@/components/features/agents/session-start-modal";
 import type { HumanReviewFeedbackModalModel } from "@/features/human-review-feedback/human-review-feedback-types";
 import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
@@ -23,6 +22,7 @@ import type {
   TasksStateContextValue,
   WorkspaceStateContextValue,
 } from "@/types/state-slices";
+import { agentStudioChatDraftScopeKey } from "../agent-studio-chat-draft";
 import {
   createAgentSessionFixture,
   createSelectedSessionTranscriptStateFixture,
@@ -469,7 +469,7 @@ const registerModuleMocks = (): void => {
         role: routeSession.selection.view.role,
         session: routeSession.selection.view.selectedSession.identity,
       };
-      const draftStateKey = agentChatDraftScopeKey(draftScope);
+      const draftStateKey = agentStudioChatDraftScopeKey(draftScope);
 
       if (!lastOrchestrationSelection) {
         throw new Error("Missing orchestration selection");

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
@@ -446,9 +446,11 @@ const registerModuleMocks = (): void => {
 
   mock.module("./use-agents-page-orchestration-shell-model", () => ({
     useAgentsPageOrchestrationShellModel: ({
+      activeWorkspaceId,
       isForegroundLoadingTasks,
       routeSession,
     }: {
+      activeWorkspaceId: string | null;
       isForegroundLoadingTasks: boolean;
       routeSession: { selection: SelectionState };
     }) => {
@@ -469,7 +471,7 @@ const registerModuleMocks = (): void => {
         role: routeSession.selection.view.role,
         session: routeSession.selection.view.selectedSession.identity,
       };
-      const draftStateKey = agentStudioChatDraftScopeKey(draftScope);
+      const draftStateKey = agentStudioChatDraftScopeKey(activeWorkspaceId, draftScope);
 
       if (!lastOrchestrationSelection) {
         throw new Error("Missing orchestration selection");
@@ -820,7 +822,7 @@ describe("useAgentsPageShellModel", () => {
       await harness.mount();
 
       expect(orchestrationControllerArgs.at(-1)?.draftStateKey).toBe(
-        `task-1:planner:${selectedSessionKey()}`,
+        `workspace-repo:task-1:planner:${selectedSessionKey()}`,
       );
     } finally {
       await harness.unmount();

--- a/packages/frontend/src/pages/agents/use-agent-studio-chat-model.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-chat-model.ts
@@ -215,7 +215,7 @@ export function useAgentStudioChatModel({
     sessionReadModelLoadState.kind,
   ]);
   const draftStateKey = agentStudioChatDraftScopeKey(composer.draftScope);
-  const draftScope = useMemo<AgentChatDraftScope>(
+  const composerDraftScope = useMemo<AgentChatDraftScope>(
     () => ({
       key: draftStateKey,
       persistence: draftPersistence,
@@ -259,7 +259,7 @@ export function useAgentStudioChatModel({
       isReadOnly: surfaceState.composerReadOnly,
       readOnlyReason: surfaceState.composerReadOnlyReason,
       ...(pendingSendItems ? { pendingSendItems } : {}),
-      draftScope,
+      draftScope: composerDraftScope,
       onSend: reviewCommentComposer.onSend,
       isSending: sessionActions.isSending,
       isStarting: sessionActions.isStarting,
@@ -295,7 +295,7 @@ export function useAgentStudioChatModel({
     }),
     [
       chatContextUsage,
-      draftScope,
+      composerDraftScope,
       modelSelection.agentOptions,
       modelSelection.isSelectionCatalogLoading,
       modelSelection.isSlashCommandsLoading,

--- a/packages/frontend/src/pages/agents/use-agent-studio-chat-model.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-chat-model.ts
@@ -7,17 +7,18 @@ import type {
   AgentChatPendingSendItems,
 } from "@/components/features/agents/agent-chat/agent-chat.types";
 import type { AgentChatComposerDraft } from "@/components/features/agents/agent-chat/agent-chat-composer-draft";
-import {
-  type AgentChatDraftScope,
-  agentChatDraftScopeKey,
-} from "@/components/features/agents/agent-chat/agent-chat-draft-scope";
-import type { AgentChatDraftSessionIdentity } from "@/components/features/agents/agent-chat/agent-chat-draft-storage";
+import type { AgentChatDraftScope } from "@/components/features/agents/agent-chat/agent-chat-draft-scope";
 import { useAgentChatSurfaceModel } from "@/components/features/agents/agent-chat/use-agent-chat-surface-model";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
 import type { AgentStudioContextUsage } from "@/features/agent-chat-composer/context-usage/context-usage-resolution";
 import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
 import { useAgentSessionReadModelState } from "@/state/app-state-provider";
 import type { AgentOperationsContextValue } from "@/types/state-slices";
+import {
+  type AgentStudioChatDraftScope,
+  agentStudioChatDraftScopeKey,
+  createAgentStudioChatDraftPersistence,
+} from "./agent-studio-chat-draft";
 import { deriveAgentStudioChatSurfaceState } from "./agent-studio-chat-surface-state";
 import { toSelectedSessionThreadSession } from "./agent-studio-thread-session";
 import type { AgentStudioSelectedSessionContext } from "./selected-session/selected-session-context";
@@ -71,7 +72,7 @@ export type AgentStudioChatModelSelectionContext = {
 };
 
 export type AgentStudioChatComposerContext = {
-  draftScope: AgentChatDraftScope;
+  draftScope: AgentStudioChatDraftScope;
   workspaceId: string | null;
 };
 
@@ -155,18 +156,15 @@ export function useAgentStudioChatModel({
   const selectedSessionKey = selectedSessionIdentity
     ? agentSessionIdentityKey(selectedSessionIdentity)
     : null;
-  const draftPersistenceIdentity = useMemo<AgentChatDraftSessionIdentity | null>(() => {
-    if (!composer.workspaceId || !selectedSessionIdentity) {
-      return null;
-    }
-
-    return {
-      workspaceId: composer.workspaceId,
-      externalSessionId: selectedSessionIdentity.externalSessionId,
-      runtimeKind: selectedSessionIdentity.runtimeKind,
-      workingDirectory: selectedSessionIdentity.workingDirectory,
-    };
-  }, [composer.workspaceId, selectedSessionIdentity]);
+  const draftPersistence = useMemo(
+    () =>
+      createAgentStudioChatDraftPersistence({
+        workspaceId: composer.workspaceId,
+        taskId: selectedSession.taskId,
+        session: selectedSessionIdentity,
+      }),
+    [composer.workspaceId, selectedSession.taskId, selectedSessionIdentity],
+  );
   const surfaceState = useMemo(
     () =>
       deriveAgentStudioChatSurfaceState({
@@ -214,7 +212,14 @@ export function useAgentStudioChatModel({
     selectedSessionTranscriptState.kind,
     sessionReadModelLoadState.kind,
   ]);
-  const draftStateKey = agentChatDraftScopeKey(composer.draftScope);
+  const draftStateKey = agentStudioChatDraftScopeKey(composer.draftScope);
+  const draftScope = useMemo<AgentChatDraftScope>(
+    () => ({
+      key: draftStateKey,
+      persistence: draftPersistence,
+    }),
+    [draftPersistence, draftStateKey],
+  );
   const reviewCommentComposer = useAgentStudioReviewCommentComposerAdapter({
     draftScope: composer.draftScope,
     draftStateKey,
@@ -235,7 +240,6 @@ export function useAgentStudioChatModel({
 
   const composerConfig = useMemo(
     () => ({
-      taskId: selectedSession.taskId,
       displayedSessionKey: selectedSessionKey,
       selectedSession: selectedSessionIdentity
         ? {
@@ -253,8 +257,7 @@ export function useAgentStudioChatModel({
       isReadOnly: surfaceState.composerReadOnly,
       readOnlyReason: surfaceState.composerReadOnlyReason,
       ...(pendingSendItems ? { pendingSendItems } : {}),
-      draftStateKey,
-      draftPersistenceIdentity,
+      draftScope,
       onSend: reviewCommentComposer.onSend,
       isSending: sessionActions.isSending,
       isStarting: sessionActions.isStarting,
@@ -290,8 +293,7 @@ export function useAgentStudioChatModel({
     }),
     [
       chatContextUsage,
-      draftStateKey,
-      draftPersistenceIdentity,
+      draftScope,
       modelSelection.agentOptions,
       modelSelection.isSelectionCatalogLoading,
       modelSelection.isSlashCommandsLoading,
@@ -327,7 +329,6 @@ export function useAgentStudioChatModel({
       selectedSessionModel,
       selectedSessionKey,
       selectedSessionRuntimeData.isLoadingModelCatalog,
-      selectedSession.taskId,
       surfaceState.composerReadOnly,
       surfaceState.composerReadOnlyReason,
       sessionActions.busySendBlockedReason,

--- a/packages/frontend/src/pages/agents/use-agent-studio-chat-model.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-chat-model.ts
@@ -12,6 +12,7 @@ import { useAgentChatSurfaceModel } from "@/components/features/agents/agent-cha
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
 import type { AgentStudioContextUsage } from "@/features/agent-chat-composer/context-usage/context-usage-resolution";
 import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
+import { useStableAgentSessionIdentity } from "@/lib/use-stable-agent-session-identity";
 import { useAgentSessionReadModelState } from "@/state/app-state-provider";
 import type { AgentOperationsContextValue } from "@/types/state-slices";
 import {
@@ -156,14 +157,15 @@ export function useAgentStudioChatModel({
   const selectedSessionKey = selectedSessionIdentity
     ? agentSessionIdentityKey(selectedSessionIdentity)
     : null;
+  const stableDraftSessionIdentity = useStableAgentSessionIdentity(selectedSessionIdentity);
   const draftPersistence = useMemo(
     () =>
       createAgentStudioChatDraftPersistence({
         workspaceId: composer.workspaceId,
         taskId: selectedSession.taskId,
-        session: selectedSessionIdentity,
+        session: stableDraftSessionIdentity,
       }),
-    [composer.workspaceId, selectedSession.taskId, selectedSessionIdentity],
+    [composer.workspaceId, selectedSession.taskId, stableDraftSessionIdentity],
   );
   const surfaceState = useMemo(
     () =>

--- a/packages/frontend/src/pages/agents/use-agent-studio-chat-model.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-chat-model.ts
@@ -214,7 +214,7 @@ export function useAgentStudioChatModel({
     selectedSessionTranscriptState.kind,
     sessionReadModelLoadState.kind,
   ]);
-  const draftStateKey = agentStudioChatDraftScopeKey(composer.draftScope);
+  const draftStateKey = agentStudioChatDraftScopeKey(composer.workspaceId, composer.draftScope);
   const composerDraftScope = useMemo<AgentChatDraftScope>(
     () => ({
       key: draftStateKey,

--- a/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { agentChatDraftScopeKey } from "@/components/features/agents/agent-chat/agent-chat-draft-scope";
 import type { TaskExecutionSelectedFile } from "@/components/features/agents/task-execution-file-explorer-model";
 import { agentSessionIdentityKey, toAgentSessionIdentity } from "@/lib/agent-session-identity";
 import { toAgentSessionSummary } from "@/state/agent-sessions-store";
 import { createChatSettingsFixture } from "@/test-utils/shared-test-fixtures";
+import { agentStudioChatDraftScopeKey } from "./agent-studio-chat-draft";
 import {
   createAgentSessionFixture,
   createSelectedSessionTranscriptStateFixture,
@@ -250,7 +250,7 @@ describe("buildAgentStudioPageModelsArgs", () => {
       role: "planner",
       session: toAgentSessionIdentity(session),
     });
-    expect(agentChatDraftScopeKey(mapped.composer.draftScope)).toBe(
+    expect(agentStudioChatDraftScopeKey(mapped.composer.draftScope)).toBe(
       `task-1:planner:${agentSessionIdentityKey(toAgentSessionIdentity(session))}`,
     );
   });

--- a/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
@@ -250,8 +250,10 @@ describe("buildAgentStudioPageModelsArgs", () => {
       role: "planner",
       session: toAgentSessionIdentity(session),
     });
-    expect(agentStudioChatDraftScopeKey(mapped.composer.draftScope)).toBe(
-      `task-1:planner:${agentSessionIdentityKey(toAgentSessionIdentity(session))}`,
+    expect(
+      agentStudioChatDraftScopeKey(mapped.composer.workspaceId, mapped.composer.draftScope),
+    ).toBe(
+      `workspace-repo:task-1:planner:${agentSessionIdentityKey(toAgentSessionIdentity(session))}`,
     );
   });
 

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -1179,7 +1179,10 @@ describe("useAgentStudioPageModels", () => {
     expect(nextState.agentChatModel.thread).toBe(initialThreadModel);
     expect(nextState.agentChatModel.composer).not.toBe(initialComposerModel);
     expect(nextState.agentChatModel.composer.draftScope.key).toBe(
-      agentStudioChatDraftScopeKey(draftScopeFixture("draft-update")),
+      agentStudioChatDraftScopeKey(
+        baseProps.composer.workspaceId,
+        draftScopeFixture("draft-update"),
+      ),
     );
 
     await harness.unmount();

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -1185,6 +1185,38 @@ describe("useAgentStudioPageModels", () => {
     await harness.unmount();
   });
 
+  test("keeps draft persistence stable for equivalent session identity objects", async () => {
+    const session = createSession("session-1", "external-1");
+    const selectedSessionIdentity = toAgentSessionIdentity(session);
+    const selectedSessionCore = {
+      loadedSession: session,
+      sessionsForTask: summarizeSessions([session]),
+      selectedSessionIdentity,
+    };
+    const harness = createHookHarness(
+      createHookArgs({
+        selectedSessionCore,
+      }),
+    );
+
+    await harness.mount();
+    const initialPersistence = harness.getLatest().agentChatModel.composer.draftScope.persistence;
+
+    await harness.update(
+      createHookArgs({
+        selectedSessionCore: {
+          ...selectedSessionCore,
+          selectedSessionIdentity: { ...selectedSessionIdentity },
+        },
+      }),
+    );
+
+    expect(harness.getLatest().agentChatModel.composer.draftScope.persistence).toBe(
+      initialPersistence,
+    );
+    await harness.unmount();
+  });
+
   test("keeps composer model stable for thread-only updates", async () => {
     const session = createSession("session-1", "external-1");
     const baseProps = createHookArgs({

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -3,10 +3,6 @@ import { act, createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { AgentChatModel } from "@/components/features/agents/agent-chat/agent-chat.types";
 import { AgentChatComposer } from "@/components/features/agents/agent-chat/agent-chat-composer";
-import {
-  type AgentChatDraftScope,
-  agentChatDraftScopeKey,
-} from "@/components/features/agents/agent-chat/agent-chat-draft-scope";
 import { AgentChatSettingsProvider } from "@/components/features/agents/agent-chat/agent-chat-settings-context";
 import { createComposerDraft } from "@/components/features/agents/agent-chat/agent-chat-test-fixtures";
 import { AgentChatThread } from "@/components/features/agents/agent-chat/agent-chat-thread";
@@ -23,6 +19,10 @@ import type {
   SessionMessagesState,
 } from "@/types/agent-orchestrator";
 import { readyAgentSessionReadModelLoadState } from "@/types/agent-session-read-model";
+import {
+  type AgentStudioChatDraftScope,
+  agentStudioChatDraftScopeKey,
+} from "./agent-studio-chat-draft";
 import {
   createAgentSessionFixture,
   createSelectedSessionTranscriptStateFixture,
@@ -46,7 +46,7 @@ type HookArgs = Parameters<UseAgentStudioPageModelsHook>[0];
 const DEFAULT_SKILLS: HookArgs["modelSelection"]["skills"] = [];
 const reloadSessionReadModel = () => undefined;
 
-const draftScopeFixture = (taskId: string): AgentChatDraftScope => ({
+const draftScopeFixture = (taskId: string): AgentStudioChatDraftScope => ({
   taskId,
   role: "planner",
   session: null,
@@ -357,7 +357,7 @@ const createAgentChatThreadElement = (model: AgentChatModel) =>
   );
 
 describe("useAgentStudioPageModels", () => {
-  test("keeps the interactive composer model available before a task is selected", async () => {
+  test("keeps a read-only composer model available before a task is selected", async () => {
     const harness = createHookHarness(
       createHookArgs({
         selectedSessionCore: {
@@ -373,7 +373,8 @@ describe("useAgentStudioPageModels", () => {
     await harness.mount();
 
     const state = harness.getLatest();
-    expect(state.agentChatModel.composer.taskId).toBe("");
+    expect(state.agentChatModel.composer.isReadOnly).toBe(true);
+    expect(state.agentChatModel.composer.readOnlyReason).toBe("Select a task to begin.");
     expect(state.agentChatModel.thread.emptyState?.title).toBe("Select a task to begin.");
 
     await harness.unmount();
@@ -412,12 +413,7 @@ describe("useAgentStudioPageModels", () => {
       totalTokens: 12,
       contextWindow: 100,
     });
-    expect(state.agentChatModel.composer.draftPersistenceIdentity).toEqual({
-      workspaceId: "workspace-repo",
-      externalSessionId: "external-1",
-      runtimeKind: "opencode",
-      workingDirectory: "/repo",
-    });
+    expect(state.agentChatModel.composer.draftScope.persistence).not.toBeNull();
     expect(state.agentChatModel.thread.runtimeReadiness.state).toBe("ready");
     expect(state.agentChatModel.thread.isSessionWorking).toBe(true);
     expect(state.agentChatModel.chatSettings.showThinkingMessages).toBe(false);
@@ -1182,8 +1178,8 @@ describe("useAgentStudioPageModels", () => {
     const nextState = harness.getLatest();
     expect(nextState.agentChatModel.thread).toBe(initialThreadModel);
     expect(nextState.agentChatModel.composer).not.toBe(initialComposerModel);
-    expect(nextState.agentChatModel.composer.draftStateKey).toBe(
-      agentChatDraftScopeKey(draftScopeFixture("draft-update")),
+    expect(nextState.agentChatModel.composer.draftScope.key).toBe(
+      agentStudioChatDraftScopeKey(draftScopeFixture("draft-update")),
     );
 
     await harness.unmount();

--- a/packages/frontend/src/pages/agents/use-agent-studio-review-comment-composer-adapter.test.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-review-comment-composer-adapter.test.ts
@@ -3,11 +3,11 @@ import {
   createEmptyComposerDraft,
   draftToSerializedText,
 } from "@/components/features/agents/agent-chat/agent-chat-composer-draft";
-import type { AgentChatDraftScope } from "@/components/features/agents/agent-chat/agent-chat-draft-scope";
 import type {
   InlineCommentDraft,
   InlineCommentDraftSnapshot,
 } from "@/state/use-inline-comment-draft-store";
+import type { AgentStudioChatDraftScope } from "./agent-studio-chat-draft";
 import {
   type AgentStudioReviewCommentStore,
   createAgentStudioReviewCommentComposerAdapter,
@@ -143,9 +143,9 @@ const createFakeReviewCommentStore = (
 
 const buildScope = (
   taskId: string,
-  role: AgentChatDraftScope["role"],
+  role: AgentStudioChatDraftScope["role"],
   externalSessionId: string | null,
-): AgentChatDraftScope => ({
+): AgentStudioChatDraftScope => ({
   taskId,
   role,
   session:

--- a/packages/frontend/src/pages/agents/use-agent-studio-review-comment-composer-adapter.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-review-comment-composer-adapter.ts
@@ -5,13 +5,13 @@ import {
   appendTextToDraft,
 } from "@/components/features/agents/agent-chat/agent-chat-composer-draft";
 import {
-  type AgentChatDraftScope,
-  didAgentChatDraftScopeSwitchSessionOnly,
-} from "@/components/features/agents/agent-chat/agent-chat-draft-scope";
-import {
   type InlineCommentDraftStore,
   useInlineCommentDraftStore,
 } from "@/state/use-inline-comment-draft-store";
+import {
+  type AgentStudioChatDraftScope,
+  didAgentStudioChatDraftScopeSwitchSessionOnly,
+} from "./agent-studio-chat-draft";
 
 export type AgentStudioReviewCommentStore = Pick<
   InlineCommentDraftStore,
@@ -26,7 +26,7 @@ export type AgentStudioReviewCommentStore = Pick<
 >;
 
 type AgentStudioReviewCommentComposerAdapter = {
-  syncDraftScope: (draftScope: AgentChatDraftScope, draftStateKey: string) => void;
+  syncDraftScope: (draftScope: AgentStudioChatDraftScope, draftStateKey: string) => void;
   submitDraft: (
     draft: AgentChatComposerDraft,
     onSend: AgentChatComposerModel["onSend"],
@@ -36,7 +36,7 @@ type AgentStudioReviewCommentComposerAdapter = {
 export const createAgentStudioReviewCommentComposerAdapter = (
   getStore: () => AgentStudioReviewCommentStore,
 ): AgentStudioReviewCommentComposerAdapter => {
-  let previousDraftScope: AgentChatDraftScope | null = null;
+  let previousDraftScope: AgentStudioChatDraftScope | null = null;
 
   return {
     syncDraftScope: (draftScope, draftStateKey) => {
@@ -47,7 +47,7 @@ export const createAgentStudioReviewCommentComposerAdapter = (
       const store = getStore();
       if (
         previousDraftScope !== null &&
-        didAgentChatDraftScopeSwitchSessionOnly(previousDraftScope, draftScope) &&
+        didAgentStudioChatDraftScopeSwitchSessionOnly(previousDraftScope, draftScope) &&
         store.drafts.some((draft) => draft.status === "submitting")
       ) {
         store.setDraftStateKey(draftStateKey);
@@ -92,7 +92,7 @@ export const createAgentStudioReviewCommentComposerAdapter = (
 };
 
 type UseAgentStudioReviewCommentComposerAdapterArgs = {
-  draftScope: AgentChatDraftScope;
+  draftScope: AgentStudioChatDraftScope;
   draftStateKey: string;
   onSend: AgentChatComposerModel["onSend"];
 };


### PR DESCRIPTION
## Summary
- Decouple shared chat composer draft state from workflow task and role identity.
- Add an opaque caller-owned draft key with optional persistence.
- Keep Agent Studio version 2 localStorage keys and payloads unchanged.
- Preserve draft switch, version-safe clear, restore, attachment, and lifecycle flush behavior.
- Handle recreated equivalent persistence adapters without render loops or stale writes.

## Goal
Repository chat needs to reuse the shared composer without inventing task or workflow-role values. The previous shared hook owned Agent Studio storage details, which tied a generic UI draft to one workflow caller and made later reuse unsafe.

## Implementation
- Define the shared draft boundary as an opaque key plus a narrow persistence adapter.
- Move Agent Studio task, role, and session key construction into an Agent Studio adapter.
- Capture task identity inside that adapter while keeping the existing version 2 storage contract intact.
- Compare semantic persistence targets so equivalent adapter wrappers can refresh without hydration or state churn.
- Keep flush-before-switch, submitted-version clearing, failed-send restore, new-input-wins, stale-identity rejection, and page-hide or unmount flush semantics.
- Add focused coverage for in-memory callers, non-task identities, persistence switching, race handling, existing payload reads, and equivalent wrapper refreshes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Improvements
- Improved chat draft persistence and restoration across workspace, session, and task changes.
- Preserved meaningful drafts during context changes while correctly loading replacement drafts.
- Stabilized draft persistence across equivalent session identities.
- Prevented submitted text from reappearing after persistence refreshes during sending.

## Bug Fixes
- Agent Studio chat is now read-only when no task is selected.
- Added a clear message explaining that a task must be selected before composing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->