### PR TITLE
fix(agent-studio): make repeated sidebar session clicks work

### DIFF
--- a/packages/frontend/src/pages/agents/query-sync/use-agent-studio-query-sync.ts
+++ b/packages/frontend/src/pages/agents/query-sync/use-agent-studio-query-sync.ts
@@ -6,6 +6,7 @@ import { useRepoNavigationPersistence } from "./use-repo-navigation-persistence"
 
 type UseAgentStudioQuerySyncArgs = {
   activeWorkspaceId: string | null;
+  locationKey: string;
   navigationType: "POP" | "PUSH" | "REPLACE";
   searchParams: URLSearchParams;
   setSearchParams: SetURLSearchParams;
@@ -13,11 +14,13 @@ type UseAgentStudioQuerySyncArgs = {
 
 export function useAgentStudioQuerySync({
   activeWorkspaceId,
+  locationKey,
   navigationType,
   searchParams,
   setSearchParams,
 }: UseAgentStudioQuerySyncArgs) {
   const { navigation, setNavigation, updateQuery } = useNavigationUrlSync({
+    locationKey,
     navigationType,
     searchParams,
     setSearchParams,

--- a/packages/frontend/src/pages/agents/query-sync/use-navigation-url-sync.ts
+++ b/packages/frontend/src/pages/agents/query-sync/use-navigation-url-sync.ts
@@ -11,6 +11,7 @@ import {
 } from "./agent-studio-navigation";
 
 type UseNavigationUrlSyncArgs = {
+  locationKey: string;
   navigationType: "POP" | "PUSH" | "REPLACE";
   searchParams: URLSearchParams;
   setSearchParams: SetURLSearchParams;
@@ -23,6 +24,7 @@ type UseNavigationUrlSyncResult = {
 };
 
 export function useNavigationUrlSync({
+  locationKey,
   navigationType,
   searchParams,
   setSearchParams,
@@ -67,7 +69,7 @@ export function useNavigationUrlSync({
       syncingFromSearchParamsRef.current = true;
       return parsed;
     });
-  }, [navigationType, searchParams]);
+  }, [locationKey, navigationType, searchParams]);
 
   useEffect(() => {
     if (syncingFromSearchParamsRef.current) {

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-route-session-model.ts
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-route-session-model.ts
@@ -1,5 +1,5 @@
 import { startTransition, useCallback, useEffect } from "react";
-import { useNavigationType, useSearchParams } from "react-router";
+import { useLocation, useNavigationType, useSearchParams } from "react-router";
 import type { AgentSessionSummary } from "@/state/agent-sessions-store";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import type { AgentStudioQueryUpdate } from "../query-sync/agent-studio-navigation";
@@ -40,6 +40,7 @@ export function useAgentsPageRouteSessionModel({
   repoSettings,
   isLoadingRepoSettings,
 }: UseAgentsPageRouteSessionModelArgs): AgentsPageRouteSessionModel {
+  const { key: locationKey } = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const navigationType = useNavigationType();
 
@@ -54,6 +55,7 @@ export function useAgentsPageRouteSessionModel({
     updateQuery,
   } = useAgentStudioQuerySync({
     activeWorkspaceId,
+    locationKey,
     navigationType,
     searchParams,
     setSearchParams,

--- a/packages/frontend/src/pages/agents/use-agent-studio-query-sync.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-query-sync.test.tsx
@@ -171,13 +171,14 @@ describe("useAgentStudioQuerySync", () => {
   test("reapplies a sidebar session when a new location keeps the same URL", async () => {
     const searchParams = new URLSearchParams("task=task-1&session=session-1&agent=build");
     const setSearchParams: SetURLSearchParams = () => {};
-    const harness = createHookHarness({
+    const initialProps: HookArgsWithDefaults = {
       activeWorkspaceId: null,
       locationKey: "sidebar-location-1",
       navigationType: "PUSH",
       searchParams,
       setSearchParams,
-    });
+    };
+    const harness = createHookHarness(initialProps);
 
     await harness.mount();
     await harness.run((state) => {
@@ -186,11 +187,8 @@ describe("useAgentStudioQuerySync", () => {
     expect(harness.getLatest().sessionExternalIdParam).toBe("session-2");
 
     await harness.update({
-      activeWorkspaceId: null,
+      ...initialProps,
       locationKey: "sidebar-location-2",
-      navigationType: "PUSH",
-      searchParams,
-      setSearchParams,
     });
 
     expect(harness.getLatest().sessionExternalIdParam).toBe("session-1");

--- a/packages/frontend/src/pages/agents/use-agent-studio-query-sync.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-query-sync.test.tsx
@@ -27,6 +27,7 @@ type StatefulQuerySyncArgs = {
 
 type HookArgsWithDefaults = {
   activeWorkspaceId: string | null;
+  locationKey: string;
   navigationType: HookArgs["navigationType"];
   searchParams: HookArgs["searchParams"];
   setSearchParams: HookArgs["setSearchParams"];
@@ -34,11 +35,13 @@ type HookArgsWithDefaults = {
 
 const normalizeHookArgs = ({
   activeWorkspaceId,
+  locationKey,
   navigationType,
   searchParams,
   setSearchParams,
 }: HookArgsWithDefaults): HookArgs => ({
   activeWorkspaceId,
+  locationKey,
   navigationType,
   searchParams,
   setSearchParams,
@@ -67,6 +70,7 @@ const createStatefulQuerySyncHarness = (initialProps: StatefulQuerySyncArgs) =>
     return useAgentStudioQuerySync(
       normalizeHookArgs({
         activeWorkspaceId,
+        locationKey: "stateful-location",
         navigationType: "REPLACE",
         searchParams,
         setSearchParams,
@@ -77,6 +81,7 @@ const createStatefulQuerySyncHarness = (initialProps: StatefulQuerySyncArgs) =>
 const withQuerySyncDefaults = (
   overrides: Partial<HookArgsWithDefaults> & Pick<HookArgsWithDefaults, "activeWorkspaceId">,
 ): HookArgsWithDefaults => ({
+  locationKey: "location-1",
   navigationType: "REPLACE",
   searchParams: new URLSearchParams(""),
   setSearchParams: () => {},
@@ -92,6 +97,7 @@ describe("useAgentStudioQuerySync", () => {
 
     const harness = createHookHarness({
       activeWorkspaceId: null,
+      locationKey: "location-1",
       navigationType: "REPLACE",
       searchParams: new URLSearchParams("task=task-1&agent=build"),
       setSearchParams,
@@ -133,6 +139,7 @@ describe("useAgentStudioQuerySync", () => {
 
     const harness = createHookHarness({
       activeWorkspaceId: null,
+      locationKey: "location-1",
       navigationType: "REPLACE",
       searchParams: new URLSearchParams("task=task-1&agent=spec"),
       setSearchParams,
@@ -145,6 +152,7 @@ describe("useAgentStudioQuerySync", () => {
 
     await harness.update({
       activeWorkspaceId: null,
+      locationKey: "location-2",
       navigationType: "POP",
       searchParams: new URLSearchParams("task=task-2&session=session-2&agent=planner"),
       setSearchParams,
@@ -157,6 +165,35 @@ describe("useAgentStudioQuerySync", () => {
 
     expect(calls).toHaveLength(0);
 
+    await harness.unmount();
+  });
+
+  test("reapplies a sidebar session when a new location keeps the same URL", async () => {
+    const searchParams = new URLSearchParams("task=task-1&session=session-1&agent=build");
+    const setSearchParams: SetURLSearchParams = () => {};
+    const harness = createHookHarness({
+      activeWorkspaceId: null,
+      locationKey: "sidebar-location-1",
+      navigationType: "PUSH",
+      searchParams,
+      setSearchParams,
+    });
+
+    await harness.mount();
+    await harness.run((state) => {
+      state.updateQuery({ session: "session-2" });
+    });
+    expect(harness.getLatest().sessionExternalIdParam).toBe("session-2");
+
+    await harness.update({
+      activeWorkspaceId: null,
+      locationKey: "sidebar-location-2",
+      navigationType: "PUSH",
+      searchParams,
+      setSearchParams,
+    });
+
+    expect(harness.getLatest().sessionExternalIdParam).toBe("session-1");
     await harness.unmount();
   });
 

--- a/packages/frontend/src/pages/agents/use-navigation-url-sync.test.tsx
+++ b/packages/frontend/src/pages/agents/use-navigation-url-sync.test.tsx
@@ -26,6 +26,7 @@ describe("useNavigationUrlSync", () => {
 
     try {
       const harness = createHookHarness({
+        locationKey: "location-1",
         navigationType: "REPLACE",
         searchParams: new URLSearchParams("task=task-1&agent=build&autostart=1&start=now"),
         setSearchParams,
@@ -74,6 +75,7 @@ describe("useNavigationUrlSync", () => {
     };
 
     const harness = createHookHarness({
+      locationKey: "location-1",
       navigationType: "REPLACE",
       searchParams: new URLSearchParams("task=task-1&agent=spec"),
       setSearchParams,
@@ -88,6 +90,7 @@ describe("useNavigationUrlSync", () => {
     expect(calls).toHaveLength(0);
 
     await harness.update({
+      locationKey: "location-2",
       navigationType: "POP",
       searchParams: new URLSearchParams("task=task-2&session=session-2&agent=planner"),
       setSearchParams,
@@ -110,6 +113,7 @@ describe("useNavigationUrlSync", () => {
     };
 
     const harness = createHookHarness({
+      locationKey: "location-1",
       navigationType: "REPLACE",
       searchParams: new URLSearchParams("task=task-1&agent=build&autostart=1&start=now"),
       setSearchParams,
@@ -137,6 +141,7 @@ describe("useNavigationUrlSync", () => {
     }
 
     await harness.update({
+      locationKey: "location-2",
       navigationType: "REPLACE",
       searchParams: firstNext,
       setSearchParams,
@@ -150,6 +155,7 @@ describe("useNavigationUrlSync", () => {
     expect(calls).toHaveLength(2);
 
     await harness.update({
+      locationKey: "location-3",
       navigationType: "REPLACE",
       searchParams: secondNext,
       setSearchParams,
@@ -172,6 +178,7 @@ describe("useNavigationUrlSync", () => {
     };
 
     const harness = createHookHarness({
+      locationKey: "location-1",
       navigationType: "REPLACE",
       searchParams: new URLSearchParams("task=task-1&agent=build&autostart=1&start=now"),
       setSearchParams,
@@ -193,6 +200,7 @@ describe("useNavigationUrlSync", () => {
     }
 
     await harness.update({
+      locationKey: "location-2",
       navigationType: "POP",
       searchParams: previousUrl,
       setSearchParams,


### PR DESCRIPTION
Clicking an active session in the left sidebar could appear to do nothing when the URL already matched an earlier session location. Agent Studio tabs kept working because they update local selection before URL persistence.

This PR makes each React Router location an explicit URL-sync signal, so a repeated same-URL sidebar click reapplies the requested session while preserving self-authored URL echoes and browser back navigation.

It adds focused regression coverage for the same-search navigation case. No schema, migration, setup, or runtime contract changes are required. Live browser E2E coverage remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation state synchronization when moving between locations with the same URL.
  - Sidebar sessions are now correctly restored after navigation, preventing stale or missing session state.

- **Tests**
  - Added coverage for restoring sidebar sessions when the navigation location changes without a URL change.
  - Expanded synchronization tests to validate behavior across multiple navigation locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->