### PR TITLE
fix(opencode): load slash commands from current runtimes

### DIFF
--- a/packages/adapters-opencode-sdk/src/catalog-and-mcp.test.ts
+++ b/packages/adapters-opencode-sdk/src/catalog-and-mcp.test.ts
@@ -96,6 +96,32 @@ describe("catalog-and-mcp listAvailableSlashCommands", () => {
     expect(catalog.commands.map((command) => command.id)).toEqual(["system:compact", "review"]);
   });
 
+  test("accepts nullable metadata and lazy templates from the runtime", async () => {
+    const catalog = await listAvailableSlashCommands(
+      () => ({
+        command: {
+          list: async () => ({
+            data: [
+              {
+                name: "review",
+                description: null,
+                agent: null,
+                model: null,
+                source: null,
+                template: {},
+                subtask: null,
+                hints: [],
+              },
+            ],
+          }),
+        },
+      }),
+      { runtimeEndpoint: "http://127.0.0.1:1234", workingDirectory: "/repo" },
+    );
+
+    expect(catalog.commands.map((command) => command.id)).toEqual(["system:compact", "review"]);
+  });
+
   test("fails when the slash command payload is not an array", async () => {
     await expect(
       listAvailableSlashCommands(() => ({ command: { list: async () => ({ data: {} }) } }), {

--- a/packages/adapters-opencode-sdk/src/opencode-ingress.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-ingress.ts
@@ -79,14 +79,10 @@ export type ParsedOpencodeAgent = z.infer<typeof opencodeAgentSchema>;
 export const opencodeAgentListPayloadSchema = z.array(opencodeAgentSchema);
 
 const opencodeSlashCommandSchema = z.object({
-  agent: z.string().optional(),
-  description: z.string().optional(),
+  description: z.string().nullish(),
   hints: z.array(z.string()),
-  model: z.string().optional(),
   name: z.string(),
-  source: z.enum(["command", "mcp", "skill"]).optional(),
-  subtask: z.boolean().optional(),
-  template: z.string(),
+  source: z.enum(["command", "mcp", "skill"]).nullish(),
 });
 
 export const opencodeSlashCommandListPayloadSchema = z.array(opencodeSlashCommandSchema);


### PR DESCRIPTION
OpenCode 1.18.25 can return null optional command metadata and lazy template objects. OpenDucktor validated unused fields against older SDK types, so slash-command loading failed before catalog mapping.

This PR narrows ingress validation to the command fields the catalog consumes and accepts nullable optional metadata. It keeps fail-fast array validation, command sorting, the reserved compact command, and duplicate-trigger checks. A regression test covers the payload shape observed from the current runtime.