### PR TITLE
perf(tooling): speed up monorepo checks with TypeScript 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 env:
-  BUN_VERSION: 1.3.11
+  BUN_VERSION: 1.3.14
 
 jobs:
   react-doctor:

--- a/.github/workflows/dependency-hygiene-report.yml
+++ b/.github/workflows/dependency-hygiene-report.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BUN_VERSION: 1.3.11
+  BUN_VERSION: 1.3.14
 
 jobs:
   outdated-report:

--- a/.github/workflows/dependency-hygiene.yml
+++ b/.github/workflows/dependency-hygiene.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BUN_VERSION: 1.3.11
+  BUN_VERSION: 1.3.14
 
 jobs:
   knip-dependency-check:

--- a/.github/workflows/publish-homebrew-tap.yml
+++ b/.github/workflows/publish-homebrew-tap.yml
@@ -12,7 +12,7 @@ on:
         type: string
 
 env:
-  BUN_VERSION: 1.3.11
+  BUN_VERSION: 1.3.14
   DEFAULT_HOMEBREW_TAP_BRANCH: main
   DEFAULT_HOMEBREW_TAP_REPOSITORY: ${{ format('{0}/homebrew-openducktor', github.repository_owner) }}
 

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -17,7 +17,7 @@ on:
           - beta
 
 env:
-  BUN_VERSION: 1.3.11
+  BUN_VERSION: 1.3.14
 
 jobs:
   publish-mcp:

--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  BUN_VERSION: 1.3.11
+  BUN_VERSION: 1.3.14
 
 jobs:
   publish-web:

--- a/.github/workflows/release-desktop-electron.yml
+++ b/.github/workflows/release-desktop-electron.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  BUN_VERSION: 1.3.11
+  BUN_VERSION: 1.3.14
   XCODE_APP_PATH: /Applications/Xcode_26.2.app
 
 jobs:

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  BUN_VERSION: 1.3.11
+  BUN_VERSION: 1.3.14
   DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Thanks for contributing. This project is public, but it is still early and the c
 
 ## Quick Start
 
