### PR TITLE
fix(electron): use valid Windows prerelease version

### DIFF
--- a/apps/electron/scripts/package-build.test.ts
+++ b/apps/electron/scripts/package-build.test.ts
@@ -44,7 +44,7 @@ describe("build Electron release artifact", () => {
       "-c.publish.channel=beta",
       "-c.extraMetadata.version=0.4.0-beta.2",
       "-c.extraMetadata.shortVersion=0.4.0",
-      "-c.extraMetadata.shortVersionWindows=0.4.0",
+      "-c.extraMetadata.shortVersionWindows=0.4.0.0",
       "-c.mac.bundleShortVersion=0.4.0",
       "-c.mac.bundleVersion=0.4.0",
     ]);

--- a/apps/electron/scripts/package-build.ts
+++ b/apps/electron/scripts/package-build.ts
@@ -131,7 +131,7 @@ export const resolveElectronBuilderArgs = ({
     args.push(
       `-c.extraMetadata.version=${releaseMetadata.releaseVersion}`,
       `-c.extraMetadata.shortVersion=${releaseMetadata.desktopVersion}`,
-      `-c.extraMetadata.shortVersionWindows=${releaseMetadata.desktopVersion}`,
+      `-c.extraMetadata.shortVersionWindows=${releaseMetadata.desktopVersion}.0`,
       `-c.mac.bundleShortVersion=${releaseMetadata.desktopVersion}`,
       `-c.mac.bundleVersion=${releaseMetadata.desktopVersion}`,
     );


### PR DESCRIPTION
## Summary

Use a four-part numeric Windows system version for Electron prerelease packages.

## Goal

The `v0.6.0-beta.1` Windows release job failed when NSIS built the installer. The prerelease path set `shortVersionWindows` to `0.6.0`, but NSIS requires `VIProductVersion` in `X.X.X.X` form. Stable releases work because Electron Builder derives `0.5.3.0` from a stable version when no override is present.

This change makes prerelease packaging follow the same Windows version shape, so a release such as `0.6.0-beta.1` uses `0.6.0.0` for Windows system metadata while it keeps the full prerelease version for the packaged app and beta updater channel.

## Implementation

- Append `.0` to the numeric desktop version used for `extraMetadata.shortVersionWindows`.
- Keep `extraMetadata.version`, the general short version, macOS bundle versions, and updater channel behavior unchanged.
- Update the existing prerelease argument assertion to match the four-part Windows value.

## Verification

- `bun install --frozen-lockfile`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`

Cargo checks are not applicable because this Repository has no Cargo workspace or Rust source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Windows desktop package version metadata to use the required four-component format, improving compatibility with Windows packaging requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->