### PR TITLE
fix(agent-chat): remove cached transcript switch flicker

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -849,7 +849,7 @@ describe("AgentChatThread", () => {
     });
   });
 
-  test("shows the loader before rendering cached large transcripts after switching back", async () => {
+  test("renders cached large transcripts immediately after switching back", async () => {
     await withAnimationFrameTestDriver(async (animationFrameDriver) => {
       const largeMessages = Array.from({ length: 18 }, (_, turnIndex) => [
         buildMessage("user", `Turn ${turnIndex + 1} request`, {
@@ -917,14 +917,8 @@ describe("AgentChatThread", () => {
         }),
       );
 
-      expect(rendered.queryByText("Loading session")).not.toBeNull();
-      expect(rendered.queryByText("Turn 18 reply 18")).toBeNull();
-
-      await waitFor(async () => {
-        await animationFrameDriver.flushFrames();
-        await animationFrameDriver.flushTimers();
-        expect(rendered.queryByText("Turn 18 reply 18")).not.toBeNull();
-      });
+      expect(rendered.queryByText("Loading session")).toBeNull();
+      expect(rendered.queryByText("Turn 18 reply 18")).not.toBeNull();
       const immediateRowCount = rendered.container.querySelectorAll("[data-row-key]").length;
       expect(immediateRowCount).toBeGreaterThan(0);
       expect(immediateRowCount).toBeLessThan(largeMessages.length);
@@ -1177,9 +1171,9 @@ describe("AgentChatThread", () => {
         },
       }),
     );
-    await act(flush);
-
-    expect(rendered.container.textContent).toContain("Message 81");
+    await waitFor(() => {
+      expect(rendered.container.textContent).toContain("Message 81");
+    });
     rendered.unmount();
   });
 

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-transcript-model-cache.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-transcript-model-cache.ts
@@ -1,28 +1,20 @@
-import { isAgentSessionActivityWorking } from "@/lib/agent-session-activity-state";
 import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
 import { areSessionMessagesSameRevision } from "@/state/operations/agent-orchestrator/support/messages";
 import type { AgentChatTranscriptSession } from "./agent-chat.types";
-import {
-  type AgentChatTranscriptModel,
-  findActiveStreamingAssistantMessageIdInRows,
-} from "./agent-chat-transcript-model";
+import type { AgentChatTranscriptModel } from "./agent-chat-transcript-model";
 
 const TRANSCRIPT_MODEL_CACHE_LIMIT = 6;
-
-export type TranscriptModelCacheValue = Pick<
-  AgentChatTranscriptModel,
-  | "rows"
-  | "turnAnchors"
-  | "hasAttachmentMessages"
-  | "lastUserMessageKey"
-  | "activeStreamingAssistantMessageId"
->;
 
 export type TranscriptModelCacheEntry = AgentChatTranscriptModel & {
   messages: AgentChatTranscriptSession["messages"];
 };
 
 export type TranscriptModelCache = Map<string, TranscriptModelCacheEntry>;
+
+export type TranscriptModelCacheLookup = {
+  current: TranscriptModelCacheEntry | null;
+  latest: TranscriptModelCacheEntry | null;
+};
 
 const toTranscriptModelCacheKey = (sessionKey: string, showThinkingMessages: boolean): string =>
   `${sessionKey}:${showThinkingMessages ? "thinking:on" : "thinking:off"}`;
@@ -45,22 +37,6 @@ const touchTranscriptModelCacheEntry = (
     }
     cache.delete(oldestKey);
   }
-};
-
-const toTranscriptModelCacheValue = (
-  cacheEntry: TranscriptModelCacheEntry,
-  activityState: AgentChatTranscriptSession["activityState"],
-): TranscriptModelCacheValue => {
-  return {
-    rows: cacheEntry.rows,
-    turnAnchors: cacheEntry.turnAnchors,
-    hasAttachmentMessages: cacheEntry.hasAttachmentMessages,
-    lastUserMessageKey: cacheEntry.lastUserMessageKey,
-    activeStreamingAssistantMessageId: isAgentSessionActivityWorking(activityState)
-      ? (cacheEntry.activeStreamingAssistantMessageId ??
-        findActiveStreamingAssistantMessageIdInRows(cacheEntry.rows))
-      : null,
-  };
 };
 
 export const createTranscriptModelCache = (): TranscriptModelCache =>
@@ -87,55 +63,36 @@ export const writeTranscriptModelCacheEntry = ({
   });
 };
 
-export const peekReusableTranscriptModelState = ({
+export const readTranscriptModelCache = ({
   session,
   showThinkingMessages,
   cache,
-  touch = true,
+  touchCurrent = false,
 }: {
   session: AgentChatTranscriptSession;
   showThinkingMessages: boolean;
   cache: TranscriptModelCache;
-  touch?: boolean;
-}): TranscriptModelCacheValue | null => {
+  touchCurrent?: boolean;
+}): TranscriptModelCacheLookup => {
   const cacheKey = toTranscriptModelCacheKey(
     agentSessionIdentityKey(session),
     showThinkingMessages,
   );
   const cacheEntry = cache.get(cacheKey);
   if (!cacheEntry) {
-    return null;
+    return { current: null, latest: null };
   }
 
-  if (
-    !areSessionMessagesSameRevision(
-      { externalSessionId: session.externalSessionId, messages: cacheEntry.messages },
-      session,
-    )
-  ) {
-    return null;
-  }
+  const isCurrent = areSessionMessagesSameRevision(
+    { externalSessionId: session.externalSessionId, messages: cacheEntry.messages },
+    session,
+  );
 
-  if (touch) {
+  if (isCurrent && touchCurrent) {
     touchTranscriptModelCacheEntry(cache, cacheKey, cacheEntry);
   }
-  return toTranscriptModelCacheValue(cacheEntry, session.activityState);
-};
-
-// Intentionally returns the latest entry for this session key without revision validation.
-// Callers must apply strict safety gates before reusing any prefix rows from it.
-export const peekTranscriptModelCacheEntry = ({
-  session,
-  showThinkingMessages,
-  cache,
-}: {
-  session: AgentChatTranscriptSession;
-  showThinkingMessages: boolean;
-  cache: TranscriptModelCache;
-}): TranscriptModelCacheEntry | null => {
-  const cacheKey = toTranscriptModelCacheKey(
-    agentSessionIdentityKey(session),
-    showThinkingMessages,
-  );
-  return cache.get(cacheKey) ?? null;
+  return {
+    current: isCurrent ? cacheEntry : null,
+    latest: cacheEntry,
+  };
 };

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-transcript-model.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-transcript-model.test.ts
@@ -456,7 +456,7 @@ describe("agent chat transcript model", () => {
     expect(rows[0]?.key).toBe(`${sessionKey}:0:assistant-live`);
   });
 
-  test("buildAgentChatTranscriptModel marks active streaming assistant only while session activity is running", () => {
+  test("buildAgentChatTranscriptModel keeps streaming metadata independent of session activity", () => {
     const sharedMessages = [
       buildMessage("assistant", "Working", {
         id: "assistant-live",
@@ -487,10 +487,10 @@ describe("agent chat transcript model", () => {
     });
 
     expect(runningRowsState.activeStreamingAssistantMessageId).toBe("assistant-live");
-    expect(idleRowsState.activeStreamingAssistantMessageId).toBeNull();
+    expect(idleRowsState.activeStreamingAssistantMessageId).toBe("assistant-live");
   });
 
-  test("buildAgentChatTranscriptModel restores streaming metadata when session activity resumes", () => {
+  test("buildAgentChatTranscriptModel preserves streaming metadata when session activity resumes", () => {
     const sharedMessages = [
       buildMessage("assistant", "Working", {
         id: "assistant-live",
@@ -520,7 +520,7 @@ describe("agent chat transcript model", () => {
       showThinkingMessages: true,
     });
 
-    expect(idleRowsState.activeStreamingAssistantMessageId).toBeNull();
+    expect(idleRowsState.activeStreamingAssistantMessageId).toBe("assistant-live");
     expect(resumedRowsState.activeStreamingAssistantMessageId).toBe("assistant-live");
   });
 });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-transcript-model.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-transcript-model.ts
@@ -1,4 +1,3 @@
-import { isAgentSessionActivityWorking } from "@/lib/agent-session-activity-state";
 import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
 import {
   forEachSessionMessageFrom,
@@ -65,11 +64,9 @@ const isVisibleTranscriptMessage = (
 
 const updateAggregateMetadataForMessage = ({
   message,
-  isSessionWorking,
   metadata,
 }: {
   message: AgentChatMessage;
-  isSessionWorking: boolean;
   metadata: AgentChatTranscriptMetadata;
 }): void => {
   if (
@@ -80,7 +77,7 @@ const updateAggregateMetadataForMessage = ({
     metadata.hasAttachmentMessages = true;
   }
 
-  if (isSessionWorking && isAssistantMessageStreaming(message)) {
+  if (isAssistantMessageStreaming(message)) {
     metadata.activeStreamingAssistantMessageId = message.id;
   }
 };
@@ -143,7 +140,6 @@ export function createAgentChatTranscriptModelBuilder(
   const turnRowStartIndexes: number[] = [];
   const sessionKey = agentSessionIdentityKey(session);
   const messageCount = getSessionMessageCount(session);
-  const isSessionWorking = isAgentSessionActivityWorking(session.activityState);
   const metadata: AgentChatTranscriptMetadata = {
     hasAttachmentMessages: false,
     lastUserMessageKey: null,
@@ -152,7 +148,7 @@ export function createAgentChatTranscriptModelBuilder(
   let nextMessageIndex = 0;
 
   const processMessage = (message: AgentChatMessage, messageIndex: number): void => {
-    updateAggregateMetadataForMessage({ message, isSessionWorking, metadata });
+    updateAggregateMetadataForMessage({ message, metadata });
 
     if (!isVisibleTranscriptMessage(message, showThinkingMessages)) {
       return;
@@ -227,10 +223,7 @@ const findRowIndexForMessage = (rows: AgentChatTranscriptRow[], messageId: strin
   return matchingRowIndex;
 };
 
-const buildMetadataFromRows = (
-  rows: AgentChatTranscriptRow[],
-  isSessionWorking: boolean,
-): AgentChatTranscriptMetadata => {
+const buildMetadataFromRows = (rows: AgentChatTranscriptRow[]): AgentChatTranscriptMetadata => {
   const metadata: AgentChatTranscriptMetadata = {
     hasAttachmentMessages: false,
     lastUserMessageKey: null,
@@ -239,7 +232,7 @@ const buildMetadataFromRows = (
 
   for (const row of rows) {
     if (row.kind === "message") {
-      updateAggregateMetadataForMessage({ message: row.message, isSessionWorking, metadata });
+      updateAggregateMetadataForMessage({ message: row.message, metadata });
       if (row.message.role === "user") {
         metadata.lastUserMessageKey = row.key;
       }
@@ -247,19 +240,6 @@ const buildMetadataFromRows = (
   }
 
   return metadata;
-};
-
-export const findActiveStreamingAssistantMessageIdInRows = (
-  rows: AgentChatTranscriptRow[],
-): string | null => {
-  for (let rowIndex = rows.length - 1; rowIndex >= 0; rowIndex -= 1) {
-    const row = rows[rowIndex];
-    if (row?.kind === "message" && isAssistantMessageStreaming(row.message)) {
-      return row.message.id;
-    }
-  }
-
-  return null;
 };
 
 // This helper intentionally trusts the caller's incremental safety plan. Use append mode only
@@ -304,14 +284,13 @@ export function updateAgentChatTranscriptModelFromPrefix({
   }
 
   const rows = previousTranscriptModel.rows.slice(0, firstTailRowIndex);
-  const isSessionWorking = isAgentSessionActivityWorking(session.activityState);
-  const metadata = buildMetadataFromRows(rows, isSessionWorking);
+  const metadata = buildMetadataFromRows(rows);
 
   let messageIndex = startMessageIndex;
   forEachSessionMessageFrom(session, startMessageIndex, (message) => {
     const currentMessageIndex = messageIndex;
     messageIndex += 1;
-    updateAggregateMetadataForMessage({ message, isSessionWorking, metadata });
+    updateAggregateMetadataForMessage({ message, metadata });
     if (!isVisibleTranscriptMessage(message, showThinkingMessages)) {
       return;
     }

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-rendered-transcript.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-rendered-transcript.ts
@@ -1,12 +1,4 @@
-import {
-  type RefObject,
-  startTransition,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { type RefObject, useLayoutEffect, useMemo, useRef } from "react";
 import type { AgentChatThreadModel, AgentChatTranscriptPresentation } from "./agent-chat.types";
 import { useAgentChatSettings } from "./agent-chat-settings-context";
 import { isAssistantMessageStreaming } from "./agent-chat-streaming";
@@ -77,49 +69,14 @@ export function useAgentChatRenderedTranscript({
   const { session, displayedSessionKey, shouldResetWindow, notice } = transcript;
   const { showThinkingMessages } = useAgentChatSettings();
   const messagesContentRef = useRef<HTMLDivElement | null>(null);
-  const renderableFrameRef = useRef<number | null>(null);
-  const [renderableSessionKey, setRenderableSessionKey] = useState(displayedSessionKey);
-  const isSessionSwitchPending = renderableSessionKey !== displayedSessionKey;
-  const renderableSession = isSessionSwitchPending ? null : session;
   const { transcriptState: transcriptModelState, isTranscriptModelMissing } =
     useAgentChatTranscriptModel({
-      session: renderableSession,
+      session,
       showThinkingMessages,
     });
-  useEffect(() => {
-    if (renderableSessionKey === displayedSessionKey) {
-      return;
-    }
-
-    const requestFrame = globalThis.requestAnimationFrame;
-    if (typeof requestFrame !== "function") {
-      startTransition(() => {
-        setRenderableSessionKey(displayedSessionKey);
-      });
-      return;
-    }
-
-    renderableFrameRef.current = requestFrame(() => {
-      renderableFrameRef.current = null;
-      startTransition(() => {
-        setRenderableSessionKey(displayedSessionKey);
-      });
-    });
-
-    return () => {
-      if (renderableFrameRef.current !== null) {
-        globalThis.cancelAnimationFrame(renderableFrameRef.current);
-        renderableFrameRef.current = null;
-      }
-    };
-  }, [displayedSessionKey, renderableSessionKey]);
-  const effectiveShouldResetTranscriptWindow =
-    shouldResetWindow || isTranscriptModelMissing || isSessionSwitchPending;
+  const effectiveShouldResetTranscriptWindow = shouldResetWindow || isTranscriptModelMissing;
   const effectiveTranscriptNotice =
-    notice ??
-    (isTranscriptModelMissing || isSessionSwitchPending ? TRANSCRIPT_MODEL_PENDING_NOTICE : null);
-  const windowRows = isSessionSwitchPending ? [] : transcriptModelState.rows;
-  const windowTurnAnchors = isSessionSwitchPending ? [] : transcriptModelState.turnAnchors;
+    notice ?? (isTranscriptModelMissing ? TRANSCRIPT_MODEL_PENDING_NOTICE : null);
   const {
     visibleRows,
     visibleTurnAnchors,
@@ -129,8 +86,8 @@ export function useAgentChatRenderedTranscript({
     scrollToTop,
     scrollToBottomOnSend,
   } = useAgentChatWindow({
-    rows: windowRows,
-    turnAnchors: windowTurnAnchors,
+    rows: transcriptModelState.rows,
+    turnAnchors: transcriptModelState.turnAnchors,
     displayedSessionKey,
     shouldResetForTranscriptLoad: effectiveShouldResetTranscriptWindow,
     isSessionWorking,

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-row-window.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-row-window.ts
@@ -31,6 +31,11 @@ type RowRange = {
   endRowExclusive: number;
 };
 
+type SessionRowRange = {
+  sessionKey: string | null;
+  range: RowRange;
+};
+
 type PrependScrollSnapshot = {
   scrollHeight: number;
   overflowAnchor: string;
@@ -115,9 +120,13 @@ export function useAgentChatRowWindow({
   shouldFollowLatestWindow,
   messagesContainerRef,
 }: UseAgentChatRowWindowInput): UseAgentChatRowWindowResult {
-  const [range, setRangeState] = useState<RowRange>(() => latestRange(rows.length));
+  const [sessionRange, setSessionRange] = useState<SessionRowRange>(() => ({
+    sessionKey: displayedSessionKey,
+    range: latestRange(rows.length),
+  }));
+  const didSessionChange = sessionRange.sessionKey !== displayedSessionKey;
+  const range = didSessionChange ? latestRange(rows.length) : sessionRange.range;
   const rangeRef = useRef(range);
-  const previousSessionKeyRef = useRef<string | null>(displayedSessionKey);
   const pendingLatestResetRef = useRef(shouldResetForTranscriptLoad && rows.length === 0);
   const previousRowsLengthRef = useRef(rows.length);
   const previousFirstVisibleRowKeyRef = useRef(rows[range.startRow]?.key ?? null);
@@ -127,16 +136,31 @@ export function useAgentChatRowWindow({
   const shouldTrimTopAfterAppendRef = useRef(false);
   const lastScrollTopRef = useRef(0);
 
+  useLayoutEffect(() => {
+    if (!didSessionChange) {
+      return;
+    }
+
+    const nextRange = latestRange(rows.length);
+    rangeRef.current = nextRange;
+    pendingLatestResetRef.current = shouldResetForTranscriptLoad && rows.length === 0;
+    previousRowsLengthRef.current = rows.length;
+    previousFirstVisibleRowKeyRef.current = rows[nextRange.startRow]?.key ?? null;
+    setSessionRange({ sessionKey: displayedSessionKey, range: nextRange });
+  }, [didSessionChange, displayedSessionKey, rows, shouldResetForTranscriptLoad]);
+
   const setRange = useCallback(
     (nextRange: RowRange) => {
       const clampedRange = clampRange(nextRange, rows.length);
       rangeRef.current = clampedRange;
       previousFirstVisibleRowKeyRef.current = rows[clampedRange.startRow]?.key ?? null;
-      setRangeState((currentRange) =>
-        areRangesEqual(currentRange, clampedRange) ? currentRange : clampedRange,
+      setSessionRange((current) =>
+        current.sessionKey === displayedSessionKey && areRangesEqual(current.range, clampedRange)
+          ? current
+          : { sessionKey: displayedSessionKey, range: clampedRange },
       );
     },
-    [rows],
+    [displayedSessionKey, rows],
   );
 
   const selectFirstRowWindow = useCallback(() => {
@@ -285,30 +309,24 @@ export function useAgentChatRowWindow({
   }, [expandAfter, expandBefore, messagesContainerRef, range]);
 
   useLayoutEffect(() => {
-    const didSessionChange = previousSessionKeyRef.current !== displayedSessionKey;
     const previousRowsLength = previousRowsLengthRef.current;
     const previousRange = rangeRef.current;
     const previousFirstVisibleRowKey = previousFirstVisibleRowKeyRef.current;
     previousRowsLengthRef.current = rows.length;
 
     if (didSessionChange) {
-      previousSessionKeyRef.current = displayedSessionKey;
-      pendingLatestResetRef.current = shouldResetForTranscriptLoad && rows.length === 0;
+      return;
     }
 
-    if ((didSessionChange || pendingLatestResetRef.current) && rows.length > 0) {
+    if (pendingLatestResetRef.current && rows.length > 0) {
       pendingLatestResetRef.current = false;
-      const nextRange = latestRange(rows.length);
-      setRange(nextRange);
-      previousFirstVisibleRowKeyRef.current = rows[nextRange.startRow]?.key ?? null;
+      setRange(latestRange(rows.length));
       return;
     }
 
     if (rows.length !== previousRowsLength) {
       if (shouldFollowLatestWindow && previousRange.endRowExclusive === previousRowsLength) {
-        const nextRange = latestRange(rows.length);
-        setRange(nextRange);
-        previousFirstVisibleRowKeyRef.current = rows[nextRange.startRow]?.key ?? null;
+        setRange(latestRange(rows.length));
         return;
       }
 
@@ -323,28 +341,18 @@ export function useAgentChatRowWindow({
             endRowExclusive: Math.min(rows.length, nextFirstVisibleIndex + previousWindowSize),
           };
           setRange(nextRange);
-          previousFirstVisibleRowKeyRef.current = rows[nextRange.startRow]?.key ?? null;
           return;
         }
       }
     }
 
     if (rows.length > 0 && previousRange.startRow >= rows.length) {
-      const nextRange = latestRange(rows.length);
-      setRange(nextRange);
-      previousFirstVisibleRowKeyRef.current = rows[nextRange.startRow]?.key ?? null;
+      setRange(latestRange(rows.length));
       return;
     }
 
     previousFirstVisibleRowKeyRef.current = rows[rangeRef.current.startRow]?.key ?? null;
-  }, [
-    displayedSessionKey,
-    rows,
-    rows.length,
-    setRange,
-    shouldFollowLatestWindow,
-    shouldResetForTranscriptLoad,
-  ]);
+  }, [didSessionChange, rows, rows.length, setRange, shouldFollowLatestWindow]);
 
   useEffect(() => {
     const container = messagesContainerRef.current;

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-transcript-model.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-transcript-model.test.ts
@@ -102,6 +102,48 @@ describe("useAgentChatTranscriptModel", () => {
     await harness.unmount();
   });
 
+  test("schedules a small full cache miss after switching sessions", async () => {
+    const initialSession = buildSession({
+      externalSessionId: "session-small-cache-miss-initial",
+      messages: [buildMessage("assistant", "Initial", { id: "assistant-initial" })],
+    });
+    const switchedSession = buildSession({
+      externalSessionId: "session-small-cache-miss-target",
+      messages: [buildMessage("assistant", "Ready later", { id: "assistant-target" })],
+    });
+    const observedStates: HookResult[] = [];
+    const Probe = (props: HarnessProps) => {
+      observedStates.push(useAgentChatTranscriptModel(props));
+      return null;
+    };
+
+    const rendered = render(
+      createElement(Probe, {
+        session: initialSession,
+        showThinkingMessages: true,
+      }),
+    );
+
+    const observationsBeforeSwitch = observedStates.length;
+    rendered.rerender(
+      createElement(Probe, {
+        session: switchedSession,
+        showThinkingMessages: true,
+      }),
+    );
+
+    expect(observedStates[observationsBeforeSwitch]?.transcriptState.rows).toEqual([]);
+    expect(observedStates[observationsBeforeSwitch]?.isTranscriptModelMissing).toBe(true);
+
+    await flushTranscriptDerivation(
+      () => Boolean(observedStates.at(-1)?.hasCurrentRowsForActiveSession),
+      { timeoutMs: 1_000 },
+    );
+    expect(observedStates.at(-1)?.transcriptState.rows.length).toBeGreaterThan(0);
+
+    rendered.unmount();
+  });
+
   test("discards stale derivation after switching sessions before queued work runs", async () => {
     const firstSession = createLargeSession("session-stale-a");
     const secondSession = createLargeSession("session-stale-b");
@@ -132,16 +174,16 @@ describe("useAgentChatTranscriptModel", () => {
       showThinkingMessages: true,
     });
 
-    await harness.update({
-      session: {
-        ...session,
-        title: "Updated title with the same transcript revision",
-      },
-      showThinkingMessages: true,
-    });
-    await flushTranscriptDerivation(() => harness.getLatest().hasCurrentRowsForActiveSession, {
-      timeoutMs: 1_000,
-    });
+    for (let updateIndex = 0; updateIndex < 5; updateIndex += 1) {
+      await harness.update({
+        session: {
+          ...session,
+          title: `Updated title ${updateIndex}`,
+        },
+        showThinkingMessages: true,
+      });
+      await animationFrameDriver.flushTimers(1);
+    }
 
     expect(harness.getLatest().transcriptState.rows.length).toBeGreaterThan(0);
     expect(harness.getLatest().hasCurrentRowsForActiveSession).toBe(true);
@@ -268,6 +310,9 @@ describe("useAgentChatTranscriptModel", () => {
       }),
       showThinkingMessages: true,
     });
+    await flushTranscriptDerivation(() => harness.getLatest().hasCurrentRowsForActiveSession, {
+      timeoutMs: 1_000,
+    });
 
     const latest = harness.getLatest();
     expect(latest.hasCurrentRowsForActiveSession).toBe(true);
@@ -347,6 +392,9 @@ describe("useAgentChatTranscriptModel", () => {
         ),
       }),
       showThinkingMessages: true,
+    });
+    await flushTranscriptDerivation(() => harness.getLatest().hasCurrentRowsForActiveSession, {
+      timeoutMs: 1_000,
     });
 
     const latest = harness.getLatest();
@@ -493,7 +541,7 @@ describe("useAgentChatTranscriptModel", () => {
     await harness.unmount();
   });
 
-  test("publishes cached rows asynchronously when switching back to an unchanged idle session", async () => {
+  test("shows cached rows on the first render when switching back to an unchanged idle session", async () => {
     const firstMessages = Array.from({ length: 500 }, (_, index) =>
       buildMessage(index % 2 === 0 ? "user" : "assistant", `First ${index + 1}`, {
         id: `first-message-${index + 1}`,
@@ -548,15 +596,82 @@ describe("useAgentChatTranscriptModel", () => {
     );
 
     const firstRenderAfterSwitchBack = observedStates[observationsBeforeSwitchBack];
-    expect(firstRenderAfterSwitchBack?.transcriptState.rows).toEqual([]);
-    expect(firstRenderAfterSwitchBack?.isTranscriptModelMissing).toBe(true);
+    expect(firstRenderAfterSwitchBack?.transcriptState.rows).toBe(cachedRows);
+    expect(firstRenderAfterSwitchBack?.isTranscriptModelMissing).toBe(false);
+
+    rendered.unmount();
+  });
+
+  test("keeps cached rows visible when the restored session changes before derivation runs", async () => {
+    const firstMessages = Array.from({ length: 500 }, (_, index) =>
+      buildMessage(index % 2 === 0 ? "user" : "assistant", `First ${index + 1}`, {
+        id: `first-message-${index + 1}`,
+      }),
+    );
+    const firstSession = buildSession({
+      externalSessionId: "session-cache-revision-a",
+      status: "idle",
+      messages: createSessionMessagesState("session-cache-revision-a", firstMessages, 1),
+    });
+    const secondSession = createLargeSession("session-cache-revision-b");
+    const observedStates: HookResult[] = [];
+    const Probe = (props: HarnessProps) => {
+      observedStates.push(useAgentChatTranscriptModel(props));
+      return null;
+    };
+    const rendered = render(
+      createElement(Probe, { session: firstSession, showThinkingMessages: true }),
+    );
+    await flushTranscriptDerivation(
+      () => Boolean(observedStates.at(-1)?.hasCurrentRowsForActiveSession),
+      { timeoutMs: 1_000 },
+    );
+    const cachedRows = observedStates.at(-1)?.transcriptState.rows;
+
+    rendered.rerender(createElement(Probe, { session: secondSession, showThinkingMessages: true }));
+    await flushTranscriptDerivation(
+      () => Boolean(observedStates.at(-1)?.hasCurrentRowsForActiveSession),
+      { timeoutMs: 1_000 },
+    );
+
+    const restoredSession = buildSession({
+      ...firstSession,
+      messages: createSessionMessagesState("session-cache-revision-a", firstMessages, 1),
+    });
+    rendered.rerender(
+      createElement(Probe, { session: restoredSession, showThinkingMessages: true }),
+    );
+    const revisedSession = buildSession({
+      ...restoredSession,
+      messages: createSessionMessagesState(
+        "session-cache-revision-a",
+        [
+          buildMessage("user", "Changed first message", { id: "first-message-1" }),
+          ...firstMessages.slice(1),
+        ],
+        2,
+      ),
+    });
+    rendered.rerender(
+      createElement(Probe, { session: revisedSession, showThinkingMessages: true }),
+    );
+
+    const firstRevisedRender = observedStates.at(-1);
+    expect(firstRevisedRender?.transcriptState.rows).toBe(cachedRows);
+    expect(firstRevisedRender?.isTranscriptModelMissing).toBe(false);
+    expect(firstRevisedRender?.isTranscriptModelPending).toBe(true);
 
     await flushTranscriptDerivation(
       () => Boolean(observedStates.at(-1)?.hasCurrentRowsForActiveSession),
       { timeoutMs: 1_000 },
     );
-    expect(observedStates.at(-1)?.transcriptState.rows).toBe(cachedRows);
-    expect(observedStates.at(-1)?.isTranscriptModelMissing).toBe(false);
+    expect(
+      observedStates
+        .at(-1)
+        ?.transcriptState.rows.some(
+          (row) => row.kind === "message" && row.message.content === "Changed first message",
+        ),
+    ).toBe(true);
 
     rendered.unmount();
   });

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-transcript-model.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-transcript-model.ts
@@ -1,4 +1,12 @@
-import { startTransition, useEffect, useMemo, useReducer, useRef } from "react";
+import {
+  startTransition,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 import { isAgentSessionActivityWorking } from "@/lib/agent-session-activity-state";
 import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
 import {
@@ -16,8 +24,7 @@ import {
 } from "./agent-chat-transcript-model";
 import {
   createTranscriptModelCache,
-  peekReusableTranscriptModelState,
-  peekTranscriptModelCacheEntry,
+  readTranscriptModelCache,
   type TranscriptModelCache,
   type TranscriptModelCacheEntry,
   writeTranscriptModelCacheEntry,
@@ -67,12 +74,16 @@ const EMPTY_TRANSCRIPT_MODEL_STATE: TranscriptModelState = Object.freeze({
 const buildTranscriptModelRevision = (
   session: AgentChatTranscriptSession | null,
   showThinkingMessages: boolean,
+  messages: AgentChatTranscriptSession["messages"] | null = session?.messages ?? null,
 ): TranscriptModelRevision => {
-  if (!session) {
+  if (!session || !messages) {
     return EMPTY_TRANSCRIPT_MODEL_REVISION;
   }
 
-  const messagesRevision = getSessionMessagesRevision(session);
+  const messagesRevision = getSessionMessagesRevision({
+    externalSessionId: session.externalSessionId,
+    messages,
+  });
   const sessionKey = agentSessionIdentityKey(session);
 
   return {
@@ -114,15 +125,15 @@ const toTranscriptModelState = ({
   };
 };
 
-const buildImmediateTranscriptModelState = ({
-  session,
-  showThinkingMessages,
-  cache,
-}: {
-  session: AgentChatTranscriptSession;
-  showThinkingMessages: boolean;
-  cache: TranscriptModelCache;
-}): TranscriptModelState => {
+const createInitialTranscriptModelCache = (
+  session: AgentChatTranscriptSession | null,
+  showThinkingMessages: boolean,
+): TranscriptModelCache => {
+  const cache = createTranscriptModelCache();
+  if (!session || getSessionMessageCount(session) > TRANSCRIPT_DERIVATION_SYNC_MESSAGE_LIMIT) {
+    return cache;
+  }
+
   const transcriptModel = createAgentChatTranscriptModelBuilder(session, {
     showThinkingMessages,
   }).complete();
@@ -132,37 +143,7 @@ const buildImmediateTranscriptModelState = ({
     transcriptModel,
     cache,
   });
-
-  return toTranscriptModelState({
-    session,
-    revision: buildTranscriptModelRevision(session, showThinkingMessages),
-    transcriptModel,
-  });
-};
-
-const areTranscriptModelRevisionsEqual = (
-  left: TranscriptModelRevision,
-  right: TranscriptModelRevision,
-): boolean => {
-  return (
-    left.sessionKey === right.sessionKey &&
-    left.activityState === right.activityState &&
-    left.showThinkingMessages === right.showThinkingMessages &&
-    left.messagesSessionKey === right.messagesSessionKey &&
-    left.version === right.version &&
-    left.count === right.count
-  );
-};
-
-const toTranscriptModelRevisionKey = (revision: TranscriptModelRevision): string => {
-  return [
-    revision.sessionKey ?? "",
-    revision.activityState ?? "",
-    revision.showThinkingMessages ? "thinking:on" : "thinking:off",
-    revision.messagesSessionKey ?? "",
-    revision.version ?? "",
-    revision.count ?? "",
-  ].join("\u001f");
+  return cache;
 };
 
 const now = (): number => {
@@ -286,96 +267,70 @@ export const useAgentChatTranscriptModel = ({
   isTranscriptModelMissing: boolean;
   isTranscriptModelPending: boolean;
 } => {
-  const rowsCacheRef = useRef<TranscriptModelCache | null>(null);
-  if (rowsCacheRef.current === null) {
-    rowsCacheRef.current = createTranscriptModelCache();
-  }
-  const rowsCache = rowsCacheRef.current;
+  const [rowsCache] = useState(() =>
+    createInitialTranscriptModelCache(session, showThinkingMessages),
+  );
+  const derivationSessionRef = useRef(session);
   const derivationTokenRef = useRef(0);
   const activeRevision = useMemo(
     () => buildTranscriptModelRevision(session, showThinkingMessages),
     [session, showThinkingMessages],
   );
-  const activeRevisionKey = useMemo(
-    () => toTranscriptModelRevisionKey(activeRevision),
-    [activeRevision],
-  );
-  const [resolvedTranscriptState, dispatchResolvedTranscriptState] = useReducer(
-    (_current: TranscriptModelState, next: TranscriptModelState) => next,
-    undefined,
-    () => {
-      if (!session || getSessionMessageCount(session) > TRANSCRIPT_DERIVATION_SYNC_MESSAGE_LIMIT) {
-        return EMPTY_TRANSCRIPT_MODEL_STATE;
-      }
-
-      return buildImmediateTranscriptModelState({
-        session,
-        showThinkingMessages,
-        cache: rowsCache,
-      });
-    },
-  );
-  const activeSessionRef = useRef(session);
-  const activeRevisionRef = useRef(activeRevision);
-  const resolvedTranscriptStateRef = useRef(resolvedTranscriptState);
-  activeSessionRef.current = session;
-  activeRevisionRef.current = activeRevision;
-  resolvedTranscriptStateRef.current = resolvedTranscriptState;
-  const displayedTranscriptState = resolvedTranscriptState;
-  const hasRowsForActiveSession = Boolean(
-    session &&
-      displayedTranscriptState.revision.sessionKey === agentSessionIdentityKey(session) &&
-      displayedTranscriptState.revision.showThinkingMessages === showThinkingMessages,
-  );
-  const hasCurrentRowsForActiveSession = Boolean(
-    session && areTranscriptModelRevisionsEqual(displayedTranscriptState.revision, activeRevision),
-  );
+  const derivationRevisionKey = JSON.stringify([
+    activeRevision.sessionKey,
+    activeRevision.messagesSessionKey,
+    activeRevision.version,
+    activeRevision.count,
+  ]);
+  const [, publishCacheWrite] = useReducer((generation: number) => generation + 1, 0);
+  const cacheLookup = session
+    ? readTranscriptModelCache({ session, showThinkingMessages, cache: rowsCache })
+    : { current: null, latest: null };
+  const displayedTranscriptModel = cacheLookup.current ?? cacheLookup.latest;
+  let displayedTranscriptState = EMPTY_TRANSCRIPT_MODEL_STATE;
+  if (session && displayedTranscriptModel) {
+    displayedTranscriptState = toTranscriptModelState({
+      session,
+      revision: cacheLookup.current
+        ? activeRevision
+        : buildTranscriptModelRevision(
+            session,
+            showThinkingMessages,
+            displayedTranscriptModel.messages,
+          ),
+      transcriptModel: displayedTranscriptModel,
+    });
+  }
+  const hasRowsForActiveSession = displayedTranscriptModel !== null;
+  const hasCurrentRowsForActiveSession = cacheLookup.current !== null;
   const isTranscriptModelMissing = Boolean(session && !hasRowsForActiveSession);
   const isTranscriptModelPending = Boolean(session && !hasCurrentRowsForActiveSession);
 
+  useLayoutEffect(() => {
+    derivationSessionRef.current = session;
+  }, [session]);
+
   useEffect(() => {
-    // activeRevisionKey intentionally triggers this effect; async work reads refs below.
-    void activeRevisionKey;
+    void derivationRevisionKey;
     derivationTokenRef.current += 1;
     const derivationToken = derivationTokenRef.current;
-    const currentSession = activeSessionRef.current;
-    const currentRevision = activeRevisionRef.current;
+    const currentSession = derivationSessionRef.current;
 
     if (!currentSession) {
-      dispatchResolvedTranscriptState(EMPTY_TRANSCRIPT_MODEL_STATE);
       return;
     }
 
-    if (
-      areTranscriptModelRevisionsEqual(resolvedTranscriptStateRef.current.revision, currentRevision)
-    ) {
-      return;
-    }
-
-    const reusableTranscriptModel = peekReusableTranscriptModelState({
+    const currentCacheLookup = readTranscriptModelCache({
       session: currentSession,
       showThinkingMessages,
       cache: rowsCache,
+      touchCurrent: true,
     });
-    if (reusableTranscriptModel) {
-      const nextTranscriptState = toTranscriptModelState({
-        session: currentSession,
-        revision: currentRevision,
-        transcriptModel: reusableTranscriptModel,
-      });
-      startTransition(() => {
-        if (derivationTokenRef.current === derivationToken) {
-          dispatchResolvedTranscriptState(nextTranscriptState);
-        }
-      });
+    if (currentCacheLookup.current) {
       return;
     }
 
-    const previousCacheEntry = peekTranscriptModelCacheEntry({
-      session: currentSession,
-      showThinkingMessages,
-      cache: rowsCache,
-    });
+    const previousCacheEntry = currentCacheLookup.latest;
     const incrementalPlan = getIncrementalTranscriptModelPlan({
       previousCacheEntry,
       currentSession,
@@ -398,37 +353,15 @@ export const useAgentChatTranscriptModel = ({
         if (derivationTokenRef.current === derivationToken) {
           // Bounded incremental derivation intentionally publishes current selected rows immediately
           // so large running sessions stay responsive as new tail messages stream in.
-          dispatchResolvedTranscriptState(
-            toTranscriptModelState({
-              session: currentSession,
-              revision: currentRevision,
-              transcriptModel,
-            }),
-          );
+          publishCacheWrite();
         }
         return;
       }
     }
 
-    const builder = createAgentChatTranscriptModelBuilder(currentSession, { showThinkingMessages });
-    if (getSessionMessageCount(currentSession) <= TRANSCRIPT_DERIVATION_SYNC_MESSAGE_LIMIT) {
-      const transcriptModel = builder.complete();
-      writeTranscriptModelCacheEntry({
-        session: currentSession,
-        showThinkingMessages,
-        transcriptModel,
-        cache: rowsCache,
-      });
-      dispatchResolvedTranscriptState(
-        toTranscriptModelState({
-          session: currentSession,
-          revision: currentRevision,
-          transcriptModel,
-        }),
-      );
-      return;
-    }
-
+    const builder = createAgentChatTranscriptModelBuilder(currentSession, {
+      showThinkingMessages,
+    });
     let scheduledWorkId: ReturnType<typeof globalThis.setTimeout> | null = null;
     const scheduleNextChunk = (): void => {
       scheduledWorkId = globalThis.setTimeout(() => {
@@ -463,14 +396,9 @@ export const useAgentChatTranscriptModel = ({
           transcriptModel,
           cache: rowsCache,
         });
-        const nextTranscriptState = toTranscriptModelState({
-          session: currentSession,
-          revision: currentRevision,
-          transcriptModel,
-        });
         startTransition(() => {
           if (derivationTokenRef.current === derivationToken) {
-            dispatchResolvedTranscriptState(nextTranscriptState);
+            publishCacheWrite();
           }
         });
       }, 0);
@@ -483,7 +411,7 @@ export const useAgentChatTranscriptModel = ({
         globalThis.clearTimeout(scheduledWorkId);
       }
     };
-  }, [activeRevisionKey, rowsCache, showThinkingMessages]);
+  }, [derivationRevisionKey, rowsCache, showThinkingMessages]);
 
   const transcriptState = useMemo(() => {
     if (!hasRowsForActiveSession) {

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
@@ -1911,6 +1911,47 @@ describe("useAgentChatWindow", () => {
     await harness.unmount();
   });
 
+  test("switching large sessions exposes the next latest row window on its first render", async () => {
+    const firstSessionRows = createTurnRows(50, "session-1");
+    const secondSessionRows = createTurnRows(60, "session-2");
+    const observedResults: HookResult[] = [];
+    const messagesContainerRef = createRef<HTMLDivElement>();
+    const messagesContentRef = createRef<HTMLDivElement>();
+    const harness = createSharedHookHarness(
+      (props: HarnessProps) => {
+        const result = useAgentChatWindow({
+          ...props,
+          turnAnchors: props.turnAnchors ?? buildAgentChatTurnAnchors(props.rows),
+          messagesContainerRef,
+          messagesContentRef,
+        });
+        observedResults.push(result);
+        return result;
+      },
+      {
+        rows: firstSessionRows,
+        displayedSessionKey: "session-1",
+        shouldResetForTranscriptLoad: false,
+      },
+    );
+    await harness.mount();
+    await harness.run((result) => result.scrollToTop());
+    const observationsBeforeSwitch = observedResults.length;
+
+    await harness.update({
+      rows: secondSessionRows,
+      displayedSessionKey: "session-2",
+      shouldResetForTranscriptLoad: false,
+    });
+
+    const firstSwitchedRender = observedResults[observationsBeforeSwitch];
+    const expectedStart = secondSessionRows.length - AGENT_CHAT_ROW_WINDOW_SIZE;
+    expect(firstSwitchedRender?.windowStart).toBe(expectedStart);
+    expect(firstSwitchedRender?.visibleRows[0]).toBe(secondSessionRows[expectedStart]);
+
+    await harness.unmount();
+  });
+
   test("switching sessions clears manual scroll state so late-rendered content stays pinned", async () => {
     const firstSessionRows = createTurnRows(12, "session-1");
     const secondSessionRows = createTurnRows(12, "session-2");


### PR DESCRIPTION
## Summary
- render cached transcript rows on the first session-switch render
- keep stale same-session rows visible while a newer revision derives
- reset row windows by displayed session so switched transcripts open at their latest rows

## Goal
Switching back to a cached agent transcript briefly showed a loading notice and empty rows because rendering waited for an animation-frame gate and then republished cached data asynchronously. Large session switches could also reuse the previous session's row-window range for one render. This PR removes that visible flicker while preserving non-blocking derivation for true cache misses.

## Implementation
- make the transcript model cache the source of resolved rows, with one read returning both the current revision and the latest same-session entry
- seed bounded first-mount transcripts synchronously, but schedule full post-mount cache misses in chunks
- preserve cached rows for a stale revision until current rows are ready, and key derivation by transcript revision so unrelated session updates cannot starve queued work
- keep streaming metadata activity-neutral in cached models and filter it at presentation time
- remove the unconditional requestAnimationFrame session-switch gate
- key row-window state by displayed session and derive the latest range during the first switched render
- add regression coverage for cached restoration, stale-row retention, small asynchronous cache misses, repeated same-revision updates, and first-render latest windows

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test` (4,110 tests passed)
- `bun run build`
- React Doctor: 100/100
- Cargo checks: not applicable; the repository has no `Cargo.toml`

Existing non-failing React test warnings, one host unused-import lint warning, and build chunk-size warnings remain outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Switching between agent chat sessions now displays cached transcript content immediately, without an unnecessary loading overlay or stale rows.
  - Large transcripts retain the correct visible row range during session changes.
  - Streaming assistant metadata remains accurate across idle and resumed sessions.
  - Transcript updates now render reliably when rows or revisions change.

- **Tests**
  - Expanded coverage for transcript caching, session switching, streaming state, asynchronous rendering, and large transcript windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->