### PR TITLE
fix(prompts): make pull request kickoff task-focused and provider-safe

### DIFF
--- a/packages/contracts/src/prompt-schemas.test.ts
+++ b/packages/contracts/src/prompt-schemas.test.ts
@@ -55,4 +55,14 @@ describe("prompt placeholder validation", () => {
     expect(result.unsupportedPlaceholders).toEqual([]);
     expect(result.missingRequiredPlaceholders).toEqual(["git.targetBranch"]);
   });
+
+  test("accepts the target placeholder for pull request kickoff overrides", () => {
+    const result = validatePromptTemplatePlaceholders(
+      "Publish against {{git.targetBranch}}.",
+      "kickoff.build_pull_request_generation",
+    );
+
+    expect(result.unsupportedPlaceholders).toEqual([]);
+    expect(result.missingRequiredPlaceholders).toEqual([]);
+  });
 });

--- a/packages/contracts/src/prompt-schemas.test.ts
+++ b/packages/contracts/src/prompt-schemas.test.ts
@@ -46,13 +46,13 @@ describe("prompt placeholder validation", () => {
     expect(result.missingRequiredPlaceholders).toEqual(["humanFeedback"]);
   });
 
-  test("requires comparison and provider base placeholders for pull request kickoff overrides", () => {
+  test("requires one target placeholder for pull request kickoff overrides", () => {
     const result = validatePromptTemplatePlaceholders(
-      "Compare {{git.targetBranch}} before publishing.",
+      "Publish the current branch.",
       "kickoff.build_pull_request_generation",
     );
 
     expect(result.unsupportedPlaceholders).toEqual([]);
-    expect(result.missingRequiredPlaceholders).toEqual(["git.pullRequestBaseBranch"]);
+    expect(result.missingRequiredPlaceholders).toEqual(["git.targetBranch"]);
   });
 });

--- a/packages/contracts/src/prompt-schemas.test.ts
+++ b/packages/contracts/src/prompt-schemas.test.ts
@@ -45,4 +45,14 @@ describe("prompt placeholder validation", () => {
     expect(result.unsupportedPlaceholders).toEqual([]);
     expect(result.missingRequiredPlaceholders).toEqual(["humanFeedback"]);
   });
+
+  test("requires comparison and provider base placeholders for pull request kickoff overrides", () => {
+    const result = validatePromptTemplatePlaceholders(
+      "Compare {{git.targetBranch}} before publishing.",
+      "kickoff.build_pull_request_generation",
+    );
+
+    expect(result.unsupportedPlaceholders).toEqual([]);
+    expect(result.missingRequiredPlaceholders).toEqual(["git.pullRequestBaseBranch"]);
+  });
 });

--- a/packages/contracts/src/prompt-schemas.ts
+++ b/packages/contracts/src/prompt-schemas.ts
@@ -36,7 +36,6 @@ export const agentPromptPlaceholderValues = [
   "git.operationLabel",
   "git.currentBranch",
   "git.targetBranch",
-  "git.pullRequestBaseBranch",
   "git.conflictedFiles",
   "git.conflictOutput",
 ] as const;
@@ -48,7 +47,7 @@ const REQUIRED_PLACEHOLDERS_BY_TEMPLATE: Partial<
   Record<AgentPromptTemplateId, AgentPromptPlaceholder[]>
 > = {
   "kickoff.build_after_human_request_changes": ["humanFeedback"],
-  "kickoff.build_pull_request_generation": ["git.targetBranch", "git.pullRequestBaseBranch"],
+  "kickoff.build_pull_request_generation": ["git.targetBranch"],
 };
 
 const PLACEHOLDER_PATTERN = /{{\s*([a-zA-Z0-9_.-]+)\s*}}/g;

--- a/packages/contracts/src/prompt-schemas.ts
+++ b/packages/contracts/src/prompt-schemas.ts
@@ -36,6 +36,7 @@ export const agentPromptPlaceholderValues = [
   "git.operationLabel",
   "git.currentBranch",
   "git.targetBranch",
+  "git.pullRequestBaseBranch",
   "git.conflictedFiles",
   "git.conflictOutput",
 ] as const;
@@ -47,6 +48,7 @@ const REQUIRED_PLACEHOLDERS_BY_TEMPLATE: Partial<
   Record<AgentPromptTemplateId, AgentPromptPlaceholder[]>
 > = {
   "kickoff.build_after_human_request_changes": ["humanFeedback"],
+  "kickoff.build_pull_request_generation": ["git.targetBranch", "git.pullRequestBaseBranch"],
 };
 
 const PLACEHOLDER_PATTERN = /{{\s*([a-zA-Z0-9_.-]+)\s*}}/g;

