### PR TITLE
fix(frontend): keep streamed markdown in sync

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-content.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-content.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { render } from "@testing-library/react";
+import { createElement } from "react";
+import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
+import type { AgentChatMessage } from "@/types/agent-orchestrator";
+import { MessageBody } from "./agent-chat-message-card-content";
+
+enableReactActEnvironment();
+
+const createAssistantMessage = (content: string): AgentChatMessage => ({
+  id: "assistant-streaming-markdown",
+  role: "assistant",
+  content,
+  timestamp: "2026-08-31T09:37:00.000Z",
+  meta: {
+    kind: "assistant",
+    agentRole: "build",
+    isFinal: false,
+  },
+});
+
+const createMessageBody = (content: string) =>
+  createElement(MessageBody, {
+    message: createAssistantMessage(content),
+    modelCatalog: null,
+    parentSession: null,
+    assistantAccentColor: undefined,
+    isStreamingAssistantMessage: true,
+    timeLabel: "",
+    systemPromptBody: "",
+    sessionWorkingDirectory: null,
+    toolCallPresentation: null,
+  });
+
+const createReasoningMessageBody = (content: string) =>
+  createElement(MessageBody, {
+    message: {
+      ...createAssistantMessage(content),
+      role: "thinking",
+      meta: {
+        kind: "reasoning",
+        partId: "reasoning-streaming-markdown",
+        completed: false,
+      },
+    },
+    modelCatalog: null,
+    parentSession: null,
+    assistantAccentColor: undefined,
+    isStreamingAssistantMessage: false,
+    timeLabel: "",
+    systemPromptBody: "",
+    sessionWorkingDirectory: null,
+    toolCallPresentation: null,
+  });
+
+describe("MessageBody streamed markdown", () => {
+  test("renders the current streamed markdown without delaying whitespace or syntax", () => {
+    const rendered = render(createMessageBody("Streamed"));
+
+    try {
+      rendered.rerender(createMessageBody("Streamed **markdown** text with spaces"));
+
+      expect(rendered.container.textContent).toContain("Streamed markdown text with spaces");
+      expect(rendered.container.querySelector("strong")?.textContent).toBe("markdown");
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("renders the current reasoning markdown without delaying whitespace or syntax", () => {
+    const rendered = render(createReasoningMessageBody("Reasoning"));
+
+    try {
+      rendered.rerender(createReasoningMessageBody("Reasoning **markdown** text with spaces"));
+
+      expect(rendered.container.textContent).toContain("Reasoning markdown text with spaces");
+      expect(rendered.container.querySelector("strong")?.textContent).toBe("markdown");
+    } finally {
+      rendered.unmount();
+    }
+  });
+});

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
@@ -5,17 +5,7 @@ import type {
   AgentUserMessageDisplayPart,
 } from "@openducktor/core";
 import { Brain, Cpu, Hammer, LoaderCircle } from "lucide-react";
-import {
-  Fragment,
-  type MouseEvent,
-  type ReactElement,
-  type ReactNode,
-  useCallback,
-  useDeferredValue,
-  useEffect,
-  useReducer,
-  useRef,
-} from "react";
+import { Fragment, type MouseEvent, type ReactElement, type ReactNode, useCallback } from "react";
 import { CopyIconButton } from "@/components/ui/copy-icon-button";
 import { buildCopyPreview } from "@/lib/copy-preview";
 import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
@@ -40,9 +30,6 @@ import { formatAgentDuration } from "./format-agent-duration";
 import type { ParentSessionRuntimeContext } from "./subagent-session-key";
 import { SubagentTranscriptButton } from "./subagent-transcript-button";
 
-const TEXT_RENDER_PACE_MS = 24;
-const TEXT_RENDER_SNAP = /[\s.,!?;:)\]]/;
-
 type TranscriptAttachmentReference = AgentAttachmentReference & {
   localPreviewAvailable?: boolean;
 };
@@ -63,96 +50,6 @@ const toTranscriptAttachment = (
     reference.localPreviewAvailable = attachment.localPreviewAvailable;
   }
   return reference;
-};
-
-const pacedStep = (size: number): number => {
-  if (size <= 12) {
-    return 2;
-  }
-  if (size <= 48) {
-    return 4;
-  }
-  if (size <= 96) {
-    return 8;
-  }
-  return Math.min(24, Math.ceil(size / 8));
-};
-
-const nextPacedBoundary = (text: string, start: number): number => {
-  const end = Math.min(text.length, start + pacedStep(text.length - start));
-  const max = Math.min(text.length, end + 8);
-  for (let index = end; index < max; index += 1) {
-    if (TEXT_RENDER_SNAP.test(text[index] ?? "")) {
-      return index + 1;
-    }
-  }
-  return end;
-};
-
-const usePacedStreamingText = (text: string, streaming: boolean): string => {
-  const [visibleText, dispatchVisibleText] = useReducer(
-    (_current: string, next: string) => next,
-    text,
-  );
-  const shownRef = useRef(text);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    const clearScheduled = () => {
-      if (timeoutRef.current !== null) {
-        clearTimeout(timeoutRef.current);
-        timeoutRef.current = null;
-      }
-    };
-
-    const sync = (nextText: string) => {
-      shownRef.current = nextText;
-      dispatchVisibleText(nextText);
-    };
-
-    const run = () => {
-      timeoutRef.current = null;
-      if (!streaming) {
-        sync(text);
-        return;
-      }
-      if (!text.startsWith(shownRef.current) || text.length <= shownRef.current.length) {
-        sync(text);
-        return;
-      }
-
-      const end = nextPacedBoundary(text, shownRef.current.length);
-      sync(text.slice(0, end));
-      if (end < text.length) {
-        timeoutRef.current = setTimeout(run, TEXT_RENDER_PACE_MS);
-      }
-    };
-
-    if (!streaming) {
-      clearScheduled();
-      sync(text);
-      return clearScheduled;
-    }
-
-    if (!text.startsWith(shownRef.current) || text.length < shownRef.current.length) {
-      clearScheduled();
-      sync(text);
-      return clearScheduled;
-    }
-
-    if (text.length !== shownRef.current.length && timeoutRef.current === null) {
-      timeoutRef.current = setTimeout(run, TEXT_RENDER_PACE_MS);
-    }
-
-    return () => {
-      if (timeoutRef.current !== null) {
-        clearTimeout(timeoutRef.current);
-        timeoutRef.current = null;
-      }
-    };
-  }, [streaming, text]);
-
-  return visibleText;
 };
 
 type MessageHeaderProps = {
@@ -212,15 +109,13 @@ const REASONING_MARKDOWN_CLASS_NAME = cn(
 
 const ReasoningMessage = ({ content, streaming }: ReasoningMessageProps): ReactElement => {
   const sourceText = streaming ? content || "Thinking…" : content;
-  const pacedContent = usePacedStreamingText(sourceText, streaming);
-  const renderedContent = useDeferredValue(pacedContent);
   return (
     <div className="px-1 py-0.5 text-muted-foreground">
       <div className="space-y-0.5 text-[13px] leading-relaxed">
         <span className="block text-[11px] font-medium text-muted-foreground">Thinking:</span>
         <div className="min-w-0">
           <AgentChatMarkdownRenderer
-            markdown={streaming ? renderedContent : pacedContent}
+            markdown={sourceText}
             streaming={streaming}
             variant="compact"
             className={REASONING_MARKDOWN_CLASS_NAME}
@@ -283,14 +178,12 @@ const AssistantMessage = ({
 }: AssistantMessageProps): ReactElement => {
   const streaming = isStreamingAssistantMessage;
   const copyable = canCopyAssistantMessage(message, isStreamingAssistantMessage);
-  const pacedContent = usePacedStreamingText(message.content, streaming);
-  const renderedContent = useDeferredValue(pacedContent);
   const footer = getAssistantFooterData(message, modelCatalog);
   return (
     <div className="group/message relative space-y-2 pr-9">
       {copyable ? <AssistantMessageCopyButton markdown={message.content} /> : null}
       <AgentChatMarkdownRenderer
-        markdown={streaming ? renderedContent : pacedContent}
+        markdown={message.content}
         streaming={streaming}
         variant="document"
       />


### PR DESCRIPTION
Streamed assistant and reasoning Markdown lagged behind the current runtime text because chat paced and deferred each update. Whitespace and syntax could remain missing until a later render, so live output differed from the final message.

This PR renders each streamed Markdown update from the current message content while keeping partial code-fence healing. It adds DOM regression coverage for whitespace and inline Markdown updates in both assistant and reasoning messages.