-1. Install the core tooling: Bun `1.3.11`, Node.js `22.12` or later, Xcode Command Line Tools, `git`, and at least one supported runtime (`opencode`, `codex`, or `claude`).
+1. Install the core tooling: Bun `1.3.14`, Node.js `22.12` or later, Xcode Command Line Tools, `git`, and at least one supported runtime (`opencode`, `codex`, or `claude`).
 2. Install workspace dependencies from the repository root:
 
 ```sh
@@ -41,7 +41,7 @@ Useful alternative:
 
 Core tooling:
 
-- Bun `1.3.11`
+- Bun `1.3.14`
 - Node.js `22.12` or later
 - Xcode Command Line Tools
 - `git`

--- a/apps/electron/tsconfig.json
+++ b/apps/electron/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "allowImportingTsExtensions": true,
-    "baseUrl": ".",
     "types": ["vite/client", "bun-types", "node"],
     "jsx": "react-jsx",
     "paths": {

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "knip": "^6.29.0",
         "oxfmt": "^0.63.0",
         "oxlint": "^1.78.0",
-        "typescript": "^5.7.3",
+        "typescript": "^7.0.2",
         "yaml": "^2.9.0",
         "zod": "^4.4.3",
       },
@@ -1030,6 +1030,46 @@
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.3", "", {}, "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg=="],
 
@@ -2133,7 +2173,7 @@
 
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,3 +33,4 @@ This folder contains the project documentation for OpenDucktor's current archite
 - [mcp-runtime-security.md](mcp-runtime-security.md): current MCP transport and threat assumptions.
 - [dependency-hygiene.md](dependency-hygiene.md): dependency update and audit policy.
 - [release-process.md](release-process.md): Electron desktop, MCP, web package, Homebrew, version sync, and draft publishing steps.
+- [typescript-toolchain.md](typescript-toolchain.md): supported TypeScript and Bun versions, editor requirements, and TypeScript 7 migration evidence.

--- a/docs/typescript-toolchain.md
+++ b/docs/typescript-toolchain.md
@@ -14,6 +14,8 @@ TypeScript 7 defaults `types` to an empty array. The MCP config declares `node` 
 
 The MCP declaration review emitted the package once with TypeScript 5.9.3 and once with TypeScript 7.0.2, then compared every generated `.d.ts` file. All files were byte-identical except `odt-task-store.d.ts`. Its diff only reordered object properties and union members; it added or removed no API member or union value. No tracked snapshot or release check depends on declaration order.
 
+The MCP clean build keeps composite build state inside `dist`, checks the full JavaScript and declaration artifact set, and removes the build metadata before packaging. Its build regression test runs this clean build twice so stale state cannot hide missing declarations.
+
 The browser terminal transport copies each outgoing `Uint8Array` with `frame.slice()` before `WebSocket.send`. This creates an `ArrayBuffer`-backed view at the browser boundary and leaves incoming `ArrayBuffer` frames unchanged.
 
 ## Verification Baseline

--- a/docs/typescript-toolchain.md
+++ b/docs/typescript-toolchain.md
@@ -1,0 +1,23 @@
+# TypeScript Toolchain
+
+OpenDucktor uses TypeScript 7.0.2 and Bun 1.3.14. Keep the root `packageManager` field and every workflow `BUN_VERSION` pin in sync when Bun changes.
+
+## Editor And Tool Support
+
+TypeScript 7 does not ship the legacy `tsserver` binary or its stable compiler API. Editors must use a TypeScript 7-aware language server instead of starting `node_modules/typescript/lib/tsserver.js`. The repository does not import `typescript` as a runtime or build API; it uses the package through the `tsc` command only.
+
+## TypeScript 7 Migration Review
+
+The TypeScript 7 migration removed `baseUrl` from the shared, Electron, frontend, and web TypeScript configs. Each remaining `paths` entry is relative to its owning config. Frontend modules consumed as source by another workspace package use relative imports for their own runtime dependencies so Bun does not need the consumer's `@/` alias to load them.
+
+TypeScript 7 defaults `types` to an empty array. The MCP config declares `node` and `bun-types`, and the Core config declares `node`, because those projects use those runtime globals.
+
+The MCP declaration review emitted the package once with TypeScript 5.9.3 and once with TypeScript 7.0.2, then compared every generated `.d.ts` file. All files were byte-identical except `odt-task-store.d.ts`. Its diff only reordered object properties and union members; it added or removed no API member or union value. No tracked snapshot or release check depends on declaration order.
+
+The browser terminal transport copies each outgoing `Uint8Array` with `frame.slice()` before `WebSocket.send`. This creates an `ArrayBuffer`-backed view at the browser boundary and leaves incoming `ArrayBuffer` frames unchanged.
+
+## Verification Baseline
+
+Run `bun install`, `bun run format:check`, `bun run lint`, `bun run typecheck`, `bun run test`, `bun run build`, `bun run deps:unused:deps`, and `bun run deps:unused:exports` from the repository root after a TypeScript or Bun change.
+
+On the TypeScript 7.0.2 migration branch, warm typecheck took 3.06 seconds against the TypeScript 5.9 baseline of 12.5–12.7 seconds. Warm build took 2.57 seconds against the 12.0 second baseline. These figures cover the full workspace commands on the same local checkout and are not CI service-level targets.

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "knip": "^6.29.0",
     "oxfmt": "^0.63.0",
     "oxlint": "^1.78.0",
-    "typescript": "^5.7.3",
+    "typescript": "^7.0.2",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
@@ -67,5 +67,5 @@
   "engines": {
     "node": ">=22.6.0"
   },
-  "packageManager": "bun@1.3.11"
+  "packageManager": "bun@1.3.14"
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,7 +4,8 @@
     "composite": true,
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import type { ChatSettings } from "@openducktor/contracts";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import type { NamedExoticComponent, ReactElement } from "react";
+import type { ReactElement } from "react";
 import { createChatSettingsFixture } from "@/test-utils/shared-test-fixtures";
 import type { FileEditData } from "./agent-chat-message-card-model";
 
@@ -11,10 +11,10 @@ const pierreDiffViewerModule = await import("@/components/features/agents/pierre
 type RestorableSpy = { mockRestore(): void };
 let pierreViewerSpies: RestorableSpy[] = [];
 
-const namedExoticMock = <Props,>(
-  component: (props: Props) => ReactElement | null,
-  original: NamedExoticComponent<Props>,
-): NamedExoticComponent<Props> => Object.assign(component, { $$typeof: original.$$typeof });
+const namedExoticMock = <MockComponent extends object, OriginalComponent extends object>(
+  component: MockComponent,
+  original: OriginalComponent,
+): MockComponent & OriginalComponent => Object.assign(component, original);
 
 const preloaderMock = mock(({ filePath }: { patch: string; filePath: string }) => (
   <div data-testid="pierre-diff-preloader">{filePath}</div>

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -160,6 +160,7 @@ describe("AgentChatThread", () => {
     globalThis.IntersectionObserver = class MockIntersectionObserver implements IntersectionObserver {
       readonly root = null;
       readonly rootMargin = "0px";
+      readonly scrollMargin = "0px";
       readonly thresholds = [0];
 
       disconnect(): void {}

--- a/packages/frontend/src/components/features/agents/agent-studio-git-panel/file-diff-list.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-git-panel/file-diff-list.test.tsx
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { act, type NamedExoticComponent, type ReactElement, useState } from "react";
+import { act, type ReactElement, useState } from "react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useInlineCommentDraftStore } from "@/state/use-inline-comment-draft-store";
 
@@ -8,10 +8,10 @@ const pierreDiffViewerModule = await import("@/components/features/agents/pierre
 type RestorableSpy = { mockRestore(): void };
 let pierreViewerSpies: RestorableSpy[] = [];
 
-const namedExoticMock = <Props,>(
-  component: (props: Props) => ReactElement | null,
-  original: NamedExoticComponent<Props>,
-): NamedExoticComponent<Props> => Object.assign(component, { $$typeof: original.$$typeof });
+const namedExoticMock = <MockComponent extends object, OriginalComponent extends object>(
+  component: MockComponent,
+  original: OriginalComponent,
+): MockComponent & OriginalComponent => Object.assign(component, original);
 
 type FileDiffListComponent = (typeof import("./file-diff-list"))["FileDiffList"];
 

--- a/packages/frontend/src/lib/browser-live-control-events.ts
+++ b/packages/frontend/src/lib/browser-live-control-events.ts
@@ -1,9 +1,9 @@
 import {
   BROWSER_LIVE_RECONNECTED_EVENT_KIND,
   BROWSER_LIVE_STREAM_WARNING_EVENT_KIND,
-} from "@/lib/browser-live/constants";
+} from "./browser-live/constants";
 import type { DevServerEvent } from "@openducktor/contracts";
-import type { BrowserLiveControlEvent, BrowserLiveControlEventKind } from "@/types";
+import type { BrowserLiveControlEvent, BrowserLiveControlEventKind } from "../types";
 
 export function browserLiveControlEvent(
   kind: typeof BROWSER_LIVE_RECONNECTED_EVENT_KIND,

--- a/packages/frontend/src/startup-splash/runtime.ts
+++ b/packages/frontend/src/startup-splash/runtime.ts
@@ -1,4 +1,4 @@
-import { scheduleTask, type ScheduleTask } from "@/lib/scheduling";
+import { scheduleTask, type ScheduleTask } from "../lib/scheduling";
 
 const STARTUP_SPLASH_ID = "openducktor-startup";
 const STARTUP_SPLASH_STATUS_SELECTOR = "[data-odt-startup-status]";

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "types": ["vite/client", "node", "bun-types"],
     "paths": {
       "@/*": ["./src/*"]

--- a/packages/openducktor-mcp/scripts/build.test.ts
+++ b/packages/openducktor-mcp/scripts/build.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { readdir } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildMcpPackage, MCP_PACKAGE_BUILD_ARTIFACTS } from "./build";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(scriptDirectory, "..");
+const distDirectory = join(packageRoot, "dist");
+
+const expectedBuildArtifacts = [...MCP_PACKAGE_BUILD_ARTIFACTS].sort();
+
+describe("MCP package build", () => {
+  test("emits the published JavaScript and declaration artifacts after every clean build", async () => {
+    await buildMcpPackage();
+    expect((await readdir(distDirectory)).sort()).toEqual(expectedBuildArtifacts);
+
+    await buildMcpPackage();
+    expect((await readdir(distDirectory)).sort()).toEqual(expectedBuildArtifacts);
+  }, 15_000);
+});

--- a/packages/openducktor-mcp/scripts/build.ts
+++ b/packages/openducktor-mcp/scripts/build.ts
@@ -1,13 +1,43 @@
+import { stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { cleanDirectory, markExecutable, runCommand } from "@openducktor/build-tools";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(scriptDirectory, "..");
-const outputPath = join(packageRoot, "dist", "index.js");
+const distDirectory = join(packageRoot, "dist");
+const outputPath = join(distDirectory, "index.js");
+const buildInfoPath = join(distDirectory, "tsconfig.tsbuildinfo");
+
+export const MCP_PACKAGE_BUILD_ARTIFACTS = [
+  "host-bridge-client.d.ts",
+  "index.d.ts",
+  "index.js",
+  "lib.d.ts",
+  "listed-tool-schema.d.ts",
+  "mcp-server.d.ts",
+  "odt-task-store.d.ts",
+  "path-utils.d.ts",
+  "store-context.d.ts",
+  "tool-results.d.ts",
+] as const;
+
+const assertBuildArtifacts = async (): Promise<void> => {
+  await Promise.all(
+    MCP_PACKAGE_BUILD_ARTIFACTS.map(async (artifact) => {
+      const artifactPath = join(distDirectory, artifact);
+      const metadata = await stat(artifactPath).catch((cause: unknown) => {
+        throw new Error(`MCP package build artifact is missing: ${artifactPath}`, { cause });
+      });
+      if (!metadata.isFile()) {
+        throw new Error(`MCP package build artifact is not a file: ${artifactPath}`);
+      }
+    }),
+  );
+};
 
 export const buildMcpPackage = async (): Promise<void> => {
-  await cleanDirectory(join(packageRoot, "dist"));
+  await cleanDirectory(distDirectory);
   await runCommand({
     command: [
       "bun",
@@ -28,6 +58,8 @@ export const buildMcpPackage = async (): Promise<void> => {
     cwd: packageRoot,
     label: "MCP package declaration build",
   });
+  await assertBuildArtifacts();
+  await cleanDirectory(buildInfoPath);
 };
 
 if (import.meta.main) {

--- a/packages/openducktor-mcp/tsconfig.json
+++ b/packages/openducktor-mcp/tsconfig.json
@@ -7,6 +7,7 @@
     "noEmit": false,
     "rootDir": "src",
     "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "lib": ["ES2022"],
     "types": ["node", "bun-types"],
     "resolveJsonModule": true

--- a/packages/openducktor-mcp/tsconfig.json
+++ b/packages/openducktor-mcp/tsconfig.json
@@ -8,6 +8,7 @@
     "rootDir": "src",
     "outDir": "dist",
     "lib": ["ES2022"],
+    "types": ["node", "bun-types"],
     "resolveJsonModule": true
   },
   "include": ["src"],

--- a/packages/openducktor-web/src/browser-shell-bridge.ts
+++ b/packages/openducktor-web/src/browser-shell-bridge.ts
@@ -1,5 +1,8 @@
-import { createDisabledAppUpdateBridge, type ShellBridge } from "@openducktor/frontend";
 import { getAppVersion } from "@openducktor/frontend/lib/app-version";
+import {
+  createDisabledAppUpdateBridge,
+  type ShellBridge,
+} from "@openducktor/frontend/lib/shell-bridge";
 import { Effect } from "effect";
 import { getBrowserBackendUrlEffect } from "./browser-config";
 import { validateExternalBrowserUrlEffect } from "./browser-url-validation";

--- a/packages/openducktor-web/src/terminals/browser-terminal-transport.test.ts
+++ b/packages/openducktor-web/src/terminals/browser-terminal-transport.test.ts
@@ -22,7 +22,8 @@ class FakeWebSocket extends EventTarget implements WebSocket {
   onerror: ((this: WebSocket, event: Event) => void) | null = null;
   onmessage: ((this: WebSocket, event: MessageEvent) => void) | null = null;
   onopen: ((this: WebSocket, event: Event) => void) | null = null;
-  readyState = 0;
+  readyState: WebSocket["readyState"] = FakeWebSocket.CONNECTING;
+  readonly sentData: (string | ArrayBufferLike | Blob | ArrayBufferView)[] = [];
 
   readonly url: string;
   readonly protocol: string;
@@ -34,7 +35,9 @@ class FakeWebSocket extends EventTarget implements WebSocket {
     FakeWebSocket.instances.push(this);
   }
 
-  send(_data: string | ArrayBufferLike | Blob | ArrayBufferView): void {}
+  send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void {
+    this.sentData.push(data);
+  }
 
   close(_code?: number, _reason?: string): void {
     this.readyState = 3;
@@ -48,6 +51,10 @@ class FakeWebSocket extends EventTarget implements WebSocket {
   emitClose(code: number, reason: string): void {
     this.readyState = 3;
     this.dispatchEvent(Object.assign(new Event("close"), { code, reason }));
+  }
+
+  emitMessage(data: ArrayBuffer): void {
+    this.dispatchEvent(new MessageEvent("message", { data }));
   }
 }
 
@@ -77,6 +84,46 @@ afterEach(() => {
 });
 
 describe("createBrowserTerminalBridge", () => {
+  test("copies outgoing frames to an ArrayBuffer-backed view", async () => {
+    const bridge = createBrowserTerminalBridge();
+    const connecting = bridge.connect(
+      () => undefined,
+      () => undefined,
+      () => undefined,
+    );
+    const socket = await waitForSocket();
+    socket.emitOpen();
+    const connection = await connecting;
+    const frame = new Uint8Array(new SharedArrayBuffer(3));
+    frame.set([1, 2, 3]);
+
+    await connection.send(frame);
+
+    const sent = socket.sentData[0];
+    expect(sent).toBeInstanceOf(Uint8Array);
+    if (!(sent instanceof Uint8Array)) throw new Error("Expected a Uint8Array WebSocket frame.");
+    expect(sent).not.toBe(frame);
+    expect(sent.buffer).toBeInstanceOf(ArrayBuffer);
+    expect(Array.from(sent)).toEqual([1, 2, 3]);
+  });
+
+  test("forwards incoming ArrayBuffer frames", async () => {
+    const frames: Uint8Array[] = [];
+    const bridge = createBrowserTerminalBridge();
+    const connecting = bridge.connect(
+      (frame) => frames.push(frame),
+      () => undefined,
+      () => undefined,
+    );
+    const socket = await waitForSocket();
+    socket.emitOpen();
+    await connecting;
+
+    socket.emitMessage(Uint8Array.from([4, 5, 6]).buffer);
+
+    expect(frames.map((frame) => Array.from(frame))).toEqual([[4, 5, 6]]);
+  });
+
   test("reports an abnormal WebSocket close before marking the transport disconnected", async () => {
     const failures: TerminalFailure[] = [];
     const states: string[] = [];

--- a/packages/openducktor-web/src/terminals/browser-terminal-transport.ts
+++ b/packages/openducktor-web/src/terminals/browser-terminal-transport.ts
@@ -65,7 +65,7 @@ export const createBrowserTerminalBridge = (): TerminalBridge => ({
             if (socket.readyState !== WebSocket.OPEN) {
               throw new Error("Terminal WebSocket is disconnected.");
             }
-            socket.send(frame);
+            socket.send(frame.slice());
           },
           close: async () => {
             socket.close(1000, "Terminal renderer disconnected.");

--- a/packages/openducktor-web/tsconfig.json
+++ b/packages/openducktor-web/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "declaration": true,
     "emitDeclarationOnly": false,
     "types": ["vite/client", "node", "bun-types"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,7 +13,6 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": true,
-    "baseUrl": "."
+    "exactOptionalPropertyTypes": true
   }
 }


### PR DESCRIPTION
TypeScript 5.9 made monorepo typechecks and builds slower than needed, while the TypeScript 7 migration requires stricter config, runtime type, and WebSocket boundary updates.

## Goal

Upgrade the workspace to TypeScript 7.0.2 without weakening type safety, runtime behavior, editor support, or published package contents. The MCP clean build now emits and checks its complete declaration set on every run, and contributor guidance uses the pinned Bun 1.3.14 toolchain.

## Performance result

- Warm `bun run typecheck`: 12.5–12.7 seconds with TypeScript 5.9, 3.06 seconds with TypeScript 7.0.2.
- Warm `bun run build`: 12.0 seconds with TypeScript 5.9, 2.57 seconds with TypeScript 7.0.2.
- The gains apply to TypeScript compiler work; Vite, Bun, and Electron bundling do not receive the same compiler speedup.

The MCP declaration comparison found only deterministic property and union-member ordering changes in `odt-task-store.d.ts`, with no semantic API change. A repeated clean-build regression test and npm package dry run confirm that `dist/index.d.ts` and the full expected declaration set ship with the package.

The branch passes Bun install, format, lint, all 13 TypeScript project checks, the full workspace test suite, the full build and declaration emit, both Knip checks, focused browser terminal tests, repeated MCP clean builds, and npm package-content inspection.