### PR TITLE
fix(electron): keep native controls visible across themes

### DIFF
--- a/apps/electron/src/main/main.ts
+++ b/apps/electron/src/main/main.ts
@@ -9,6 +9,8 @@ import {
   appUpdateCheckInputSchema,
   appUpdateCommandResultSchema,
   appUpdateStateSchema,
+  settingsSnapshotSchema,
+  themeSchema,
 } from "@openducktor/contracts";
 import { OPEN_DUCKTOR_STARTUP_BACKGROUND } from "@openducktor/frontend/startup-splash/theme";
 import {
@@ -89,8 +91,18 @@ import { installApplicationMenu, registerWindowContextMenu } from "./main-menu";
 import { registerElectronTerminalIpc } from "./terminals/electron-terminal-ipc";
 import { createNodePtyPort } from "./terminals/node-pty-adapter";
 
-const { app, BrowserWindow, clipboard, ipcMain, nativeImage, net, protocol, session, shell } =
-  electron;
+const {
+  app,
+  BrowserWindow,
+  clipboard,
+  ipcMain,
+  nativeImage,
+  nativeTheme,
+  net,
+  protocol,
+  session,
+  shell,
+} = electron;
 const APPLICATION_NAME = "OpenDucktor";
 const currentVersion = resolveElectronAppVersion({
   isPackaged: app.isPackaged,
@@ -690,11 +702,19 @@ const registerIpcHandlers = (
   registerElectronTerminalIpc({ ipcMain, terminalService: hostCommandRouter.terminalService });
   registerElectronHostInvokeHandler(ipcMain, {
     isHostShutdownStarted: shutdownController.isHostShutdownStarted,
-    invoke: (command, args) => {
+    invoke: async (command, args) => {
       const operation = hostCommandRouter.invoke(command, args);
-      return runElectronHostInvoke(operation, (effect) =>
+      const result = await runElectronHostInvoke(operation, (effect) =>
         electronMainRuntimeBindings.runHostCommand(command, effect),
       );
+      if (result.ok) {
+        if (command === "workspace_get_settings_snapshot") {
+          nativeTheme.themeSource = settingsSnapshotSchema.parse(result.value).theme;
+        } else if (command === "set_theme") {
+          nativeTheme.themeSource = themeSchema.unwrap().parse(args?.theme);
+        }
+      }
+      return result;
     },
   });
 


### PR DESCRIPTION
Inactive native window controls could disappear against OpenDucktor's light surfaces because Electron kept the operating system appearance instead of the app's selected theme.

This PR makes the existing OpenDucktor theme setting control Electron-rendered native UI on macOS, Windows, and Linux. It applies the loaded settings snapshot at startup and updates Electron after a successful theme change.

The fix stays in the Electron host-command boundary and reuses the existing theme schemas. It adds no theme store and changes no persisted setting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now restores your saved theme when it starts.
  * Changing the theme immediately updates the native application appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->