--- a/packages/core/src/services/agent-system-prompts.test.ts
+++ b/packages/core/src/services/agent-system-prompts.test.ts
@@ -437,20 +437,21 @@ describe("kickoff and permission prompts", () => {
     const prompt = result.prompt;
 
     expectPromptToContainAll(prompt, [
-      "Publish a review-ready pull request for the current Builder session.",
-      "comparisonRef: origin/release/2026.04",
-      "branch: release/2026.04",
-      "Use comparisonRef for git comparison and rebasing. Pass branch alone as the provider pull-request base.",
+      "Publish a review-ready pull request for the current task.",
+      "Git comparison ref: origin/release/2026.04",
+      "Pull request base branch: release/2026.04",
+      "Use the Git comparison ref for diffs and rebasing. Pass only the pull request base branch to provider tools.",
       "Follow the repository's pull request conventions, including its contribution guidance and GitHub pull request template when present.",
       "Diagnose check failures, fix their root causes, and rerun the affected checks until all required checks pass.",
-      "If the source branch is behind comparisonRef, rebase it on comparisonRef and resolve conflicts carefully.",
+      "If the source branch is behind the Git comparison ref, rebase it and resolve conflicts carefully.",
       "Use a concise Conventional Commit-style pull request title that explains why the change matters.",
       "Start the body with the problem, then explain the goal and the context reviewers need.",
       "Do not lead with an implementation inventory or add a verification section.",
-      "Push the source branch, then create or update the pull request against the exact branch above with provider-native tooling.",
+      "Push the source branch, then create or update the pull request against the pull request base branch shown above with provider-native tooling.",
       "After the pull request exists, call odt_set_pull_request with taskId task-1, the tool's required providerId, and the pull request number.",
+      "If any fail, diagnose and fix the root cause, rerun the affected local checks, commit and push the fix, then check again until all required checks pass.",
     ]);
-    expect(result.templates[0]?.builtinVersion).toBe(5);
+    expect(result.templates[0]?.builtinVersion).toBe(6);
   });
 
   test("rejects pull request generation kickoff when target branch context is missing", () => {

--- a/packages/core/src/services/agent-system-prompts.test.ts
+++ b/packages/core/src/services/agent-system-prompts.test.ts
@@ -427,9 +427,9 @@ describe("kickoff and permission prompts", () => {
       task: {
         taskId: "task-1",
       },
-      git: {
-        targetBranch: "origin/release/2026.04",
-        pullRequestBaseBranch: "release/2026.04",
+      targetBranch: {
+        remote: "origin",
+        branch: "release/2026.04",
       },
     });
 
@@ -463,7 +463,7 @@ describe("kickoff and permission prompts", () => {
     );
   });
 
-  test("rejects pull request generation kickoff when provider base context is missing", () => {
+  test("rejects an upstream-relative pull request target", () => {
     expect(() =>
       buildAgentKickoffPrompt({
         role: "build",
@@ -471,12 +471,12 @@ describe("kickoff and permission prompts", () => {
         task: {
           taskId: "task-1",
         },
-        git: {
-          targetBranch: "origin/main",
+        targetBranch: {
+          branch: "@{upstream}",
         },
       }),
     ).toThrow(
-      'Missing required git context for "kickoff.build_pull_request_generation": pullRequestBaseBranch.',
+      "Pull request generation requires an explicit target branch; '@{upstream}' cannot identify a provider base branch.",
     );
   });
 

--- a/packages/core/src/services/agent-system-prompts.test.ts
+++ b/packages/core/src/services/agent-system-prompts.test.ts
@@ -438,11 +438,10 @@ describe("kickoff and permission prompts", () => {
 
     expectPromptToContainAll(prompt, [
       "Publish a review-ready pull request for the current task.",
-      "Base ref: origin/release/2026.04",
-      "Base branch: release/2026.04",
-      "Use the base ref for Git diffs and rebases. Use the base branch with pull request provider tools.",
+      "Pull request base:\nrelease/2026.04",
+      "Use the base branch for Git diffs, rebases, and pull request provider tools.",
       "Treat the current task artifacts and live repository state as the source of truth.",
-      "If the source branch is behind the base ref, rebase it and resolve conflicts.",
+      "If the source branch is behind the base branch, rebase it and resolve conflicts.",
       "Preparation is complete when the diff matches the current task and every required local check passes.",
       "Use a concise Conventional Commit-style pull request title that explains why the change matters.",
       "Start the body with the problem and goal. Add reviewer context and decisions or tradeoffs that affect review.",
@@ -454,6 +453,7 @@ describe("kickoff and permission prompts", () => {
     ]);
     expect(prompt).not.toContain("Builder session");
     expect(prompt).not.toContain("comparison");
+    expect(prompt).not.toContain("origin/release/2026.04");
     expect(prompt).not.toContain("target");
     expect(result.templates[0]?.builtinVersion).toBe(5);
   });
@@ -487,7 +487,7 @@ describe("kickoff and permission prompts", () => {
         },
       }),
     ).toThrow(
-      "Pull request generation requires an explicit target branch; '@{upstream}' cannot identify a provider base branch.",
+      "Pull request generation requires an explicit target branch; '@{upstream}' cannot identify a pull request base branch.",
     );
   });
 

--- a/packages/core/src/services/agent-system-prompts.test.ts
+++ b/packages/core/src/services/agent-system-prompts.test.ts
@@ -427,9 +427,11 @@ describe("kickoff and permission prompts", () => {
       task: {
         taskId: "task-1",
       },
-      targetBranch: {
-        remote: "origin",
-        branch: "release/2026.04",
+      git: {
+        targetBranch: {
+          remote: "origin",
+          branch: "release/2026.04",
+        },
       },
     });
     const prompt = result.prompt;
@@ -473,8 +475,10 @@ describe("kickoff and permission prompts", () => {
         task: {
           taskId: "task-1",
         },
-        targetBranch: {
-          branch: "@{upstream}",
+        git: {
+          targetBranch: {
+            branch: "@{upstream}",
+          },
         },
       }),
     ).toThrow(

--- a/packages/core/src/services/agent-system-prompts.test.ts
+++ b/packages/core/src/services/agent-system-prompts.test.ts
@@ -438,20 +438,24 @@ describe("kickoff and permission prompts", () => {
 
     expectPromptToContainAll(prompt, [
       "Publish a review-ready pull request for the current task.",
-      "Git comparison ref: origin/release/2026.04",
-      "Pull request base branch: release/2026.04",
-      "Use the Git comparison ref for diffs and rebasing. Pass only the pull request base branch to provider tools.",
-      "Follow the repository's pull request conventions, including its contribution guidance and GitHub pull request template when present.",
-      "Diagnose check failures, fix their root causes, and rerun the affected checks until all required checks pass.",
-      "If the source branch is behind the Git comparison ref, rebase it and resolve conflicts carefully.",
+      "Base ref: origin/release/2026.04",
+      "Base branch: release/2026.04",
+      "Use the base ref for Git diffs and rebases. Use the base branch with pull request provider tools.",
+      "Treat the current task artifacts and live repository state as the source of truth.",
+      "If the source branch is behind the base ref, rebase it and resolve conflicts.",
+      "Preparation is complete when the diff matches the current task and every required local check passes.",
       "Use a concise Conventional Commit-style pull request title that explains why the change matters.",
-      "Start the body with the problem, then explain the goal and the context reviewers need.",
-      "Do not lead with an implementation inventory or add a verification section.",
-      "Push the source branch, then create or update the pull request against the pull request base branch shown above with provider-native tooling.",
+      "Start the body with the problem and goal. Add reviewer context and decisions or tradeoffs that affect review.",
+      "Push the source branch, create or update the pull request against the base branch, and confirm the published title and body follow repository conventions.",
       "After the pull request exists, call odt_set_pull_request with taskId task-1, the tool's required providerId, and the pull request number.",
       "If any fail, diagnose and fix the root cause, rerun the affected local checks, commit and push the fix, then check again until all required checks pass.",
+      "Completion criterion: the task references the pull request and every required pull request check passes.",
+      "Report the pull request URL and the passed local and pull request checks.",
     ]);
-    expect(result.templates[0]?.builtinVersion).toBe(6);
+    expect(prompt).not.toContain("Builder session");
+    expect(prompt).not.toContain("comparison");
+    expect(prompt).not.toContain("target");
+    expect(result.templates[0]?.builtinVersion).toBe(5);
   });
 
   test("rejects pull request generation kickoff when target branch context is missing", () => {

--- a/packages/core/src/services/agent-system-prompts.test.ts
+++ b/packages/core/src/services/agent-system-prompts.test.ts
@@ -429,20 +429,22 @@ describe("kickoff and permission prompts", () => {
       },
       git: {
         targetBranch: "origin/release/2026.04",
+        pullRequestBaseBranch: "release/2026.04",
       },
     });
 
     expectPromptToContainAll(prompt, [
       "Publish a review-ready pull request for the current Builder session.",
-      "targetBranch: origin/release/2026.04",
-      "Treat the targetBranch above as the pull-request base branch for this task.",
+      "comparisonRef: origin/release/2026.04",
+      "pullRequestBaseBranch: release/2026.04",
+      "Use comparisonRef for git comparison and rebasing. Use pullRequestBaseBranch only as the provider pull-request base.",
       "Follow the repository's pull request conventions, including its contribution guidance and GitHub pull request template when present.",
       "Diagnose check failures, fix their root causes, and rerun the affected checks until all required checks pass.",
-      "If the source branch is behind targetBranch, rebase it on targetBranch and resolve conflicts carefully.",
-      "Use a concise Conventional Commit title that explains why the change matters.",
+      "If the source branch is behind comparisonRef, rebase it on comparisonRef and resolve conflicts carefully.",
+      "Use a concise Conventional Commit-style pull request title that explains why the change matters.",
       "Start the body with the problem, then explain the goal and the context reviewers need.",
       "Do not lead with an implementation inventory or add a verification section.",
-      "Push the source branch, then create or update the pull request against the exact targetBranch above with provider-native tooling.",
+      "Push the source branch, then create or update the pull request against the exact pullRequestBaseBranch above with provider-native tooling.",
       "After the pull request exists, call odt_set_pull_request with taskId task-1, the tool's required providerId, and the pull request number.",
     ]);
   });
@@ -458,6 +460,23 @@ describe("kickoff and permission prompts", () => {
       }),
     ).toThrow(
       'Missing required git context for "kickoff.build_pull_request_generation": targetBranch.',
+    );
+  });
+
+  test("rejects pull request generation kickoff when provider base context is missing", () => {
+    expect(() =>
+      buildAgentKickoffPrompt({
+        role: "build",
+        templateId: "kickoff.build_pull_request_generation",
+        task: {
+          taskId: "task-1",
+        },
+        git: {
+          targetBranch: "origin/main",
+        },
+      }),
+    ).toThrow(
+      'Missing required git context for "kickoff.build_pull_request_generation": pullRequestBaseBranch.',
     );
   });
 

--- a/packages/core/src/services/agent-system-prompts.test.ts
+++ b/packages/core/src/services/agent-system-prompts.test.ts
@@ -421,7 +421,7 @@ describe("kickoff and permission prompts", () => {
   });
 
   test("pull request generation kickoff drives repo-aware publication for reused sessions and forks", () => {
-    const prompt = buildAgentKickoffPrompt({
+    const result = buildAgentKickoffPromptBundle({
       role: "build",
       templateId: "kickoff.build_pull_request_generation",
       task: {
@@ -432,21 +432,23 @@ describe("kickoff and permission prompts", () => {
         branch: "release/2026.04",
       },
     });
+    const prompt = result.prompt;
 
     expectPromptToContainAll(prompt, [
       "Publish a review-ready pull request for the current Builder session.",
       "comparisonRef: origin/release/2026.04",
-      "pullRequestBaseBranch: release/2026.04",
-      "Use comparisonRef for git comparison and rebasing. Use pullRequestBaseBranch only as the provider pull-request base.",
+      "branch: release/2026.04",
+      "Use comparisonRef for git comparison and rebasing. Pass branch alone as the provider pull-request base.",
       "Follow the repository's pull request conventions, including its contribution guidance and GitHub pull request template when present.",
       "Diagnose check failures, fix their root causes, and rerun the affected checks until all required checks pass.",
       "If the source branch is behind comparisonRef, rebase it on comparisonRef and resolve conflicts carefully.",
       "Use a concise Conventional Commit-style pull request title that explains why the change matters.",
       "Start the body with the problem, then explain the goal and the context reviewers need.",
       "Do not lead with an implementation inventory or add a verification section.",
-      "Push the source branch, then create or update the pull request against the exact pullRequestBaseBranch above with provider-native tooling.",
+      "Push the source branch, then create or update the pull request against the exact branch above with provider-native tooling.",
       "After the pull request exists, call odt_set_pull_request with taskId task-1, the tool's required providerId, and the pull request number.",
     ]);
+    expect(result.templates[0]?.builtinVersion).toBe(5);
   });
 
   test("rejects pull request generation kickoff when target branch context is missing", () => {

--- a/packages/core/src/services/agent-system-prompts.test.ts
+++ b/packages/core/src/services/agent-system-prompts.test.ts
@@ -420,7 +420,7 @@ describe("kickoff and permission prompts", () => {
     ).toThrow('Prompt placeholder "humanFeedback" must not be empty.');
   });
 
-  test("pull request generation kickoff supports reused sessions and forks", () => {
+  test("pull request generation kickoff drives repo-aware publication for reused sessions and forks", () => {
     const prompt = buildAgentKickoffPrompt({
       role: "build",
       templateId: "kickoff.build_pull_request_generation",
@@ -433,11 +433,16 @@ describe("kickoff and permission prompts", () => {
     });
 
     expectPromptToContainAll(prompt, [
-      "Focus only on pull request publication work for the current Builder session.",
+      "Publish a review-ready pull request for the current Builder session.",
       "targetBranch: origin/release/2026.04",
       "Treat the targetBranch above as the pull-request base branch for this task.",
-      "Always rebase on targetBranch before pushing the source branch.",
-      "Then create or update the pull request against the exact targetBranch above using the provider-native tooling available.",
+      "Follow the repository's pull request conventions, including its contribution guidance and GitHub pull request template when present.",
+      "Diagnose check failures, fix their root causes, and rerun the affected checks until all required checks pass.",
+      "If the source branch is behind targetBranch, rebase it on targetBranch and resolve conflicts carefully.",
+      "Use a concise Conventional Commit title that explains why the change matters.",
+      "Start the body with the problem, then explain the goal and the context reviewers need.",
+      "Do not lead with an implementation inventory or add a verification section.",
+      "Push the source branch, then create or update the pull request against the exact targetBranch above with provider-native tooling.",
       "After the pull request exists, call odt_set_pull_request with taskId task-1, the tool's required providerId, and the pull request number.",
     ]);
   });

--- a/packages/core/src/services/agent-system-prompts.ts
+++ b/packages/core/src/services/agent-system-prompts.ts
@@ -46,6 +46,7 @@ export type AgentPromptGitContext = {
   operationLabel?: string;
   currentBranch?: string;
   targetBranch?: string;
+  pullRequestBaseBranch?: string;
   conflictedFiles?: string[];
   conflictOutput?: string;
 };
@@ -460,22 +461,25 @@ const AGENT_PROMPT_DEFINITIONS: Record<AgentPromptTemplateId, AgentPromptTemplat
   "kickoff.build_pull_request_generation": {
     id: "kickoff.build_pull_request_generation",
     purpose: "kickoff",
-    builtinVersion: 5,
+    builtinVersion: 6,
     template: joinPromptBlocks(
       "Publish a review-ready pull request for the current Builder session.",
-      lineSection("Pull request context", ["- targetBranch: {{git.targetBranch}}"]),
+      lineSection("Pull request context", [
+        "- comparisonRef: {{git.targetBranch}}",
+        "- pullRequestBaseBranch: {{git.pullRequestBaseBranch}}",
+      ]),
       bulletSection("Prepare", [
-        "Treat the targetBranch above as the pull-request base branch for this task.",
+        "Use comparisonRef for git comparison and rebasing. Use pullRequestBaseBranch only as the provider pull-request base.",
         "Follow the repository's pull request conventions, including its contribution guidance and GitHub pull request template when present.",
-        "Inspect the current source branch, remote branch, existing pull-request state, task artifacts, and actual diff against targetBranch. Use live evidence instead of relying on the session summary.",
+        "Inspect the current source branch, remote branch, existing pull-request state, task artifacts, and actual diff against comparisonRef. Use live evidence instead of relying on the session summary.",
         "Run the repository-required checks. Diagnose check failures, fix their root causes, and rerun the affected checks until all required checks pass.",
-        "If the source branch is behind targetBranch, rebase it on targetBranch and resolve conflicts carefully.",
+        "If the source branch is behind comparisonRef, rebase it on comparisonRef and resolve conflicts carefully.",
       ]),
       bulletSection("Write and publish", [
-        "Use a concise Conventional Commit title that explains why the change matters.",
+        "Use a concise Conventional Commit-style pull request title that explains why the change matters.",
         "Start the body with the problem, then explain the goal and the context reviewers need. Include key decisions or tradeoffs when they help review.",
         "Follow any repository pull request template and fill every relevant section. Do not lead with an implementation inventory or add a verification section.",
-        "Push the source branch, then create or update the pull request against the exact targetBranch above with provider-native tooling.",
+        "Push the source branch, then create or update the pull request against the exact pullRequestBaseBranch above with provider-native tooling.",
       ]),
       bulletSection("Finish", [
         "After the pull request exists, call odt_set_pull_request with taskId {{task.id}}, the tool's required providerId, and the pull request number.",
@@ -583,6 +587,7 @@ const buildPlaceholderValues = ({
           "git.operationLabel": compact(git.operationLabel),
           "git.currentBranch": compact(git.currentBranch),
           "git.targetBranch": compact(git.targetBranch),
+          "git.pullRequestBaseBranch": compact(git.pullRequestBaseBranch),
           "git.conflictedFiles": compactList(git.conflictedFiles),
           "git.conflictOutput": compact(git.conflictOutput),
         }
@@ -731,6 +736,12 @@ export const buildAgentKickoffPromptBundle = (
     if (!targetBranch) {
       throw new Error(
         'Missing required git context for "kickoff.build_pull_request_generation": targetBranch.',
+      );
+    }
+    const pullRequestBaseBranch = input.git?.pullRequestBaseBranch?.trim();
+    if (!pullRequestBaseBranch) {
+      throw new Error(
+        'Missing required git context for "kickoff.build_pull_request_generation": pullRequestBaseBranch.',
       );
     }
   }

--- a/packages/core/src/services/agent-system-prompts.ts
+++ b/packages/core/src/services/agent-system-prompts.ts
@@ -460,17 +460,26 @@ const AGENT_PROMPT_DEFINITIONS: Record<AgentPromptTemplateId, AgentPromptTemplat
   "kickoff.build_pull_request_generation": {
     id: "kickoff.build_pull_request_generation",
     purpose: "kickoff",
-    builtinVersion: 4,
+    builtinVersion: 5,
     template: joinPromptBlocks(
-      "Focus only on pull request publication work for the current Builder session.",
+      "Publish a review-ready pull request for the current Builder session.",
       lineSection("Pull request context", ["- targetBranch: {{git.targetBranch}}"]),
-      bulletSection("Publication workflow", [
+      bulletSection("Prepare", [
         "Treat the targetBranch above as the pull-request base branch for this task.",
-        "Inspect the current source branch, remote branch, and existing pull-request state before deciding whether to create a new pull request or update an existing one.",
-        "Always rebase on targetBranch before pushing the source branch.",
-        "Then create or update the pull request against the exact targetBranch above using the provider-native tooling available.",
-        "Write a pull request title and body grounded in the task, spec, plan, and actual implementation diff.",
+        "Follow the repository's pull request conventions, including its contribution guidance and GitHub pull request template when present.",
+        "Inspect the current source branch, remote branch, existing pull-request state, task artifacts, and actual diff against targetBranch. Use live evidence instead of relying on the session summary.",
+        "Run the repository-required checks. Diagnose check failures, fix their root causes, and rerun the affected checks until all required checks pass.",
+        "If the source branch is behind targetBranch, rebase it on targetBranch and resolve conflicts carefully.",
+      ]),
+      bulletSection("Write and publish", [
+        "Use a concise Conventional Commit title that explains why the change matters.",
+        "Start the body with the problem, then explain the goal and the context reviewers need. Include key decisions or tradeoffs when they help review.",
+        "Follow any repository pull request template and fill every relevant section. Do not lead with an implementation inventory or add a verification section.",
+        "Push the source branch, then create or update the pull request against the exact targetBranch above with provider-native tooling.",
+      ]),
+      bulletSection("Finish", [
         "After the pull request exists, call odt_set_pull_request with taskId {{task.id}}, the tool's required providerId, and the pull request number.",
+        "Report local check results and hosted check state separately; keep pending hosted checks marked as pending.",
       ]),
       "Use taskId {{task.id}} for every odt_* tool call.",
     ),

--- a/packages/core/src/services/agent-system-prompts.ts
+++ b/packages/core/src/services/agent-system-prompts.ts
@@ -470,11 +470,11 @@ const AGENT_PROMPT_DEFINITIONS: Record<AgentPromptTemplateId, AgentPromptTemplat
       "Publish a review-ready pull request for the current task.",
       lineSection("Pull request base", ["{{git.targetBranch}}"]),
       bulletSection("Prepare", [
-        "Use the base ref for Git diffs and rebases. Use the base branch with pull request provider tools.",
+        "Use the base branch for Git diffs, rebases, and pull request provider tools.",
         "Treat the current task artifacts and live repository state as the source of truth.",
         "Read the repository's contribution guidance and pull request template when present.",
-        "Inspect the source branch, its remote, any existing pull request, and the diff against the base ref.",
-        "If the source branch is behind the base ref, rebase it and resolve conflicts.",
+        "Inspect the source branch, any existing pull request, and the diff against the base branch.",
+        "If the source branch is behind the base branch, rebase it and resolve conflicts.",
         "Run every required local check. Fix root causes and rerun affected checks until all pass.",
         "Preparation is complete when the diff matches the current task and every required local check passes.",
       ]),
@@ -535,14 +535,7 @@ const compact = (value: string | undefined): string => {
   return trimmed && trimmed.length > 0 ? trimmed : "(none)";
 };
 
-type PullRequestTargetContext = {
-  comparisonRef: string;
-  branch: string;
-};
-
-const resolvePullRequestTarget = (
-  targetBranch: GitTargetBranch | undefined,
-): PullRequestTargetContext => {
+const resolvePullRequestTarget = (targetBranch: GitTargetBranch | undefined): string => {
   const branch = targetBranch?.branch.trim();
   if (!branch) {
     throw new Error(
@@ -551,15 +544,11 @@ const resolvePullRequestTarget = (
   }
   if (branch === "@{upstream}") {
     throw new Error(
-      "Pull request generation requires an explicit target branch; '@{upstream}' cannot identify a provider base branch.",
+      "Pull request generation requires an explicit target branch; '@{upstream}' cannot identify a pull request base branch.",
     );
   }
 
-  const remote = targetBranch?.remote?.trim();
-  return {
-    comparisonRef: remote ? `${remote}/${branch}` : branch,
-    branch,
-  };
+  return branch;
 };
 
 const compactList = (values: string[] | undefined): string => {
@@ -593,16 +582,11 @@ const buildPlaceholderValues = ({
   role: AgentRole;
   task: BuildAgentKickoffPromptInput["task"];
   extraPlaceholders?: BuildAgentKickoffPromptInput["extraPlaceholders"];
-  pullRequestTarget?: PullRequestTargetContext;
+  pullRequestTarget?: string;
   git?: AgentPromptGitContext;
 }): Record<string, string> => {
   const humanFeedback = extraPlaceholders?.humanFeedback?.trim();
-  const targetBranchPlaceholder = pullRequestTarget
-    ? [
-        `- Base ref: ${pullRequestTarget.comparisonRef}`,
-        `- Base branch: ${pullRequestTarget.branch}`,
-      ].join("\n")
-    : compact(git?.targetBranch);
+  const targetBranchPlaceholder = pullRequestTarget ?? compact(git?.targetBranch);
 
   if (extraPlaceholders?.humanFeedback !== undefined && !humanFeedback) {
     throw new Error('Prompt placeholder "humanFeedback" must not be empty.');
@@ -719,7 +703,7 @@ const buildPromptFromTemplates = ({
   role: AgentRole;
   task: BuildAgentKickoffPromptInput["task"];
   extraPlaceholders?: BuildAgentKickoffPromptInput["extraPlaceholders"];
-  pullRequestTarget?: PullRequestTargetContext;
+  pullRequestTarget?: string;
   git?: AgentPromptGitContext;
   overrides: RepoPromptOverrides | undefined;
 }): BuiltAgentPrompt => {

--- a/packages/core/src/services/agent-system-prompts.ts
+++ b/packages/core/src/services/agent-system-prompts.ts
@@ -462,15 +462,12 @@ const AGENT_PROMPT_DEFINITIONS: Record<AgentPromptTemplateId, AgentPromptTemplat
   "kickoff.build_pull_request_generation": {
     id: "kickoff.build_pull_request_generation",
     purpose: "kickoff",
-    builtinVersion: 6,
+    builtinVersion: 5,
     template: joinPromptBlocks(
       "Publish a review-ready pull request for the current Builder session.",
-      lineSection("Pull request context", [
-        "- comparisonRef: {{git.targetBranch}}",
-        "- pullRequestBaseBranch: {{git.pullRequestBaseBranch}}",
-      ]),
+      lineSection("Pull request target", ["{{git.targetBranch}}"]),
       bulletSection("Prepare", [
-        "Use comparisonRef for git comparison and rebasing. Use pullRequestBaseBranch only as the provider pull-request base.",
+        "Use comparisonRef for git comparison and rebasing. Pass branch alone as the provider pull-request base.",
         "Follow the repository's pull request conventions, including its contribution guidance and GitHub pull request template when present.",
         "Inspect the current source branch, remote branch, existing pull-request state, task artifacts, and actual diff against comparisonRef. Use live evidence instead of relying on the session summary.",
         "Run the repository-required checks. Diagnose check failures, fix their root causes, and rerun the affected checks until all required checks pass.",
@@ -480,7 +477,7 @@ const AGENT_PROMPT_DEFINITIONS: Record<AgentPromptTemplateId, AgentPromptTemplat
         "Use a concise Conventional Commit-style pull request title that explains why the change matters.",
         "Start the body with the problem, then explain the goal and the context reviewers need. Include key decisions or tradeoffs when they help review.",
         "Follow any repository pull request template and fill every relevant section. Do not lead with an implementation inventory or add a verification section.",
-        "Push the source branch, then create or update the pull request against the exact pullRequestBaseBranch above with provider-native tooling.",
+        "Push the source branch, then create or update the pull request against the exact branch above with provider-native tooling.",
       ]),
       bulletSection("Finish", [
         "After the pull request exists, call odt_set_pull_request with taskId {{task.id}}, the tool's required providerId, and the pull request number.",
@@ -533,7 +530,7 @@ const compact = (value: string | undefined): string => {
 
 type PullRequestTargetContext = {
   comparisonRef: string;
-  baseBranch: string;
+  branch: string;
 };
 
 const resolvePullRequestTarget = (
@@ -554,7 +551,7 @@ const resolvePullRequestTarget = (
   const remote = targetBranch?.remote?.trim();
   return {
     comparisonRef: remote ? `${remote}/${branch}` : branch,
-    baseBranch: branch,
+    branch,
   };
 };
 
@@ -593,6 +590,12 @@ const buildPlaceholderValues = ({
   git?: AgentPromptGitContext;
 }): Record<string, string> => {
   const humanFeedback = extraPlaceholders?.humanFeedback?.trim();
+  const targetBranchPlaceholder = pullRequestTarget
+    ? [
+        `- comparisonRef: ${pullRequestTarget.comparisonRef}`,
+        `- branch: ${pullRequestTarget.branch}`,
+      ].join("\n")
+    : compact(git?.targetBranch);
 
   if (extraPlaceholders?.humanFeedback !== undefined && !humanFeedback) {
     throw new Error('Prompt placeholder "humanFeedback" must not be empty.');
@@ -616,8 +619,7 @@ const buildPlaceholderValues = ({
       ? {
           "git.operationLabel": compact(git?.operationLabel),
           "git.currentBranch": compact(git?.currentBranch),
-          "git.targetBranch": compact(pullRequestTarget?.comparisonRef ?? git?.targetBranch),
-          "git.pullRequestBaseBranch": compact(pullRequestTarget?.baseBranch),
+          "git.targetBranch": targetBranchPlaceholder,
           "git.conflictedFiles": compactList(git?.conflictedFiles),
           "git.conflictOutput": compact(git?.conflictOutput),
         }

--- a/packages/core/src/services/agent-system-prompts.ts
+++ b/packages/core/src/services/agent-system-prompts.ts
@@ -465,26 +465,30 @@ const AGENT_PROMPT_DEFINITIONS: Record<AgentPromptTemplateId, AgentPromptTemplat
   "kickoff.build_pull_request_generation": {
     id: "kickoff.build_pull_request_generation",
     purpose: "kickoff",
-    builtinVersion: 6,
+    builtinVersion: 5,
     template: joinPromptBlocks(
       "Publish a review-ready pull request for the current task.",
-      lineSection("Pull request target", ["{{git.targetBranch}}"]),
+      lineSection("Pull request base", ["{{git.targetBranch}}"]),
       bulletSection("Prepare", [
-        "Use the Git comparison ref for diffs and rebasing. Pass only the pull request base branch to provider tools.",
-        "Follow the repository's pull request conventions, including its contribution guidance and GitHub pull request template when present.",
-        "Inspect the current source branch, remote branch, existing pull-request state, task artifacts, and actual diff against the Git comparison ref. Use live evidence instead of relying on the session summary.",
-        "Run the repository-required checks. Diagnose check failures, fix their root causes, and rerun the affected checks until all required checks pass.",
-        "If the source branch is behind the Git comparison ref, rebase it and resolve conflicts carefully.",
+        "Use the base ref for Git diffs and rebases. Use the base branch with pull request provider tools.",
+        "Treat the current task artifacts and live repository state as the source of truth.",
+        "Read the repository's contribution guidance and pull request template when present.",
+        "Inspect the source branch, its remote, any existing pull request, and the diff against the base ref.",
+        "If the source branch is behind the base ref, rebase it and resolve conflicts.",
+        "Run every required local check. Fix root causes and rerun affected checks until all pass.",
+        "Preparation is complete when the diff matches the current task and every required local check passes.",
       ]),
-      bulletSection("Write and publish", [
+      bulletSection("Publish", [
         "Use a concise Conventional Commit-style pull request title that explains why the change matters.",
-        "Start the body with the problem, then explain the goal and the context reviewers need. Include key decisions or tradeoffs when they help review.",
-        "Follow any repository pull request template and fill every relevant section. Do not lead with an implementation inventory or add a verification section.",
-        "Push the source branch, then create or update the pull request against the pull request base branch shown above with provider-native tooling.",
+        "Start the body with the problem and goal. Add reviewer context and decisions or tradeoffs that affect review.",
+        "Follow the repository's pull request template and fill every relevant section. Keep the body focused on the current task.",
+        "Push the source branch, create or update the pull request against the base branch, and confirm the published title and body follow repository conventions.",
       ]),
-      bulletSection("Finish", [
+      bulletSection("Complete", [
         "After the pull request exists, call odt_set_pull_request with taskId {{task.id}}, the tool's required providerId, and the pull request number.",
         "Wait for required pull request checks to finish. If any fail, diagnose and fix the root cause, rerun the affected local checks, commit and push the fix, then check again until all required checks pass.",
+        "Completion criterion: the task references the pull request and every required pull request check passes.",
+        "Report the pull request URL and the passed local and pull request checks.",
       ]),
       "Use taskId {{task.id}} for every odt_* tool call.",
     ),
@@ -595,8 +599,8 @@ const buildPlaceholderValues = ({
   const humanFeedback = extraPlaceholders?.humanFeedback?.trim();
   const targetBranchPlaceholder = pullRequestTarget
     ? [
-        `- Git comparison ref: ${pullRequestTarget.comparisonRef}`,
-        `- Pull request base branch: ${pullRequestTarget.branch}`,
+        `- Base ref: ${pullRequestTarget.comparisonRef}`,
+        `- Base branch: ${pullRequestTarget.branch}`,
       ].join("\n")
     : compact(git?.targetBranch);
 

--- a/packages/core/src/services/agent-system-prompts.ts
+++ b/packages/core/src/services/agent-system-prompts.ts
@@ -465,26 +465,26 @@ const AGENT_PROMPT_DEFINITIONS: Record<AgentPromptTemplateId, AgentPromptTemplat
   "kickoff.build_pull_request_generation": {
     id: "kickoff.build_pull_request_generation",
     purpose: "kickoff",
-    builtinVersion: 5,
+    builtinVersion: 6,
     template: joinPromptBlocks(
-      "Publish a review-ready pull request for the current Builder session.",
+      "Publish a review-ready pull request for the current task.",
       lineSection("Pull request target", ["{{git.targetBranch}}"]),
       bulletSection("Prepare", [
-        "Use comparisonRef for git comparison and rebasing. Pass branch alone as the provider pull-request base.",
+        "Use the Git comparison ref for diffs and rebasing. Pass only the pull request base branch to provider tools.",
         "Follow the repository's pull request conventions, including its contribution guidance and GitHub pull request template when present.",
-        "Inspect the current source branch, remote branch, existing pull-request state, task artifacts, and actual diff against comparisonRef. Use live evidence instead of relying on the session summary.",
+        "Inspect the current source branch, remote branch, existing pull-request state, task artifacts, and actual diff against the Git comparison ref. Use live evidence instead of relying on the session summary.",
         "Run the repository-required checks. Diagnose check failures, fix their root causes, and rerun the affected checks until all required checks pass.",
-        "If the source branch is behind comparisonRef, rebase it on comparisonRef and resolve conflicts carefully.",
+        "If the source branch is behind the Git comparison ref, rebase it and resolve conflicts carefully.",
       ]),
       bulletSection("Write and publish", [
         "Use a concise Conventional Commit-style pull request title that explains why the change matters.",
         "Start the body with the problem, then explain the goal and the context reviewers need. Include key decisions or tradeoffs when they help review.",
         "Follow any repository pull request template and fill every relevant section. Do not lead with an implementation inventory or add a verification section.",
-        "Push the source branch, then create or update the pull request against the exact branch above with provider-native tooling.",
+        "Push the source branch, then create or update the pull request against the pull request base branch shown above with provider-native tooling.",
       ]),
       bulletSection("Finish", [
         "After the pull request exists, call odt_set_pull_request with taskId {{task.id}}, the tool's required providerId, and the pull request number.",
-        "Report local check results and hosted check state separately; keep pending hosted checks marked as pending.",
+        "Wait for required pull request checks to finish. If any fail, diagnose and fix the root cause, rerun the affected local checks, commit and push the fix, then check again until all required checks pass.",
       ]),
       "Use taskId {{task.id}} for every odt_* tool call.",
     ),
@@ -595,8 +595,8 @@ const buildPlaceholderValues = ({
   const humanFeedback = extraPlaceholders?.humanFeedback?.trim();
   const targetBranchPlaceholder = pullRequestTarget
     ? [
-        `- comparisonRef: ${pullRequestTarget.comparisonRef}`,
-        `- branch: ${pullRequestTarget.branch}`,
+        `- Git comparison ref: ${pullRequestTarget.comparisonRef}`,
+        `- Pull request base branch: ${pullRequestTarget.branch}`,
       ].join("\n")
     : compact(git?.targetBranch);
 

--- a/packages/core/src/services/agent-system-prompts.ts
+++ b/packages/core/src/services/agent-system-prompts.ts
@@ -39,9 +39,12 @@ export type BuildAgentKickoffPromptInput = {
     description?: string;
   };
   extraPlaceholders?: Partial<Record<"humanFeedback", string>>;
-  targetBranch?: GitTargetBranch;
-  git?: AgentPromptGitContext;
+  git?: AgentKickoffPromptGitContext;
   overrides?: RepoPromptOverrides;
+};
+
+export type AgentKickoffPromptGitContext = {
+  targetBranch?: GitTargetBranch;
 };
 
 export type AgentPromptGitContext = {
@@ -768,7 +771,7 @@ export const buildAgentKickoffPromptBundle = (
 ): BuiltAgentPrompt => {
   const pullRequestTarget =
     input.templateId === "kickoff.build_pull_request_generation"
-      ? resolvePullRequestTarget(input.targetBranch)
+      ? resolvePullRequestTarget(input.git?.targetBranch)
       : undefined;
 
   return buildPromptFromTemplates({
@@ -777,7 +780,6 @@ export const buildAgentKickoffPromptBundle = (
     task: input.task,
     ...(input.extraPlaceholders ? { extraPlaceholders: input.extraPlaceholders } : {}),
     ...(pullRequestTarget ? { pullRequestTarget } : {}),
-    ...(input.git ? { git: input.git } : {}),
     overrides: input.overrides,
   });
 };

--- a/packages/core/src/services/agent-system-prompts.ts
+++ b/packages/core/src/services/agent-system-prompts.ts
@@ -1,5 +1,6 @@
 import {
   type AgentPromptTemplateId,
+  type GitTargetBranch,
   type RepoPromptOverrides,
   validatePromptTemplatePlaceholders,
 } from "@openducktor/contracts";
@@ -38,6 +39,7 @@ export type BuildAgentKickoffPromptInput = {
     description?: string;
   };
   extraPlaceholders?: Partial<Record<"humanFeedback", string>>;
+  targetBranch?: GitTargetBranch;
   git?: AgentPromptGitContext;
   overrides?: RepoPromptOverrides;
 };
@@ -46,7 +48,6 @@ export type AgentPromptGitContext = {
   operationLabel?: string;
   currentBranch?: string;
   targetBranch?: string;
-  pullRequestBaseBranch?: string;
   conflictedFiles?: string[];
   conflictOutput?: string;
 };
@@ -530,6 +531,33 @@ const compact = (value: string | undefined): string => {
   return trimmed && trimmed.length > 0 ? trimmed : "(none)";
 };
 
+type PullRequestTargetContext = {
+  comparisonRef: string;
+  baseBranch: string;
+};
+
+const resolvePullRequestTarget = (
+  targetBranch: GitTargetBranch | undefined,
+): PullRequestTargetContext => {
+  const branch = targetBranch?.branch.trim();
+  if (!branch) {
+    throw new Error(
+      'Missing required git context for "kickoff.build_pull_request_generation": targetBranch.',
+    );
+  }
+  if (branch === "@{upstream}") {
+    throw new Error(
+      "Pull request generation requires an explicit target branch; '@{upstream}' cannot identify a provider base branch.",
+    );
+  }
+
+  const remote = targetBranch?.remote?.trim();
+  return {
+    comparisonRef: remote ? `${remote}/${branch}` : branch,
+    baseBranch: branch,
+  };
+};
+
 const compactList = (values: string[] | undefined): string => {
   const normalized = (values ?? [])
     .map((value) => value.trim())
@@ -555,11 +583,13 @@ const buildPlaceholderValues = ({
   role,
   task,
   extraPlaceholders,
+  pullRequestTarget,
   git,
 }: {
   role: AgentRole;
   task: BuildAgentKickoffPromptInput["task"];
   extraPlaceholders?: BuildAgentKickoffPromptInput["extraPlaceholders"];
+  pullRequestTarget?: PullRequestTargetContext;
   git?: AgentPromptGitContext;
 }): Record<string, string> => {
   const humanFeedback = extraPlaceholders?.humanFeedback?.trim();
@@ -582,14 +612,14 @@ const buildPlaceholderValues = ({
           humanFeedback,
         }
       : {}),
-    ...(git
+    ...(git || pullRequestTarget
       ? {
-          "git.operationLabel": compact(git.operationLabel),
-          "git.currentBranch": compact(git.currentBranch),
-          "git.targetBranch": compact(git.targetBranch),
-          "git.pullRequestBaseBranch": compact(git.pullRequestBaseBranch),
-          "git.conflictedFiles": compactList(git.conflictedFiles),
-          "git.conflictOutput": compact(git.conflictOutput),
+          "git.operationLabel": compact(git?.operationLabel),
+          "git.currentBranch": compact(git?.currentBranch),
+          "git.targetBranch": compact(pullRequestTarget?.comparisonRef ?? git?.targetBranch),
+          "git.pullRequestBaseBranch": compact(pullRequestTarget?.baseBranch),
+          "git.conflictedFiles": compactList(git?.conflictedFiles),
+          "git.conflictOutput": compact(git?.conflictOutput),
         }
       : {}),
   };
@@ -672,6 +702,7 @@ const buildPromptFromTemplates = ({
   role,
   task,
   extraPlaceholders,
+  pullRequestTarget,
   git,
   overrides,
 }: {
@@ -679,6 +710,7 @@ const buildPromptFromTemplates = ({
   role: AgentRole;
   task: BuildAgentKickoffPromptInput["task"];
   extraPlaceholders?: BuildAgentKickoffPromptInput["extraPlaceholders"];
+  pullRequestTarget?: PullRequestTargetContext;
   git?: AgentPromptGitContext;
   overrides: RepoPromptOverrides | undefined;
 }): BuiltAgentPrompt => {
@@ -686,6 +718,7 @@ const buildPromptFromTemplates = ({
     role,
     task,
     ...(extraPlaceholders ? { extraPlaceholders } : {}),
+    ...(pullRequestTarget ? { pullRequestTarget } : {}),
     ...(git ? { git } : {}),
   });
   const templates = templateIds.map((templateId) =>
@@ -731,26 +764,17 @@ export function buildAgentSystemPrompt(input: BuildAgentPromptInput): string {
 export const buildAgentKickoffPromptBundle = (
   input: BuildAgentKickoffPromptInput,
 ): BuiltAgentPrompt => {
-  if (input.templateId === "kickoff.build_pull_request_generation") {
-    const targetBranch = input.git?.targetBranch?.trim();
-    if (!targetBranch) {
-      throw new Error(
-        'Missing required git context for "kickoff.build_pull_request_generation": targetBranch.',
-      );
-    }
-    const pullRequestBaseBranch = input.git?.pullRequestBaseBranch?.trim();
-    if (!pullRequestBaseBranch) {
-      throw new Error(
-        'Missing required git context for "kickoff.build_pull_request_generation": pullRequestBaseBranch.',
-      );
-    }
-  }
+  const pullRequestTarget =
+    input.templateId === "kickoff.build_pull_request_generation"
+      ? resolvePullRequestTarget(input.targetBranch)
+      : undefined;
 
   return buildPromptFromTemplates({
     templateIds: [input.templateId],
     role: input.role,
     task: input.task,
     ...(input.extraPlaceholders ? { extraPlaceholders: input.extraPlaceholders } : {}),
+    ...(pullRequestTarget ? { pullRequestTarget } : {}),
     ...(input.git ? { git: input.git } : {}),
     overrides: input.overrides,
   });

--- a/packages/frontend/src/components/features/settings/settings-modal-model.test.ts
+++ b/packages/frontend/src/components/features/settings/settings-modal-model.test.ts
@@ -317,7 +317,7 @@ describe("settings-modal-model", () => {
 
     expect(buildPromptOverrideValidationErrors(overrides)).toEqual({
       "kickoff.build_pull_request_generation":
-        "Unsupported placeholders: {{task.foo}}, {{unknown.value}}.",
+        "Unsupported placeholders: {{task.foo}}, {{unknown.value}}, {{git.pullRequestBaseBranch}}.",
     });
   });
 

--- a/packages/frontend/src/components/features/settings/settings-modal-model.test.ts
+++ b/packages/frontend/src/components/features/settings/settings-modal-model.test.ts
@@ -308,7 +308,8 @@ describe("settings-modal-model", () => {
         enabled: true,
       },
       "kickoff.build_pull_request_generation": {
-        template: "Bad {{task.foo}} and {{unknown.value}}",
+        template:
+          "Bad {{task.foo}} and {{unknown.value}} with {{git.targetBranch}} and {{git.pullRequestBaseBranch}}",
         baseVersion: 1,
         enabled: true,
       },

--- a/packages/frontend/src/components/features/settings/settings-modal-model.test.ts
+++ b/packages/frontend/src/components/features/settings/settings-modal-model.test.ts
@@ -336,6 +336,23 @@ describe("settings-modal-model", () => {
     });
   });
 
+  test("ignores validation errors in disabled prompt overrides", () => {
+    const overrides: RepoPromptOverrides = {
+      "kickoff.build_pull_request_generation": {
+        template: "Publish the pull request.",
+        baseVersion: 4,
+        enabled: false,
+      },
+      "kickoff.spec_initial": {
+        template: "Unsupported {{task.foo}}",
+        baseVersion: 1,
+        enabled: false,
+      },
+    };
+
+    expect(buildPromptOverrideValidationErrors(overrides)).toEqual({});
+  });
+
   test("enables prompt override and creates missing entries from fallback values", () => {
     const emptyOverrides: RepoPromptOverrides = {};
     const created = togglePromptOverrideEnabled(

--- a/packages/frontend/src/components/features/settings/settings-modal-model.ts
+++ b/packages/frontend/src/components/features/settings/settings-modal-model.ts
@@ -271,7 +271,7 @@ export const buildPromptOverrideValidationErrors = (
   for (const [templateId, override] of Object.entries(overrides) as Array<
     [AgentPromptTemplateId, RepoPromptOverrides[AgentPromptTemplateId]]
   >) {
-    if (!override) {
+    if (!override || override.enabled === false) {
       continue;
     }
 

--- a/packages/frontend/src/features/session-start/session-start-prompt-context.test.ts
+++ b/packages/frontend/src/features/session-start/session-start-prompt-context.test.ts
@@ -76,7 +76,7 @@ describe("resolveSessionStartKickoffPromptContext", () => {
         },
       },
     });
-    expect(loadRepoDefaultTargetBranch).toHaveBeenCalledTimes(1);
+    expect(loadRepoDefaultTargetBranch).not.toHaveBeenCalled();
   });
 
   test("uses the repository default for pull request context when the task has no target", async () => {

--- a/packages/frontend/src/features/session-start/session-start-prompt-context.test.ts
+++ b/packages/frontend/src/features/session-start/session-start-prompt-context.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { AgentKickoffTemplateId } from "@openducktor/core";
+import {
+  FEEDBACK_MESSAGE_REQUIRED_ERROR,
+  resolveSessionStartKickoffPromptContext,
+} from "./session-start-prompt-context";
+
+const CONTEXT_FREE_TEMPLATES: AgentKickoffTemplateId[] = [
+  "kickoff.spec_initial",
+  "kickoff.planner_initial",
+  "kickoff.build_implementation_start",
+  "kickoff.build_after_qa_rejected",
+  "kickoff.qa_review",
+];
+
+describe("resolveSessionStartKickoffPromptContext", () => {
+  test.each(CONTEXT_FREE_TEMPLATES)("returns no context for %s", async (templateId) => {
+    const loadRepoDefaultTargetBranch = mock(async () => ({
+      remote: "origin",
+      branch: "main",
+    }));
+
+    await expect(
+      resolveSessionStartKickoffPromptContext({
+        templateId,
+        loadRepoDefaultTargetBranch,
+      }),
+    ).resolves.toEqual({});
+    expect(loadRepoDefaultTargetBranch).not.toHaveBeenCalled();
+  });
+
+  test("maps human review feedback to its prompt placeholder", async () => {
+    await expect(
+      resolveSessionStartKickoffPromptContext({
+        templateId: "kickoff.build_after_human_request_changes",
+        message: "  Address every review comment.  ",
+        loadRepoDefaultTargetBranch: mock(async () => null),
+      }),
+    ).resolves.toEqual({
+      extraPlaceholders: {
+        humanFeedback: "Address every review comment.",
+      },
+    });
+  });
+
+  test("rejects missing human review feedback", async () => {
+    await expect(
+      resolveSessionStartKickoffPromptContext({
+        templateId: "kickoff.build_after_human_request_changes",
+        message: "   ",
+        loadRepoDefaultTargetBranch: mock(async () => null),
+      }),
+    ).rejects.toThrow(FEEDBACK_MESSAGE_REQUIRED_ERROR);
+  });
+
+  test("maps the selected pull request target into nested Git context", async () => {
+    const loadRepoDefaultTargetBranch = mock(async () => ({
+      remote: "origin",
+      branch: "main",
+    }));
+
+    await expect(
+      resolveSessionStartKickoffPromptContext({
+        templateId: "kickoff.build_pull_request_generation",
+        taskTargetBranch: {
+          remote: "upstream",
+          branch: "release/2026.04",
+        },
+        loadRepoDefaultTargetBranch,
+      }),
+    ).resolves.toEqual({
+      git: {
+        targetBranch: {
+          remote: "upstream",
+          branch: "release/2026.04",
+        },
+      },
+    });
+    expect(loadRepoDefaultTargetBranch).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses the repository default for pull request context when the task has no target", async () => {
+    await expect(
+      resolveSessionStartKickoffPromptContext({
+        templateId: "kickoff.build_pull_request_generation",
+        loadRepoDefaultTargetBranch: mock(async () => ({
+          remote: "upstream",
+          branch: "develop",
+        })),
+      }),
+    ).resolves.toEqual({
+      git: {
+        targetBranch: {
+          remote: "upstream",
+          branch: "develop",
+        },
+      },
+    });
+  });
+});

--- a/packages/frontend/src/features/session-start/session-start-prompt-context.ts
+++ b/packages/frontend/src/features/session-start/session-start-prompt-context.ts
@@ -1,0 +1,67 @@
+import type { GitTargetBranch } from "@openducktor/contracts";
+import type { AgentKickoffTemplateId, BuildAgentKickoffPromptInput } from "@openducktor/core";
+import { effectiveTaskTargetBranch } from "@/lib/target-branch";
+
+export const FEEDBACK_MESSAGE_REQUIRED_ERROR = "Feedback message is required before sending.";
+
+type SessionStartKickoffPromptContext = Pick<
+  BuildAgentKickoffPromptInput,
+  "extraPlaceholders" | "git"
+>;
+
+type ResolveSessionStartKickoffPromptContextInput = {
+  templateId: AgentKickoffTemplateId;
+  message?: string;
+  taskTargetBranch?: GitTargetBranch;
+  loadRepoDefaultTargetBranch: () => Promise<GitTargetBranch | null>;
+};
+
+type KickoffPromptContextResolver = (
+  input: ResolveSessionStartKickoffPromptContextInput,
+) => SessionStartKickoffPromptContext | Promise<SessionStartKickoffPromptContext>;
+
+const resolveContextFreePrompt: KickoffPromptContextResolver = () => ({});
+
+const resolveHumanFeedbackPrompt: KickoffPromptContextResolver = ({ message }) => {
+  const humanFeedback = message?.trim() ?? "";
+  if (!humanFeedback) {
+    throw new Error(FEEDBACK_MESSAGE_REQUIRED_ERROR);
+  }
+
+  return {
+    extraPlaceholders: {
+      humanFeedback,
+    },
+  };
+};
+
+const resolvePullRequestPrompt: KickoffPromptContextResolver = async ({
+  taskTargetBranch,
+  loadRepoDefaultTargetBranch,
+}) => {
+  const repoDefaultTargetBranch = await loadRepoDefaultTargetBranch();
+  return {
+    git: {
+      targetBranch: effectiveTaskTargetBranch(taskTargetBranch, repoDefaultTargetBranch),
+    },
+  };
+};
+
+const KICKOFF_PROMPT_CONTEXT_RESOLVERS: Record<
+  AgentKickoffTemplateId,
+  KickoffPromptContextResolver
+> = {
+  "kickoff.spec_initial": resolveContextFreePrompt,
+  "kickoff.planner_initial": resolveContextFreePrompt,
+  "kickoff.build_implementation_start": resolveContextFreePrompt,
+  "kickoff.build_after_qa_rejected": resolveContextFreePrompt,
+  "kickoff.build_after_human_request_changes": resolveHumanFeedbackPrompt,
+  "kickoff.build_pull_request_generation": resolvePullRequestPrompt,
+  "kickoff.qa_review": resolveContextFreePrompt,
+};
+
+export const resolveSessionStartKickoffPromptContext = async (
+  input: ResolveSessionStartKickoffPromptContextInput,
+): Promise<SessionStartKickoffPromptContext> => {
+  return KICKOFF_PROMPT_CONTEXT_RESOLVERS[input.templateId](input);
+};

--- a/packages/frontend/src/features/session-start/session-start-prompt-context.ts
+++ b/packages/frontend/src/features/session-start/session-start-prompt-context.ts
@@ -39,7 +39,7 @@ const resolvePullRequestPrompt: KickoffPromptContextResolver = async ({
   taskTargetBranch,
   loadRepoDefaultTargetBranch,
 }) => {
-  const repoDefaultTargetBranch = await loadRepoDefaultTargetBranch();
+  const repoDefaultTargetBranch = taskTargetBranch ? null : await loadRepoDefaultTargetBranch();
   return {
     git: {
       targetBranch: effectiveTaskTargetBranch(taskTargetBranch, repoDefaultTargetBranch),

--- a/packages/frontend/src/features/session-start/session-start-prompts.ts
+++ b/packages/frontend/src/features/session-start/session-start-prompts.ts
@@ -1,4 +1,4 @@
-import type { RepoPromptOverrides } from "@openducktor/contracts";
+import type { GitTargetBranch, RepoPromptOverrides } from "@openducktor/contracts";
 import {
   type AgentKickoffTemplateId,
   type AgentPromptGitContext,
@@ -27,6 +27,7 @@ type TaskPromptContext = {
 type SessionStartPromptOptions = {
   overrides?: RepoPromptOverrides;
   task?: TaskPromptContext;
+  targetBranch?: GitTargetBranch;
   git?: AgentPromptGitContext;
   extraPlaceholders?: BuildAgentKickoffPromptInput["extraPlaceholders"];
 };
@@ -69,6 +70,7 @@ export const kickoffPromptForTemplate = (
       ...options?.task,
     },
     ...(options?.extraPlaceholders ? { extraPlaceholders: options.extraPlaceholders } : {}),
+    ...(options?.targetBranch ? { targetBranch: options.targetBranch } : {}),
     ...(options?.git ? { git: options.git } : {}),
     overrides: options?.overrides ?? {},
   });

--- a/packages/frontend/src/features/session-start/session-start-prompts.ts
+++ b/packages/frontend/src/features/session-start/session-start-prompts.ts
@@ -1,4 +1,4 @@
-import type { GitTargetBranch, RepoPromptOverrides } from "@openducktor/contracts";
+import type { RepoPromptOverrides } from "@openducktor/contracts";
 import {
   type AgentKickoffTemplateId,
   type AgentPromptGitContext,
@@ -24,12 +24,18 @@ type TaskPromptContext = {
   description?: string;
 };
 
-type SessionStartPromptOptions = {
+type SharedPromptOptions = {
   overrides?: RepoPromptOverrides;
   task?: TaskPromptContext;
-  targetBranch?: GitTargetBranch;
-  git?: AgentPromptGitContext;
+};
+
+type SessionStartKickoffPromptOptions = SharedPromptOptions & {
+  git?: BuildAgentKickoffPromptInput["git"];
   extraPlaceholders?: BuildAgentKickoffPromptInput["extraPlaceholders"];
+};
+
+type SessionMessagePromptOptions = SharedPromptOptions & {
+  git?: AgentPromptGitContext;
 };
 
 export const LAUNCH_ACTIONS_BY_ROLE: Record<AgentRole, SessionLaunchActionId[]> = {
@@ -60,7 +66,7 @@ export const kickoffPromptForTemplate = (
   role: AgentRole,
   templateId: AgentKickoffTemplateId,
   taskId: string,
-  options?: SessionStartPromptOptions,
+  options?: SessionStartKickoffPromptOptions,
 ): string => {
   return buildAgentKickoffPrompt({
     role,
@@ -70,7 +76,6 @@ export const kickoffPromptForTemplate = (
       ...options?.task,
     },
     ...(options?.extraPlaceholders ? { extraPlaceholders: options.extraPlaceholders } : {}),
-    ...(options?.targetBranch ? { targetBranch: options.targetBranch } : {}),
     ...(options?.git ? { git: options.git } : {}),
     overrides: options?.overrides ?? {},
   });
@@ -80,7 +85,7 @@ export const kickoffPromptForLaunchAction = (
   role: AgentRole,
   actionId: SessionLaunchActionId,
   taskId: string,
-  options?: SessionStartPromptOptions,
+  options?: SessionStartKickoffPromptOptions,
 ): string => {
   const templateId = getSessionLaunchAction(actionId).kickoffTemplateId;
   if (!templateId) {
@@ -91,9 +96,7 @@ export const kickoffPromptForLaunchAction = (
 
 export const buildGitConflictResolutionPrompt = (
   taskId: string,
-  options?: SessionStartPromptOptions & {
-    git?: AgentPromptGitContext;
-  },
+  options?: SessionMessagePromptOptions,
 ): string => {
   return buildAgentMessagePrompt({
     role: "build",

--- a/packages/frontend/src/features/session-start/session-start-workflow.test.ts
+++ b/packages/frontend/src/features/session-start/session-start-workflow.test.ts
@@ -109,7 +109,7 @@ describe("session-start-workflow", () => {
           workingDirectory: "/repo/worktree",
         },
         targetBranch: {
-          remote: "origin",
+          remote: "upstream",
           branch: "release/2026.04",
         },
         postStartAction: "kickoff",
@@ -137,14 +137,86 @@ describe("session-start-workflow", () => {
     expect(sendAgentMessage).toHaveBeenCalledWith(sessionIdentity("session-pr"), [
       expect.objectContaining({
         kind: "text",
-        text: expect.stringContaining("targetBranch: origin/release/2026.04"),
+        text: expect.stringContaining("comparisonRef: upstream/release/2026.04"),
       }),
     ]);
     const sentCalls = sendAgentMessage.mock.calls as unknown as Array<
       [ReturnType<typeof sessionIdentity>, Array<{ text?: string }>]
     >;
     const sentText = sentCalls[0]?.[1]?.[0]?.text ?? "";
-    expect(sentText).not.toContain("targetBranch: origin/main");
+    expect(sentText).toContain("pullRequestBaseBranch: release/2026.04");
+    expect(sentText).not.toContain("comparisonRef: origin/main");
+  });
+
+  test("uses the explicit branch name as the provider base for origin targets", async () => {
+    const sendAgentMessage = mock(async () => undefined);
+    const startAgentSession = mock(async () => sessionIdentity("session-pr-origin"));
+
+    await startSessionWorkflow({
+      workspaceId: null,
+      queryClient: new QueryClient(),
+      intent: {
+        taskId: "TASK-ORIGIN",
+        role: "build",
+        launchActionId: "build_pull_request_generation",
+        startMode: "reuse",
+        sourceSession: sessionIdentity("builder-session-origin"),
+        postStartAction: "kickoff",
+      },
+      selection: null,
+      task: createTaskCardFixture({
+        id: "TASK-ORIGIN",
+        title: "Generate origin PR",
+        targetBranch: {
+          remote: "origin",
+          branch: "main",
+        },
+      }),
+      startAgentSession,
+      sendAgentMessage,
+    });
+
+    const sentCalls = sendAgentMessage.mock.calls as unknown as Array<
+      [ReturnType<typeof sessionIdentity>, Array<{ text?: string }>]
+    >;
+    const sentText = sentCalls[0]?.[1]?.[0]?.text ?? "";
+    expect(sentText).toContain("comparisonRef: origin/main");
+    expect(sentText).toContain("pullRequestBaseBranch: main");
+  });
+
+  test("rejects upstream-relative targets before creating a pull request session", async () => {
+    const sendAgentMessage = mock(async () => undefined);
+    const startAgentSession = mock(async () => sessionIdentity("session-pr-upstream"));
+
+    await expect(
+      startSessionWorkflow({
+        workspaceId: null,
+        queryClient: new QueryClient(),
+        intent: {
+          taskId: "TASK-UPSTREAM",
+          role: "build",
+          launchActionId: "build_pull_request_generation",
+          startMode: "reuse",
+          sourceSession: sessionIdentity("builder-session-upstream"),
+          targetBranch: {
+            branch: "@{upstream}",
+          },
+          postStartAction: "kickoff",
+        },
+        selection: null,
+        task: createTaskCardFixture({
+          id: "TASK-UPSTREAM",
+          title: "Generate upstream PR",
+        }),
+        startAgentSession,
+        sendAgentMessage,
+      }),
+    ).rejects.toThrow(
+      "Pull request generation requires an explicit target branch; '@{upstream}' cannot identify a provider base branch.",
+    );
+
+    expect(startAgentSession).not.toHaveBeenCalled();
+    expect(sendAgentMessage).not.toHaveBeenCalled();
   });
 
   test("uses kickoff messaging with embedded human feedback for new builder sessions after review", async () => {

--- a/packages/frontend/src/features/session-start/session-start-workflow.test.ts
+++ b/packages/frontend/src/features/session-start/session-start-workflow.test.ts
@@ -137,18 +137,17 @@ describe("session-start-workflow", () => {
     expect(sendAgentMessage).toHaveBeenCalledWith(sessionIdentity("session-pr"), [
       expect.objectContaining({
         kind: "text",
-        text: expect.stringContaining("Base ref: upstream/release/2026.04"),
+        text: expect.stringContaining("Pull request base:\nrelease/2026.04"),
       }),
     ]);
     const sentCalls = sendAgentMessage.mock.calls as unknown as Array<
       [ReturnType<typeof sessionIdentity>, Array<{ text?: string }>]
     >;
     const sentText = sentCalls[0]?.[1]?.[0]?.text ?? "";
-    expect(sentText).toContain("Base branch: release/2026.04");
-    expect(sentText).not.toContain("Base ref: origin/main");
+    expect(sentText).not.toContain("upstream/release/2026.04");
   });
 
-  test("uses the explicit branch name as the provider base for origin targets", async () => {
+  test("ignores the remote when building the pull request kickoff prompt", async () => {
     const sendAgentMessage = mock(async () => undefined);
     const startAgentSession = mock(async () => sessionIdentity("session-pr-origin"));
 
@@ -180,8 +179,8 @@ describe("session-start-workflow", () => {
       [ReturnType<typeof sessionIdentity>, Array<{ text?: string }>]
     >;
     const sentText = sentCalls[0]?.[1]?.[0]?.text ?? "";
-    expect(sentText).toContain("Base ref: origin/main");
-    expect(sentText).toContain("Base branch: main");
+    expect(sentText).toContain("Pull request base:\nmain");
+    expect(sentText).not.toContain("origin/main");
   });
 
   test("rejects upstream-relative targets before creating a pull request session", async () => {
@@ -212,7 +211,7 @@ describe("session-start-workflow", () => {
         sendAgentMessage,
       }),
     ).rejects.toThrow(
-      "Pull request generation requires an explicit target branch; '@{upstream}' cannot identify a provider base branch.",
+      "Pull request generation requires an explicit target branch; '@{upstream}' cannot identify a pull request base branch.",
     );
 
     expect(startAgentSession).not.toHaveBeenCalled();

--- a/packages/frontend/src/features/session-start/session-start-workflow.test.ts
+++ b/packages/frontend/src/features/session-start/session-start-workflow.test.ts
@@ -137,15 +137,15 @@ describe("session-start-workflow", () => {
     expect(sendAgentMessage).toHaveBeenCalledWith(sessionIdentity("session-pr"), [
       expect.objectContaining({
         kind: "text",
-        text: expect.stringContaining("comparisonRef: upstream/release/2026.04"),
+        text: expect.stringContaining("Base ref: upstream/release/2026.04"),
       }),
     ]);
     const sentCalls = sendAgentMessage.mock.calls as unknown as Array<
       [ReturnType<typeof sessionIdentity>, Array<{ text?: string }>]
     >;
     const sentText = sentCalls[0]?.[1]?.[0]?.text ?? "";
-    expect(sentText).toContain("branch: release/2026.04");
-    expect(sentText).not.toContain("comparisonRef: origin/main");
+    expect(sentText).toContain("Base branch: release/2026.04");
+    expect(sentText).not.toContain("Base ref: origin/main");
   });
 
   test("uses the explicit branch name as the provider base for origin targets", async () => {
@@ -180,8 +180,8 @@ describe("session-start-workflow", () => {
       [ReturnType<typeof sessionIdentity>, Array<{ text?: string }>]
     >;
     const sentText = sentCalls[0]?.[1]?.[0]?.text ?? "";
-    expect(sentText).toContain("comparisonRef: origin/main");
-    expect(sentText).toContain("branch: main");
+    expect(sentText).toContain("Base ref: origin/main");
+    expect(sentText).toContain("Base branch: main");
   });
 
   test("rejects upstream-relative targets before creating a pull request session", async () => {

--- a/packages/frontend/src/features/session-start/session-start-workflow.test.ts
+++ b/packages/frontend/src/features/session-start/session-start-workflow.test.ts
@@ -144,7 +144,7 @@ describe("session-start-workflow", () => {
       [ReturnType<typeof sessionIdentity>, Array<{ text?: string }>]
     >;
     const sentText = sentCalls[0]?.[1]?.[0]?.text ?? "";
-    expect(sentText).toContain("pullRequestBaseBranch: release/2026.04");
+    expect(sentText).toContain("branch: release/2026.04");
     expect(sentText).not.toContain("comparisonRef: origin/main");
   });
 
@@ -181,7 +181,7 @@ describe("session-start-workflow", () => {
     >;
     const sentText = sentCalls[0]?.[1]?.[0]?.text ?? "";
     expect(sentText).toContain("comparisonRef: origin/main");
-    expect(sentText).toContain("pullRequestBaseBranch: main");
+    expect(sentText).toContain("branch: main");
   });
 
   test("rejects upstream-relative targets before creating a pull request session", async () => {

--- a/packages/frontend/src/features/session-start/session-start-workflow.test.ts
+++ b/packages/frontend/src/features/session-start/session-start-workflow.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, mock, test } from "bun:test";
+import type { RepoConfig } from "@openducktor/contracts";
 import { QueryClient } from "@tanstack/react-query";
-import { createTaskCardFixture } from "@/test-utils/shared-test-fixtures";
+import { workspaceQueryKeys } from "@/state/queries/workspace";
+import {
+  createSettingsSnapshotFixture,
+  createTaskCardFixture,
+} from "@/test-utils/shared-test-fixtures";
 import { startSessionWorkflow } from "./session-start-workflow";
 
 const BUILD_SELECTION = {
@@ -181,6 +186,74 @@ describe("session-start-workflow", () => {
     const sentText = sentCalls[0]?.[1]?.[0]?.text ?? "";
     expect(sentText).toContain("Pull request base:\nmain");
     expect(sentText).not.toContain("origin/main");
+  });
+
+  test("uses the repository default target for a forked pull request kickoff", async () => {
+    const queryClient = new QueryClient();
+    const repoConfig = {
+      workspaceId: "workspace-pr",
+      workspaceName: "PR workspace",
+      repoPath: "/repo",
+      defaultRuntimeKind: "opencode",
+      branchPrefix: "odt",
+      defaultTargetBranch: {
+        remote: "upstream",
+        branch: "develop",
+      },
+      git: { providers: {} },
+      hooks: { preStart: [], postComplete: [] },
+      devServers: [],
+      worktreeCopyPaths: [],
+      promptOverrides: {},
+      agentDefaults: {},
+    } satisfies RepoConfig;
+    queryClient.setQueryData(workspaceQueryKeys.repoConfig("workspace-pr"), repoConfig);
+    queryClient.setQueryData(
+      workspaceQueryKeys.settingsSnapshot(),
+      createSettingsSnapshotFixture({
+        workspaces: {
+          "workspace-pr": repoConfig,
+        },
+      }),
+    );
+    const sendAgentMessage = mock(async () => undefined);
+    const startAgentSession = mock(async () => sessionIdentity("session-pr-fork"));
+    const sourceSession = sessionIdentity("builder-session-fork");
+
+    await startSessionWorkflow({
+      workspaceId: "workspace-pr",
+      queryClient,
+      intent: {
+        taskId: "TASK-FORK",
+        role: "build",
+        launchActionId: "build_pull_request_generation",
+        startMode: "fork",
+        sourceSession,
+        postStartAction: "kickoff",
+      },
+      selection: BUILD_SELECTION,
+      task: createTaskCardFixture({
+        id: "TASK-FORK",
+        title: "Fork for pull request",
+      }),
+      startAgentSession,
+      sendAgentMessage,
+    });
+
+    expect(startAgentSession).toHaveBeenCalledWith({
+      taskId: "TASK-FORK",
+      role: "build",
+      startMode: "fork",
+      selectedModel: BUILD_SELECTION,
+      sourceSession,
+      holdForPostStartMessage: true,
+    });
+    expect(sendAgentMessage).toHaveBeenCalledWith(sessionIdentity("session-pr-fork"), [
+      expect.objectContaining({
+        kind: "text",
+        text: expect.stringContaining("Pull request base:\ndevelop"),
+      }),
+    ]);
   });
 
   test("rejects upstream-relative targets before creating a pull request session", async () => {

--- a/packages/frontend/src/features/session-start/session-start-workflow.ts
+++ b/packages/frontend/src/features/session-start/session-start-workflow.ts
@@ -1,12 +1,17 @@
 import type { GitTargetBranch, TaskCard } from "@openducktor/contracts";
 import type {
   AgentModelSelection,
+  AgentPromptGitContext,
   AgentRole,
   AgentSessionStartMode,
   AgentUserMessagePart,
 } from "@openducktor/core";
 import type { QueryClient } from "@tanstack/react-query";
-import { canonicalTargetBranch, effectiveTaskTargetBranch } from "@/lib/target-branch";
+import {
+  canonicalTargetBranch,
+  effectiveTaskTargetBranch,
+  UPSTREAM_TARGET_BRANCH,
+} from "@/lib/target-branch";
 import { loadEffectivePromptOverrides } from "@/state/operations/prompt-overrides";
 import { loadRepoConfigFromQuery } from "@/state/queries/workspace";
 import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
@@ -193,17 +198,22 @@ const buildPostStartMessage = async ({
   const repoDefaultTargetBranch = workspaceId
     ? (await loadRepoConfigFromQuery(queryClient, workspaceId)).defaultTargetBranch
     : null;
-  const git =
-    kickoffTemplateId === "kickoff.build_pull_request_generation"
-      ? {
-          targetBranch: canonicalTargetBranch(
-            effectiveTaskTargetBranch(
-              intent.targetBranch ?? task?.targetBranch,
-              repoDefaultTargetBranch,
-            ),
-          ),
-        }
-      : undefined;
+  let git: AgentPromptGitContext | undefined;
+  if (kickoffTemplateId === "kickoff.build_pull_request_generation") {
+    const targetBranch = effectiveTaskTargetBranch(
+      intent.targetBranch ?? task?.targetBranch,
+      repoDefaultTargetBranch,
+    );
+    if (targetBranch.branch === UPSTREAM_TARGET_BRANCH) {
+      throw new Error(
+        "Pull request generation requires an explicit target branch; '@{upstream}' cannot identify a provider base branch.",
+      );
+    }
+    git = {
+      targetBranch: canonicalTargetBranch(targetBranch),
+      pullRequestBaseBranch: targetBranch.branch,
+    };
+  }
 
   return kickoffPromptForTemplate(intent.role, kickoffTemplateId, intent.taskId, {
     overrides: promptOverrides ?? {},

--- a/packages/frontend/src/features/session-start/session-start-workflow.ts
+++ b/packages/frontend/src/features/session-start/session-start-workflow.ts
@@ -6,13 +6,16 @@ import type {
   AgentUserMessagePart,
 } from "@openducktor/core";
 import type { QueryClient } from "@tanstack/react-query";
-import { effectiveTaskTargetBranch } from "@/lib/target-branch";
 import { loadEffectivePromptOverrides } from "@/state/operations/prompt-overrides";
 import { loadRepoConfigFromQuery } from "@/state/queries/workspace";
 import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
 import type { StartAgentSession } from "@/types/agent-session-start";
 import type { SessionLaunchActionId } from "./session-start-launch-options";
 import { getSessionLaunchAction } from "./session-start-launch-options";
+import {
+  FEEDBACK_MESSAGE_REQUIRED_ERROR,
+  resolveSessionStartKickoffPromptContext,
+} from "./session-start-prompt-context";
 import { kickoffPromptForTemplate } from "./session-start-prompts";
 
 export type SendAgentMessage = (
@@ -157,8 +160,6 @@ const toError = (error: unknown): Error => {
   return error instanceof Error ? error : new Error(String(error));
 };
 
-const FEEDBACK_MESSAGE_REQUIRED_ERROR = "Feedback message is required before sending.";
-
 const buildPostStartMessage = async ({
   queryClient,
   intent,
@@ -180,37 +181,25 @@ const buildPostStartMessage = async ({
   if (!kickoffTemplateId) {
     throw new Error(`Launch action "${intent.launchActionId}" does not define a kickoff prompt.`);
   }
-  const humanFeedback =
-    kickoffTemplateId === "kickoff.build_after_human_request_changes"
-      ? (intent.message?.trim() ?? "")
-      : undefined;
-  if (kickoffTemplateId === "kickoff.build_after_human_request_changes" && !humanFeedback) {
-    throw new Error(FEEDBACK_MESSAGE_REQUIRED_ERROR);
-  }
   const promptOverrides = workspaceId
     ? await loadEffectivePromptOverrides(workspaceId, queryClient)
     : undefined;
-  const repoDefaultTargetBranch = workspaceId
-    ? (await loadRepoConfigFromQuery(queryClient, workspaceId)).defaultTargetBranch
-    : null;
-  let targetBranch: GitTargetBranch | undefined;
-  if (kickoffTemplateId === "kickoff.build_pull_request_generation") {
-    targetBranch = effectiveTaskTargetBranch(
-      intent.targetBranch ?? task?.targetBranch,
-      repoDefaultTargetBranch,
-    );
-  }
+  const taskTargetBranch = intent.targetBranch ?? task?.targetBranch;
+  const promptContext = await resolveSessionStartKickoffPromptContext({
+    templateId: kickoffTemplateId,
+    ...(intent.message === undefined ? {} : { message: intent.message }),
+    ...(taskTargetBranch ? { taskTargetBranch } : {}),
+    loadRepoDefaultTargetBranch: async () => {
+      if (!workspaceId) {
+        return null;
+      }
+      return (await loadRepoConfigFromQuery(queryClient, workspaceId)).defaultTargetBranch;
+    },
+  });
 
   return kickoffPromptForTemplate(intent.role, kickoffTemplateId, intent.taskId, {
     overrides: promptOverrides ?? {},
-    ...(humanFeedback
-      ? {
-          extraPlaceholders: {
-            humanFeedback,
-          },
-        }
-      : {}),
-    ...(targetBranch ? { targetBranch } : {}),
+    ...promptContext,
     task:
       task === null
         ? {}

--- a/packages/frontend/src/features/session-start/session-start-workflow.ts
+++ b/packages/frontend/src/features/session-start/session-start-workflow.ts
@@ -1,17 +1,12 @@
 import type { GitTargetBranch, TaskCard } from "@openducktor/contracts";
 import type {
   AgentModelSelection,
-  AgentPromptGitContext,
   AgentRole,
   AgentSessionStartMode,
   AgentUserMessagePart,
 } from "@openducktor/core";
 import type { QueryClient } from "@tanstack/react-query";
-import {
-  canonicalTargetBranch,
-  effectiveTaskTargetBranch,
-  UPSTREAM_TARGET_BRANCH,
-} from "@/lib/target-branch";
+import { effectiveTaskTargetBranch } from "@/lib/target-branch";
 import { loadEffectivePromptOverrides } from "@/state/operations/prompt-overrides";
 import { loadRepoConfigFromQuery } from "@/state/queries/workspace";
 import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
@@ -198,21 +193,12 @@ const buildPostStartMessage = async ({
   const repoDefaultTargetBranch = workspaceId
     ? (await loadRepoConfigFromQuery(queryClient, workspaceId)).defaultTargetBranch
     : null;
-  let git: AgentPromptGitContext | undefined;
+  let targetBranch: GitTargetBranch | undefined;
   if (kickoffTemplateId === "kickoff.build_pull_request_generation") {
-    const targetBranch = effectiveTaskTargetBranch(
+    targetBranch = effectiveTaskTargetBranch(
       intent.targetBranch ?? task?.targetBranch,
       repoDefaultTargetBranch,
     );
-    if (targetBranch.branch === UPSTREAM_TARGET_BRANCH) {
-      throw new Error(
-        "Pull request generation requires an explicit target branch; '@{upstream}' cannot identify a provider base branch.",
-      );
-    }
-    git = {
-      targetBranch: canonicalTargetBranch(targetBranch),
-      pullRequestBaseBranch: targetBranch.branch,
-    };
   }
 
   return kickoffPromptForTemplate(intent.role, kickoffTemplateId, intent.taskId, {
@@ -224,7 +210,7 @@ const buildPostStartMessage = async ({
           },
         }
       : {}),
-    ...(git ? { git } : {}),
+    ...(targetBranch ? { targetBranch } : {}),
     task:
       task === null
         ? {}


### PR DESCRIPTION
## Summary

- The Generate Pull Request kickoff could produce weak pull requests because it centered a Builder session and did not give the agent one clear base branch.
- This change makes the current task the source of truth, supplies one plain base branch, requires repository guidance and templates, and makes failed hosted checks fix-and-rerun work.
- Other kickoff flows and provider publication logic are out of scope.

## Testing

- [x] bun run format:check
- [x] bun run lint
- [x] bun run typecheck
- [x] bun run test
- [x] bun run build
- [ ] Not applicable

## Checklist

- [x] No external docs need updates for this built-in prompt change
- [x] I added or updated relevant tests
- [x] I kept failures explicit instead of adding fallback logic
- [x] I linked related context below

## Related Issues

OpenDucktor task openduckto-62p8

## Breaking Changes

- [ ] No breaking changes
- [x] Breaking changes are described below

Enabled custom version-4 Generate Pull Request kickoff overrides must include `{{git.targetBranch}}`. Settings report the missing placeholder so the user can update the override. Disabled legacy overrides remain saveable and do not block unrelated settings changes.

## Additional Context

The prompt uses one plain base branch for Git operations and pull request provider tools. It intentionally ignores remote metadata. Its built-in version remains 5 while this branch is under review.