### PR TITLE
fix(frontend): stop blocking git actions while the builder works

### DIFF
--- a/packages/frontend/src/features/agent-studio-build-tools/use-agent-studio-build-tools-worktree-snapshot.test.tsx
+++ b/packages/frontend/src/features/agent-studio-build-tools/use-agent-studio-build-tools-worktree-snapshot.test.tsx
@@ -446,7 +446,6 @@ describe("useAgentStudioBuildToolsWorktreeSnapshot", () => {
 
       expect(taskWorktreeGetMock).not.toHaveBeenCalled();
       expect(harness.getLatest().context).toMatchObject({
-        isSelectedBuilderWorking: true,
         sessionWorkingDirectory: "/repo/.worktrees/task-24",
       });
       expect(harness.getLatest().gitPanelContextMode).toBe("worktree");

--- a/packages/frontend/src/features/agent-studio-build-tools/use-agent-studio-build-tools-worktree-snapshot.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/use-agent-studio-build-tools-worktree-snapshot.ts
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
-import { isAgentSessionActivityWorking } from "@/lib/agent-session-activity-state";
 import { hostClient } from "@/lib/host-client";
 import { resolveTaskTargetBranchState, UPSTREAM_TARGET_BRANCH } from "@/lib/target-branch";
 import {
@@ -63,7 +62,6 @@ export type AgentStudioBuildToolsWorktreeSnapshot = {
     taskId: string | null;
     selectedTaskId: string | null;
     viewRole: BuildToolsSelectedView["role"];
-    isSelectedBuilderWorking: boolean;
     sessionWorkingDirectory: string | null;
     hasSelectedTask: boolean;
   };
@@ -315,9 +313,6 @@ function useAgentStudioBuildToolsWorktreeSnapshotWithDependencies(
         taskId,
         selectedTaskId,
         viewRole: selectedView.role,
-        isSelectedBuilderWorking:
-          selectedView.role === "build" &&
-          isAgentSessionActivityWorking(selectedView.selectedSession.activityState),
         sessionWorkingDirectory: buildToolsBootstrap.sessionWorkingDirectory,
         hasSelectedTask,
       },
@@ -342,7 +337,6 @@ function useAgentStudioBuildToolsWorktreeSnapshotWithDependencies(
       resolvedGitPanelBranch,
       selectedTaskId,
       selectedView.role,
-      selectedView.selectedSession.activityState,
       taskTargetBranchState,
       taskId,
       worktree,

--- a/packages/frontend/src/pages/agents/right-panel/use-agents-page-right-panel-model.hook.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agents-page-right-panel-model.hook.test.tsx
@@ -21,7 +21,6 @@ type BuildToolsSnapshotModule =
   typeof import("@/features/agent-studio-build-tools/use-agent-studio-build-tools-worktree-snapshot");
 type GitActionsModule = typeof import("../use-agent-studio-git-actions");
 type PullRequestReviewQueriesModule = typeof import("@/state/queries/pull-request-review");
-type GitActionsArgs = Parameters<GitActionsModule["useAgentStudioGitActions"]>[0];
 type HookArgs = Parameters<UseAgentsPageRightPanelModel>[0];
 
 let useAgentsPageRightPanelModel: UseAgentsPageRightPanelModel;
@@ -57,7 +56,6 @@ const createSnapshot = (gitConflictId: string | null) => ({
     taskId: "task-1",
     selectedTaskId: "task-1",
     viewRole: "build",
-    isSelectedBuilderWorking: true,
     sessionWorkingDirectory: "/repo",
     hasSelectedTask: true,
   },
@@ -335,69 +333,6 @@ describe("useAgentsPageRightPanelModel", () => {
     await harness.unmount();
 
     expect(events).toEqual(["A", "B", null]);
-  });
-
-  test("does not lock git actions for a builder session waiting for input", async () => {
-    const waitingInputSnapshot = createSnapshot("A");
-    buildToolsSnapshotState.current = {
-      ...waitingInputSnapshot,
-      context: {
-        ...waitingInputSnapshot.context,
-        isSelectedBuilderWorking: false,
-      },
-    };
-    const harness = createHookHarness(
-      useAgentsPageRightPanelModel,
-      createHookArgs({
-        selectedView: createSelectedView({
-          loadedSession: createAgentSessionFixture({
-            role: "build",
-            status: "running",
-            workingDirectory: "/repo",
-            pendingQuestions: [{ requestId: "question-1", questions: [] }],
-          }),
-        }),
-        activeTabId: "git",
-        isPanelOpen: true,
-      }),
-    );
-
-    await harness.mount();
-
-    const gitActionCalls = gitActionsMock.mock.calls as unknown as Array<[GitActionsArgs]>;
-    const latestGitActionArgs = gitActionCalls.at(-1)?.[0];
-    expect(latestGitActionArgs?.isBuilderSessionWorking).toBe(false);
-
-    await harness.unmount();
-  });
-
-  test("locks git actions from selected-session summary while the full session is loading", async () => {
-    const selectedSessionSummary = toAgentSessionSummary(
-      createAgentSessionFixture({
-        role: "build",
-        status: "running",
-        workingDirectory: "/repo/.worktrees/task-1",
-      }),
-    );
-    const harness = createHookHarness(
-      useAgentsPageRightPanelModel,
-      createHookArgs({
-        selectedView: createSelectedView({
-          loadedSession: null,
-          selectedSessionSummary,
-        }),
-        activeTabId: "git",
-        isPanelOpen: true,
-      }),
-    );
-
-    await harness.mount();
-
-    const gitActionCalls = gitActionsMock.mock.calls as unknown as Array<[GitActionsArgs]>;
-    const latestGitActionArgs = gitActionCalls.at(-1)?.[0];
-    expect(latestGitActionArgs?.isBuilderSessionWorking).toBe(true);
-
-    await harness.unmount();
   });
 
   test("prefetches CI review data in the background for linked pull requests", async () => {

--- a/packages/frontend/src/pages/agents/right-panel/use-agents-page-right-panel-model.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agents-page-right-panel-model.ts
@@ -291,7 +291,6 @@ export function useAgentsPageRightPanelModel({
     worktreeStatusSnapshotKey: diffData.statusSnapshotKey ?? null,
     refreshDiffData: diffData.refresh,
     isDiffDataLoading: diffData.isLoading,
-    isBuilderSessionWorking: buildToolsSnapshot.context.isSelectedBuilderWorking,
     ...(onResolveGitConflict ? { onResolveGitConflict } : {}),
   });
   const gitConflictQuickActionContext = useMemo<AgentStudioGitConflictQuickActionContext | null>(

--- a/packages/frontend/src/pages/agents/use-agent-studio-git-action-utils.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-git-action-utils.ts
@@ -1,31 +1,11 @@
-import type {
-  GitConflict,
-  GitConflictOperation,
-  GitDiffRefresh,
-} from "@/features/agent-studio-git";
+import type { GitConflictOperation, GitDiffRefresh } from "@/features/agent-studio-git";
 import { getGitConflictCopy } from "@/features/git-conflict-resolution";
 
 export type GitActionKind = "commit" | "push" | "rebase";
 
 export type RefreshGitDiffData = GitDiffRefresh;
 
-export const BUILDER_LOCK_REASON = "Git actions are disabled while the Builder session is working.";
 export const CONFLICT_LOCK_REASON = "Git actions are disabled while git conflicts are unresolved.";
-
-export const getGitActionsLockReason = (
-  isBuilderSessionWorking: boolean,
-  activeGitConflict: GitConflict | null,
-): string | null => {
-  if (isBuilderSessionWorking) {
-    return BUILDER_LOCK_REASON;
-  }
-
-  if (activeGitConflict) {
-    return CONFLICT_LOCK_REASON;
-  }
-
-  return null;
-};
 
 export const toErrorMessage = (error: unknown, fallback: string): string => {
   if (error instanceof Error && error.message.trim().length > 0) {

--- a/packages/frontend/src/pages/agents/use-agent-studio-git-actions.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-git-actions.test.tsx
@@ -736,26 +736,6 @@ describe("useAgentStudioGitActions", () => {
     }
   });
 
-  test("suppresses the lock banner when git actions are locked only because Builder is working", async () => {
-    const harness = createHookHarness(
-      createBaseArgs({
-        isBuilderSessionWorking: true,
-      }),
-    );
-
-    try {
-      await harness.mount();
-
-      expect(harness.getLatest().isGitActionsLocked).toBe(true);
-      expect(harness.getLatest().gitActionsLockReason).toBe(
-        "Git actions are disabled while the Builder session is working.",
-      );
-      expect(harness.getLatest().showLockReasonBanner).toBe(false);
-    } finally {
-      await harness.unmount();
-    }
-  });
-
   test("does not request a lock banner when git actions are unlocked", async () => {
     const harness = createHookHarness(createBaseArgs());
 

--- a/packages/frontend/src/pages/agents/use-agent-studio-git-actions.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-git-actions.ts
@@ -9,7 +9,7 @@ import type {
   GitDiffRefresh,
 } from "@/features/agent-studio-git";
 import { useAgentStudioGitActionErrors } from "./use-agent-studio-git-action-errors";
-import { BUILDER_LOCK_REASON, type GitActionKind } from "./use-agent-studio-git-action-utils";
+import { CONFLICT_LOCK_REASON, type GitActionKind } from "./use-agent-studio-git-action-utils";
 import { useAgentStudioGitCommitActions } from "./use-agent-studio-git-commit-actions";
 import { useAgentStudioGitConflictController } from "./use-agent-studio-git-conflict-controller";
 import { useAgentStudioGitPushActions } from "./use-agent-studio-git-push-actions";
@@ -68,7 +68,6 @@ type UseAgentStudioGitActionsInput = {
   worktreeStatusSnapshotKey?: string | null;
   refreshDiffData: GitDiffRefresh;
   isDiffDataLoading?: boolean;
-  isBuilderSessionWorking?: boolean;
   onResolveGitConflict?: (conflict: GitConflict) => Promise<boolean>;
 };
 
@@ -86,7 +85,6 @@ export function useAgentStudioGitActions({
   worktreeStatusSnapshotKey = null,
   refreshDiffData,
   isDiffDataLoading = false,
-  isBuilderSessionWorking = false,
   onResolveGitConflict,
 }: UseAgentStudioGitActionsInput): AgentStudioGitActionState {
   const {
@@ -120,7 +118,6 @@ export function useAgentStudioGitActions({
     detectedConflict,
     detectedConflictedFiles,
     worktreeStatusSnapshotKey,
-    isBuilderSessionWorking,
     refreshDiffData,
     clearActionErrors,
     setRebaseError,
@@ -133,7 +130,7 @@ export function useAgentStudioGitActions({
         return true;
       }
 
-      const lockReason = gitActionsLockReason ?? BUILDER_LOCK_REASON;
+      const lockReason = gitActionsLockReason ?? CONFLICT_LOCK_REASON;
 
       if (kind === "commit") {
         setCommitError(lockReason);
@@ -165,7 +162,6 @@ export function useAgentStudioGitActions({
     diffHash,
     worktreeStatusSnapshotKey,
     isDiffDataLoading,
-    isBuilderSessionWorking,
     activeGitConflict,
     refreshDiffData,
     clearActionErrors,

--- a/packages/frontend/src/pages/agents/use-agent-studio-git-conflict-controller.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-git-conflict-controller.test.tsx
@@ -28,7 +28,6 @@ const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => ({
   branch: "feature/task-10",
   detectedConflictedFiles: [],
   worktreeStatusSnapshotKey: null,
-  isBuilderSessionWorking: false,
   refreshDiffData: async () => {},
   clearActionErrors: () => {},
   setRebaseError: () => {},

--- a/packages/frontend/src/pages/agents/use-agent-studio-git-conflict-controller.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-git-conflict-controller.ts
@@ -4,7 +4,7 @@ import type { GitConflict, GitConflictAction } from "@/features/agent-studio-git
 import { getGitConflictCopy } from "@/features/git-conflict-resolution";
 import { host } from "@/state/operations/shared/host";
 import {
-  getGitActionsLockReason,
+  CONFLICT_LOCK_REASON,
   type RefreshGitDiffData,
   toErrorMessage,
 } from "./use-agent-studio-git-action-utils";
@@ -57,7 +57,6 @@ type UseAgentStudioGitConflictControllerArgs = {
   detectedConflict?: GitConflict | null;
   detectedConflictedFiles: string[];
   worktreeStatusSnapshotKey: string | null;
-  isBuilderSessionWorking: boolean;
   refreshDiffData: RefreshGitDiffData;
   clearActionErrors: () => void;
   setRebaseError: (message: string | null) => void;
@@ -166,7 +165,6 @@ export function useAgentStudioGitConflictController({
   detectedConflict = null,
   detectedConflictedFiles,
   worktreeStatusSnapshotKey,
-  isBuilderSessionWorking,
   refreshDiffData,
   clearActionErrors,
   setRebaseError,
@@ -193,9 +191,9 @@ export function useAgentStudioGitConflictController({
   const effectiveDetectedConflict = detectedConflict ?? fallbackDetectedConflict;
 
   const activeGitConflict = state.localConflict ?? effectiveDetectedConflict;
-  const isGitActionsLocked = isBuilderSessionWorking || activeGitConflict != null;
-  const gitActionsLockReason = getGitActionsLockReason(isBuilderSessionWorking, activeGitConflict);
-  const showLockReasonBanner = isGitActionsLocked && !isBuilderSessionWorking;
+  const isGitActionsLocked = activeGitConflict != null;
+  const gitActionsLockReason = activeGitConflict != null ? CONFLICT_LOCK_REASON : null;
+  const showLockReasonBanner = isGitActionsLocked;
 
   useEffect(() => {
     if (

--- a/packages/frontend/src/pages/agents/use-agent-studio-git-reset-actions.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-git-reset-actions.ts
@@ -4,7 +4,6 @@ import { toast } from "sonner";
 import type { AgentStudioPendingReset, GitConflict } from "@/features/agent-studio-git";
 import { host } from "@/state/operations/shared/host";
 import {
-  BUILDER_LOCK_REASON,
   CONFLICT_LOCK_REASON,
   type RefreshGitDiffData,
   toErrorMessage,
@@ -19,7 +18,6 @@ type UseAgentStudioGitResetActionsArgs = {
   diffHash: string | null;
   worktreeStatusSnapshotKey: string | null;
   isDiffDataLoading: boolean;
-  isBuilderSessionWorking: boolean;
   activeGitConflict: GitConflict | null;
   refreshDiffData: RefreshGitDiffData;
   clearActionErrors: () => void;
@@ -35,7 +33,6 @@ export function useAgentStudioGitResetActions({
   diffHash,
   worktreeStatusSnapshotKey,
   isDiffDataLoading,
-  isBuilderSessionWorking,
   activeGitConflict,
   refreshDiffData,
   clearActionErrors,
@@ -61,10 +58,6 @@ export function useAgentStudioGitResetActions({
   }
 
   const getResetBlockedReason = useCallback((): string | null => {
-    if (isBuilderSessionWorking) {
-      return BUILDER_LOCK_REASON;
-    }
-
     if (activeGitConflict != null) {
       return CONFLICT_LOCK_REASON;
     }
@@ -78,7 +71,7 @@ export function useAgentStudioGitResetActions({
     }
 
     return null;
-  }, [activeGitConflict, isBuilderSessionWorking, isDiffDataLoading, isResetting]);
+  }, [activeGitConflict, isDiffDataLoading, isResetting]);
 
   const resetDisabledReason = useMemo((): string | null => {
     if (!repoPath) {


### PR DESCRIPTION
## Problem
The git panel disabled commit, push, rebase, and reset whenever a Builder session was running, showing "Git actions are disabled while the Builder session is working."

This lock is annoying and unnecessary: the git actions do not race with the Builder in a way that needs guarding, and it forced users to wait through the Builder run before they could touch git.

## Goal
Let users run git actions freely while a session is in progress. Git actions are now only blocked by unresolved git conflicts, which is the one case that genuinely needs guarding.

## Changes
- Drop the `isBuilderSessionWorking` flag from the conflict controller, git-actions, and reset-actions hooks, and stop deriving `isSelectedBuilderWorking` in the build-tools worktree snapshot.
- `isGitActionsLocked` is now driven solely by `activeGitConflict`, and the lock reason is the conflict message.
- Remove the now-single-caller `getGitActionsLockReason` helper and inline the conflict check.
- Update the affected tests to the new conflict-only locking behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Git actions and reset operations are no longer blocked solely while a Builder session is working.
  - Conflict-related locking and messaging now depend on active Git conflicts, loading states, and in-progress resets.
  - Removed outdated Builder-session locking behavior from the interface.

- **Tests**
  - Updated test coverage to reflect the revised Git action and session-locking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->