### PR TITLE
feat(host): resolve repository Git providers with typed ports

### DIFF
--- a/apps/electron/src/main/electron-host.test.ts
+++ b/apps/electron/src/main/electron-host.test.ts
@@ -665,7 +665,7 @@ describe("createElectronHostCommandRouter", () => {
       descriptor: createRuntimeDefinitionsService().listRuntimeDefinitions()[0],
     } satisfies RuntimeInstanceSummary;
     try {
-      const router = createElectronHostCommandRouter({
+      const router = await createElectronHostCommandRouter({
         lifecycleLogger: {
           info(message) {
             return Effect.sync(() => lifecycleLogs.push(message));
@@ -720,7 +720,7 @@ describe("createElectronHostCommandRouter", () => {
   });
 
   test("registers migrated filesystem host commands", async () => {
-    const router = createElectronHostCommandRouter({
+    const router = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -741,7 +741,7 @@ describe("createElectronHostCommandRouter", () => {
   });
 
   test("registers migrated workspace settings host commands", async () => {
-    const router = createElectronHostCommandRouter({
+    const router = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -756,7 +756,7 @@ describe("createElectronHostCommandRouter", () => {
   });
 
   test("registers migrated local attachment host commands", async () => {
-    const router = createElectronHostCommandRouter({
+    const router = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       localAttachments: createLocalAttachments(),
@@ -815,7 +815,7 @@ describe("createElectronHostCommandRouter", () => {
         }),
     };
     const runtimeRegistry = createRuntimeRegistry({ workspaceStarter });
-    const router = createElectronHostCommandRouter({
+    const router = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -893,7 +893,7 @@ describe("createElectronHostCommandRouter", () => {
 
   test("registers migrated passive dev server state command", async () => {
     const { eventBus, events } = createEventBus();
-    const router = createElectronHostCommandRouter({
+    const router = await createElectronHostCommandRouter({
       devServerProcesses: createDevServerProcesses(),
       eventBus,
       filesystem: createFilesystem(),
@@ -982,7 +982,7 @@ describe("createElectronHostCommandRouter", () => {
   });
 
   test("registers migrated read-only git host commands", async () => {
-    const router = createElectronHostCommandRouter({
+    const router = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -1115,7 +1115,7 @@ describe("createElectronHostCommandRouter", () => {
   });
 
   test("registers migrated open-in system host commands", async () => {
-    const router = createElectronHostCommandRouter({
+    const router = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -1139,7 +1139,7 @@ describe("createElectronHostCommandRouter", () => {
   });
 
   test("registers migrated GitHub repository detection command", async () => {
-    const router = createElectronHostCommandRouter({
+    const router = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -1158,7 +1158,7 @@ describe("createElectronHostCommandRouter", () => {
   });
 
   test("registers migrated diagnostics host commands", async () => {
-    const router = createElectronHostCommandRouter({
+    const router = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -1185,7 +1185,7 @@ describe("createElectronHostCommandRouter", () => {
   });
 
   test("registers migrated task list host command", async () => {
-    const router = createElectronHostCommandRouter({
+    const router = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -1329,7 +1329,7 @@ describe("createElectronHostCommandRouter", () => {
       probeMcpStatus: () => Effect.dieMessage("unexpected MCP probe"),
     };
     const sessionTaskStore = createTaskStore();
-    const sessionStopRouter = createElectronHostCommandRouter({
+    const sessionStopRouter = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -1426,7 +1426,7 @@ describe("createElectronHostCommandRouter", () => {
       updatedAt: "2026-01-02T00:00:00Z",
       revision: 1,
     });
-    const deleteRouter = createElectronHostCommandRouter({
+    const deleteRouter = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -1454,7 +1454,7 @@ describe("createElectronHostCommandRouter", () => {
       }),
     ).resolves.toMatchObject({ id: "task-1", status: "open" });
     const resetImplementationTaskStore = createTaskStore();
-    const resetImplementationRouter = createElectronHostCommandRouter({
+    const resetImplementationRouter = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -1491,7 +1491,7 @@ describe("createElectronHostCommandRouter", () => {
       }),
     ).resolves.toMatchObject({ id: "task-1", status: "ready_for_dev" });
     const pullRequestTaskStore = createTaskStore();
-    const pullRequestRouter = createElectronHostCommandRouter({
+    const pullRequestRouter = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -1525,7 +1525,7 @@ describe("createElectronHostCommandRouter", () => {
       }),
     ).resolves.toBe(true);
 
-    const approvalRouter = createElectronHostCommandRouter({
+    const approvalRouter = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -1576,7 +1576,7 @@ describe("createElectronHostCommandRouter", () => {
       },
     });
 
-    const detectPullRequestRouter = createElectronHostCommandRouter({
+    const detectPullRequestRouter = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -1653,7 +1653,7 @@ describe("createElectronHostCommandRouter", () => {
       },
     });
 
-    const upsertPullRequestRouter = createElectronHostCommandRouter({
+    const upsertPullRequestRouter = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: {
         ...createGit(),
@@ -1740,7 +1740,7 @@ describe("createElectronHostCommandRouter", () => {
       state: "open",
     });
 
-    const pullRequestSyncRouter = createElectronHostCommandRouter({
+    const pullRequestSyncRouter = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -1851,7 +1851,7 @@ describe("createElectronHostCommandRouter", () => {
       }),
     ).resolves.toEqual({ ok: true });
 
-    const reviewRouter = createElectronHostCommandRouter({
+    const reviewRouter = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -2006,7 +2006,7 @@ describe("createElectronHostCommandRouter", () => {
       status: "closed",
     });
 
-    const directMergeStartRouter = createElectronHostCommandRouter({
+    const directMergeStartRouter = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: {
         ...createGit(),
@@ -2104,7 +2104,7 @@ describe("createElectronHostCommandRouter", () => {
       availableActions: expect.arrayContaining(["open_builder"]),
     });
 
-    const completionRouter = createElectronHostCommandRouter({
+    const completionRouter = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -2183,7 +2183,7 @@ describe("createElectronHostCommandRouter", () => {
       availableActions: expect.arrayContaining(["qa_start"]),
     });
 
-    const directMergeRouter = createElectronHostCommandRouter({
+    const directMergeRouter = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -2269,7 +2269,7 @@ describe("createElectronHostCommandRouter", () => {
       status: "closed",
     });
 
-    const mergedPullRequestRouter = createElectronHostCommandRouter({
+    const mergedPullRequestRouter = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -2352,7 +2352,7 @@ describe("createElectronHostCommandRouter", () => {
       status: "closed",
     });
 
-    const blockRouter = createElectronHostCommandRouter({
+    const blockRouter = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),
@@ -2478,7 +2478,7 @@ describe("createElectronHostCommandRouter", () => {
       },
       pathIsWithinRoot: () => Effect.succeed(true),
     };
-    const router = createElectronHostCommandRouter({
+    const router = await createElectronHostCommandRouter({
       filesystem: createFilesystem(),
       git: createGit(),
       openInTools: createOpenInTools(),

--- a/apps/electron/src/main/main.ts
+++ b/apps/electron/src/main/main.ts
@@ -248,9 +248,7 @@ const registerPrivilegedProtocolSchemes = (): void => {
   ]);
 };
 
-const createElectronHostCommandRouter = (
-  runtimeDistribution: HostRuntimeDistribution,
-): EffectNodeHostCommandRouter =>
+const createElectronHostCommandRouter = (runtimeDistribution: HostRuntimeDistribution) =>
   createElectronEffectHostCommandRouter({
     clientVersion: currentVersion,
     eventBus: hostEventBus,
@@ -326,11 +324,11 @@ const prepareElectronPreReadyRuntimeEffect = (): Effect.Effect<
         ),
     });
     const runtimeDistribution = yield* resolveRuntimeDistributionEffect();
-    const hostCommandRouter = yield* Effect.try({
-      try: () => createElectronHostCommandRouter(runtimeDistribution),
-      catch: (cause) =>
+    const hostCommandRouter = yield* createElectronHostCommandRouter(runtimeDistribution).pipe(
+      Effect.mapError((cause) =>
         mapStartupPreparationError(cause, "electron.main.create-host-router", errorMessage(cause)),
-    });
+      ),
+    );
     activeHostCommandRouter = hostCommandRouter;
     return { hostCommandRouter };
   });

--- a/apps/electron/src/main/main.ts
+++ b/apps/electron/src/main/main.ts
@@ -17,6 +17,7 @@ import {
   createHostEventBus,
   type EffectHostCommandRouter,
   type EffectNodeHostCommandRouter,
+  type GitProviderRegistrationError,
   type HostRuntimeDistribution,
 } from "@openducktor/host";
 import { Effect, Either } from "effect";
@@ -248,7 +249,9 @@ const registerPrivilegedProtocolSchemes = (): void => {
   ]);
 };
 
-const createElectronHostCommandRouter = (runtimeDistribution: HostRuntimeDistribution) =>
+const createElectronHostCommandRouter = (
+  runtimeDistribution: HostRuntimeDistribution,
+): Effect.Effect<EffectNodeHostCommandRouter, GitProviderRegistrationError> =>
   createElectronEffectHostCommandRouter({
     clientVersion: currentVersion,
     eventBus: hostEventBus,

--- a/apps/electron/src/main/main.ts
+++ b/apps/electron/src/main/main.ts
@@ -17,7 +17,6 @@ import {
   createHostEventBus,
   type EffectHostCommandRouter,
   type EffectNodeHostCommandRouter,
-  type GitProviderRegistrationError,
   type HostRuntimeDistribution,
 } from "@openducktor/host";
 import { Effect, Either } from "effect";
@@ -249,9 +248,7 @@ const registerPrivilegedProtocolSchemes = (): void => {
   ]);
 };
 
-const createElectronHostCommandRouter = (
-  runtimeDistribution: HostRuntimeDistribution,
-): Effect.Effect<EffectNodeHostCommandRouter, GitProviderRegistrationError> =>
+const createElectronHostCommandRouter = (runtimeDistribution: HostRuntimeDistribution) =>
   createElectronEffectHostCommandRouter({
     clientVersion: currentVersion,
     eventBus: hostEventBus,

--- a/packages/host/src/adapters/git-providers/github-provider-adapter.test.ts
+++ b/packages/host/src/adapters/git-providers/github-provider-adapter.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { GITHUB_PROVIDER_DESCRIPTOR, repoConfigSchema } from "@openducktor/contracts";
+import { Effect } from "effect";
+import { createGitProviderResolver } from "../../application/git/git-provider-resolver";
+import { createGithubReviewTestDependencies } from "../pull-requests/github/github-pull-request-review.test-support";
+import { createGitPortTestDouble } from "../../test-support/service-test-doubles";
+import { GithubProviderAdapter } from "./github-provider-adapter";
+
+describe("GithubProviderAdapter", () => {
+  test("resolves as the configured provider with typed capability access", async () => {
+    const github = new GithubProviderAdapter({
+      gitPort: createGitPortTestDouble({}),
+      githubDependencies: createGithubReviewTestDependencies(() =>
+        Effect.die("GitHub command execution is not expected in resolver composition"),
+      ),
+    });
+    const resolver = createGitProviderResolver([github]);
+    const config = repoConfigSchema.parse({
+      workspaceId: "repo",
+      workspaceName: "Repo",
+      repoPath: "/repo",
+      defaultRuntimeKind: "opencode",
+      git: { provider: { id: "github", enabled: true } },
+    });
+
+    const resolved = await Effect.runPromise(resolver.resolve(config));
+    const pullRequests = await Effect.runPromise(resolved.pullRequests());
+    const pullRequestReview = await Effect.runPromise(resolved.pullRequestReview());
+
+    expect(resolved).toBe(github);
+    expect(resolved.getDescriptor()).toBe(GITHUB_PROVIDER_DESCRIPTOR);
+    expect(resolved.getDescriptor().capabilities.supportsPullRequests).toBe(true);
+    expect(resolved.getDescriptor().capabilities.supportsPullRequestReview).toBe(true);
+    expect(pullRequests).toEqual(
+      expect.objectContaining({
+        findByBranch: expect.any(Function),
+        getByNumber: expect.any(Function),
+        upsert: expect.any(Function),
+      }),
+    );
+    expect(pullRequestReview.providerId).toBe("github");
+  });
+});

--- a/packages/host/src/adapters/git-providers/github-provider-adapter.test.ts
+++ b/packages/host/src/adapters/git-providers/github-provider-adapter.test.ts
@@ -31,6 +31,17 @@ describe("GithubProviderAdapter", () => {
     expect(resolved.getDescriptor()).toBe(GITHUB_PROVIDER_DESCRIPTOR);
     expect(resolved.getDescriptor().capabilities.supportsPullRequests).toBe(true);
     expect(resolved.getDescriptor().capabilities.supportsPullRequestReview).toBe(true);
+    expect(resolved.repository()).toEqual(
+      expect.objectContaining({
+        getReadRepository: expect.any(Function),
+        getWriteContext: expect.any(Function),
+      }),
+    );
+    expect(resolved.health()).toEqual(
+      expect.objectContaining({
+        getStatus: expect.any(Function),
+      }),
+    );
     expect(pullRequests).toEqual(
       expect.objectContaining({
         findByBranch: expect.any(Function),
@@ -39,5 +50,62 @@ describe("GithubProviderAdapter", () => {
       }),
     );
     expect(pullRequestReview.providerId).toBe("github");
+  });
+
+  test("reads pull requests without requiring a write remote", async () => {
+    const gitPort = createGitPortTestDouble({
+      listRemotes: () =>
+        Effect.succeed([
+          { name: "origin", url: "https://github.com/Maxsky5/openducktor.git" },
+          { name: "upstream", url: "https://github.com/Maxsky5/openducktor.git" },
+        ]),
+    });
+    const githubDependencies = createGithubReviewTestDependencies((_command, args) => {
+      if (args[0] === "auth") {
+        return Effect.succeed({ ok: true, stdout: "", stderr: "" });
+      }
+      if (args.some((arg) => arg.endsWith("/pulls/42"))) {
+        return Effect.succeed({
+          ok: true,
+          stdout: JSON.stringify({
+            number: 42,
+            html_url: "https://github.com/Maxsky5/openducktor/pull/42",
+            state: "open",
+            draft: false,
+            created_at: "2026-08-31T10:00:00Z",
+            updated_at: "2026-08-31T11:00:00Z",
+            merged_at: null,
+            closed_at: null,
+            head: { ref: "odt/task-42" },
+            base: { ref: "main" },
+          }),
+          stderr: "",
+        });
+      }
+      return Effect.succeed({ ok: true, stdout: "[]", stderr: "" });
+    });
+    const github = new GithubProviderAdapter({ githubDependencies, gitPort });
+    const pullRequests = await Effect.runPromise(github.pullRequests());
+    const repoConfig = repoConfigSchema.parse({
+      workspaceId: "repo",
+      workspaceName: "Repo",
+      repoPath: "/repo",
+      defaultRuntimeKind: "opencode",
+      git: {
+        provider: {
+          id: "github",
+          enabled: true,
+          repository: { host: "github.com", owner: "Maxsky5", name: "openducktor" },
+        },
+      },
+    });
+
+    const byBranch = await Effect.runPromise(
+      pullRequests.findByBranch({ repoConfig, sourceBranch: "odt/task-42", state: "open" }),
+    );
+    const byNumber = await Effect.runPromise(pullRequests.getByNumber({ repoConfig, number: 42 }));
+
+    expect(byBranch).toBeUndefined();
+    expect(byNumber.number).toBe(42);
   });
 });

--- a/packages/host/src/adapters/git-providers/github-provider-adapter.test.ts
+++ b/packages/host/src/adapters/git-providers/github-provider-adapter.test.ts
@@ -14,7 +14,7 @@ describe("GithubProviderAdapter", () => {
         Effect.die("GitHub command execution is not expected in resolver composition"),
       ),
     });
-    const resolver = createGitProviderResolver([github]);
+    const resolver = await Effect.runPromise(createGitProviderResolver([github]));
     const config = repoConfigSchema.parse({
       workspaceId: "repo",
       workspaceName: "Repo",

--- a/packages/host/src/adapters/git-providers/github-provider-adapter.ts
+++ b/packages/host/src/adapters/git-providers/github-provider-adapter.ts
@@ -1,4 +1,8 @@
-import { GITHUB_PROVIDER_DESCRIPTOR, type GitProviderDescriptor } from "@openducktor/contracts";
+import {
+  GITHUB_PROVIDER_DESCRIPTOR,
+  type GitProviderDescriptor,
+  type RepoConfig,
+} from "@openducktor/contracts";
 import { Effect } from "effect";
 import {
   findGithubPullRequestForBranch,
@@ -33,11 +37,12 @@ export class GithubProviderAdapter implements GitProviderPort {
     gitPort: GitPort;
   }) {
     const repositoryDependencies = { ...githubDependencies, gitPort };
+    const getWriteContext = (repoConfig: RepoConfig) =>
+      requireGithubPullRequestContext(repositoryDependencies, repoConfig.repoPath, repoConfig);
     this.repositoryPort = {
       getReadRepository: (repoConfig) =>
         requireGithubPullRequestReadRepository(githubDependencies, repoConfig.repoPath, repoConfig),
-      getWriteContext: (repoConfig) =>
-        requireGithubPullRequestContext(repositoryDependencies, repoConfig.repoPath, repoConfig),
+      getWriteContext,
     };
     this.healthPort = {
       getStatus: (repoConfig) =>
@@ -46,11 +51,7 @@ export class GithubProviderAdapter implements GitProviderPort {
     this.pullRequestsPort = {
       findByBranch: (input) =>
         Effect.gen(function* () {
-          const context = yield* requireGithubPullRequestContext(
-            repositoryDependencies,
-            input.repoConfig.repoPath,
-            input.repoConfig,
-          );
+          const context = yield* getWriteContext(input.repoConfig);
           const pullRequest = yield* findGithubPullRequestForBranch(
             githubDependencies,
             input.repoConfig.repoPath,
@@ -62,11 +63,7 @@ export class GithubProviderAdapter implements GitProviderPort {
         }),
       getByNumber: (input) =>
         Effect.gen(function* () {
-          const context = yield* requireGithubPullRequestContext(
-            repositoryDependencies,
-            input.repoConfig.repoPath,
-            input.repoConfig,
-          );
+          const context = yield* getWriteContext(input.repoConfig);
           const pullRequest = yield* fetchGithubPullRequestByNumber(
             githubDependencies,
             input.repoConfig.repoPath,
@@ -77,11 +74,7 @@ export class GithubProviderAdapter implements GitProviderPort {
         }),
       upsert: (input) =>
         Effect.gen(function* () {
-          const context = yield* requireGithubPullRequestContext(
-            repositoryDependencies,
-            input.repoConfig.repoPath,
-            input.repoConfig,
-          );
+          const context = yield* getWriteContext(input.repoConfig);
           return yield* upsertGithubPullRequest(
             githubDependencies,
             input.repoConfig.repoPath,

--- a/packages/host/src/adapters/git-providers/github-provider-adapter.ts
+++ b/packages/host/src/adapters/git-providers/github-provider-adapter.ts
@@ -37,11 +37,12 @@ export class GithubProviderAdapter implements GitProviderPort {
     gitPort: GitPort;
   }) {
     const repositoryDependencies = { ...githubDependencies, gitPort };
+    const getReadRepository = (repoConfig: RepoConfig) =>
+      requireGithubPullRequestReadRepository(githubDependencies, repoConfig.repoPath, repoConfig);
     const getWriteContext = (repoConfig: RepoConfig) =>
       requireGithubPullRequestContext(repositoryDependencies, repoConfig.repoPath, repoConfig);
     this.repositoryPort = {
-      getReadRepository: (repoConfig) =>
-        requireGithubPullRequestReadRepository(githubDependencies, repoConfig.repoPath, repoConfig),
+      getReadRepository,
       getWriteContext,
     };
     this.healthPort = {
@@ -51,11 +52,11 @@ export class GithubProviderAdapter implements GitProviderPort {
     this.pullRequestsPort = {
       findByBranch: (input) =>
         Effect.gen(function* () {
-          const context = yield* getWriteContext(input.repoConfig);
+          const repository = yield* getReadRepository(input.repoConfig);
           const pullRequest = yield* findGithubPullRequestForBranch(
             githubDependencies,
             input.repoConfig.repoPath,
-            context,
+            repository,
             input.sourceBranch,
             input.state,
           );
@@ -63,11 +64,11 @@ export class GithubProviderAdapter implements GitProviderPort {
         }),
       getByNumber: (input) =>
         Effect.gen(function* () {
-          const context = yield* getWriteContext(input.repoConfig);
+          const repository = yield* getReadRepository(input.repoConfig);
           const pullRequest = yield* fetchGithubPullRequestByNumber(
             githubDependencies,
             input.repoConfig.repoPath,
-            context,
+            repository,
             input.number,
           );
           return pullRequest.record;

--- a/packages/host/src/adapters/git-providers/github-provider-adapter.ts
+++ b/packages/host/src/adapters/git-providers/github-provider-adapter.ts
@@ -1,0 +1,117 @@
+import { GITHUB_PROVIDER_DESCRIPTOR, type GitProviderDescriptor } from "@openducktor/contracts";
+import { Effect } from "effect";
+import {
+  findGithubPullRequestForBranch,
+  fetchGithubPullRequestByNumber,
+  type GithubCommandDependencies,
+  githubProviderStatus,
+  requireGithubPullRequestContext,
+  requireGithubPullRequestReadRepository,
+  upsertGithubPullRequest,
+} from "../../application/tasks/support/github-pull-requests";
+import type { GitPort } from "../../ports/git-port";
+import type {
+  GitProviderHealthPort,
+  GitProviderPort,
+  GitProviderRepositoryPort,
+  PullRequestProviderPort,
+} from "../../ports/git-provider-port";
+import type { PullRequestReviewProviderPort } from "../../ports/pull-request-review-provider-port";
+import { createGithubPullRequestReviewAdapter } from "../pull-requests/github/github-pull-request-review-adapter";
+
+export class GithubProviderAdapter implements GitProviderPort {
+  private readonly repositoryPort: GitProviderRepositoryPort;
+  private readonly healthPort: GitProviderHealthPort;
+  private readonly pullRequestsPort: PullRequestProviderPort;
+  private readonly pullRequestReviewPort: PullRequestReviewProviderPort;
+
+  constructor({
+    githubDependencies,
+    gitPort,
+  }: {
+    githubDependencies: GithubCommandDependencies;
+    gitPort: GitPort;
+  }) {
+    const repositoryDependencies = { ...githubDependencies, gitPort };
+    this.repositoryPort = {
+      getReadRepository: (repoConfig) =>
+        requireGithubPullRequestReadRepository(githubDependencies, repoConfig.repoPath, repoConfig),
+      getWriteContext: (repoConfig) =>
+        requireGithubPullRequestContext(repositoryDependencies, repoConfig.repoPath, repoConfig),
+    };
+    this.healthPort = {
+      getStatus: (repoConfig) =>
+        githubProviderStatus(repositoryDependencies, repoConfig.repoPath, repoConfig),
+    };
+    this.pullRequestsPort = {
+      findByBranch: (input) =>
+        Effect.gen(function* () {
+          const context = yield* requireGithubPullRequestContext(
+            repositoryDependencies,
+            input.repoConfig.repoPath,
+            input.repoConfig,
+          );
+          const pullRequest = yield* findGithubPullRequestForBranch(
+            githubDependencies,
+            input.repoConfig.repoPath,
+            context,
+            input.sourceBranch,
+            input.state,
+          );
+          return pullRequest?.record;
+        }),
+      getByNumber: (input) =>
+        Effect.gen(function* () {
+          const context = yield* requireGithubPullRequestContext(
+            repositoryDependencies,
+            input.repoConfig.repoPath,
+            input.repoConfig,
+          );
+          const pullRequest = yield* fetchGithubPullRequestByNumber(
+            githubDependencies,
+            input.repoConfig.repoPath,
+            context,
+            input.number,
+          );
+          return pullRequest.record;
+        }),
+      upsert: (input) =>
+        Effect.gen(function* () {
+          const context = yield* requireGithubPullRequestContext(
+            repositoryDependencies,
+            input.repoConfig.repoPath,
+            input.repoConfig,
+          );
+          return yield* upsertGithubPullRequest(
+            githubDependencies,
+            input.repoConfig.repoPath,
+            context,
+            input.approval,
+            input.title,
+            input.body,
+          );
+        }),
+    };
+    this.pullRequestReviewPort = createGithubPullRequestReviewAdapter({ githubDependencies });
+  }
+
+  getDescriptor(): GitProviderDescriptor {
+    return GITHUB_PROVIDER_DESCRIPTOR;
+  }
+
+  repository(): GitProviderRepositoryPort {
+    return this.repositoryPort;
+  }
+
+  health(): GitProviderHealthPort {
+    return this.healthPort;
+  }
+
+  pullRequests() {
+    return Effect.succeed(this.pullRequestsPort);
+  }
+
+  pullRequestReview() {
+    return Effect.succeed(this.pullRequestReviewPort);
+  }
+}

--- a/packages/host/src/application/git/git-provider-resolver.test.ts
+++ b/packages/host/src/application/git/git-provider-resolver.test.ts
@@ -172,9 +172,9 @@ describe("createGitProviderResolver", () => {
 
   test("copies the registered provider collection", async () => {
     const github = provider({ providerDescriptor: descriptor({ id: "github" }) });
-    const registrations: GitProviderPort[] = [github];
-    const resolver = createResolverSync(registrations);
-    registrations.push(provider({ providerDescriptor: descriptor({ id: "gitlab" }) }));
+    const providers: GitProviderPort[] = [github];
+    const resolver = createResolverSync(providers);
+    providers.push(provider({ providerDescriptor: descriptor({ id: "gitlab" }) }));
 
     const result = await resolveEither(resolver, repoConfig({ id: "gitlab", enabled: true }));
 

--- a/packages/host/src/application/git/git-provider-resolver.test.ts
+++ b/packages/host/src/application/git/git-provider-resolver.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, test } from "bun:test";
+import { repoConfigSchema, type GitProviderDescriptor } from "@openducktor/contracts";
+import { Effect } from "effect";
+import type {
+  GitProviderHealthPort,
+  GitProviderPort,
+  GitProviderRepositoryPort,
+  PullRequestProviderPort,
+} from "../../ports/git-provider-port";
+import type { PullRequestReviewProviderPort } from "../../ports/pull-request-review-provider-port";
+import {
+  GitProviderCapabilityError,
+  GitProviderRegistrationError,
+  GitProviderResolutionError,
+  createGitProviderResolver,
+} from "./git-provider-resolver";
+
+const unexpectedPortCall = <Success>(): Effect.Effect<Success, never> =>
+  Effect.die("Capability port operation is not expected in resolver tests");
+
+const repositoryPort: GitProviderRepositoryPort = {
+  getReadRepository: () => unexpectedPortCall(),
+  getWriteContext: () => unexpectedPortCall(),
+};
+const healthPort: GitProviderHealthPort = {
+  getStatus: () => unexpectedPortCall(),
+};
+const pullRequestPort: PullRequestProviderPort = {
+  findByBranch: () => unexpectedPortCall(),
+  getByNumber: () => unexpectedPortCall(),
+  upsert: () => unexpectedPortCall(),
+};
+const pullRequestReviewPort: PullRequestReviewProviderPort = {
+  providerId: "test",
+  readContext: () => unexpectedPortCall(),
+};
+
+const descriptor = ({
+  id,
+  supportsPullRequests = false,
+  supportsPullRequestReview = false,
+}: {
+  id: string;
+  supportsPullRequests?: boolean;
+  supportsPullRequestReview?: boolean;
+}): GitProviderDescriptor => ({
+  id,
+  label: id,
+  description: `${id} provider`,
+  capabilities: {
+    supportsPullRequests,
+    supportsPullRequestReview,
+  },
+});
+
+const provider = ({
+  providerDescriptor,
+  pullRequests,
+  pullRequestReview,
+}: {
+  providerDescriptor: GitProviderDescriptor;
+  pullRequests?: PullRequestProviderPort;
+  pullRequestReview?: PullRequestReviewProviderPort;
+}): GitProviderPort => ({
+  getDescriptor: () => providerDescriptor,
+  repository: () => repositoryPort,
+  health: () => healthPort,
+  pullRequests: () =>
+    pullRequests
+      ? Effect.succeed(pullRequests)
+      : Effect.fail(
+          new GitProviderCapabilityError({
+            providerId: providerDescriptor.id,
+            capability: "pull_requests",
+            message: `Provider '${providerDescriptor.id}' does not support Pull Requests.`,
+          }),
+        ),
+  pullRequestReview: () =>
+    pullRequestReview
+      ? Effect.succeed(pullRequestReview)
+      : Effect.fail(
+          new GitProviderCapabilityError({
+            providerId: providerDescriptor.id,
+            capability: "pull_request_review",
+            message: `Provider '${providerDescriptor.id}' does not support Pull Request review.`,
+          }),
+        ),
+});
+
+const repoConfig = (providerConfig?: { id: string; enabled: boolean }) =>
+  repoConfigSchema.parse({
+    workspaceId: "repo",
+    workspaceName: "Repo",
+    repoPath: "/repo",
+    defaultRuntimeKind: "opencode",
+    git: providerConfig ? { provider: providerConfig } : {},
+  });
+
+const resolveEither = (
+  resolver: ReturnType<typeof createGitProviderResolver>,
+  config: ReturnType<typeof repoConfig>,
+) => Effect.runPromise(resolver.resolve(config).pipe(Effect.either));
+
+describe("createGitProviderResolver", () => {
+  test("fails with a typed error when no provider is configured", async () => {
+    const resolver = createGitProviderResolver([]);
+
+    const result = await resolveEither(resolver, repoConfig());
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(GitProviderResolutionError);
+      expect(result.left.reason).toBe("not_configured");
+      expect(result.left.providerId).toBeUndefined();
+    }
+  });
+
+  test("fails with a typed error when the configured provider is disabled", async () => {
+    const github = provider({ providerDescriptor: descriptor({ id: "github" }) });
+    const resolver = createGitProviderResolver([github]);
+
+    const result = await resolveEither(resolver, repoConfig({ id: "github", enabled: false }));
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(GitProviderResolutionError);
+      expect(result.left.reason).toBe("disabled");
+      expect(result.left.providerId).toBe("github");
+    }
+  });
+
+  test("fails with a typed error when the configured provider is not registered", async () => {
+    const github = provider({ providerDescriptor: descriptor({ id: "github" }) });
+    const resolver = createGitProviderResolver([github]);
+
+    const result = await resolveEither(resolver, repoConfig({ id: "gitlab", enabled: true }));
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(GitProviderResolutionError);
+      expect(result.left.reason).toBe("not_registered");
+      expect(result.left.providerId).toBe("gitlab");
+    }
+  });
+
+  test("resolves the exact configured GitHub provider", async () => {
+    const github = provider({ providerDescriptor: descriptor({ id: "github" }) });
+    const other = provider({ providerDescriptor: descriptor({ id: "gitlab" }) });
+    const resolver = createGitProviderResolver([other, github]);
+
+    const resolved = await Effect.runPromise(
+      resolver.resolve(repoConfig({ id: "github", enabled: true })),
+    );
+
+    expect(resolved).toBe(github);
+  });
+
+  test("copies the registered provider collection", async () => {
+    const github = provider({ providerDescriptor: descriptor({ id: "github" }) });
+    const registrations: GitProviderPort[] = [github];
+    const resolver = createGitProviderResolver(registrations);
+    registrations.push(provider({ providerDescriptor: descriptor({ id: "gitlab" }) }));
+
+    const result = await resolveEither(resolver, repoConfig({ id: "gitlab", enabled: true }));
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left.reason).toBe("not_registered");
+    }
+  });
+
+  test("rejects duplicate descriptor IDs", () => {
+    const first = provider({ providerDescriptor: descriptor({ id: "github" }) });
+    const second = provider({ providerDescriptor: descriptor({ id: "github" }) });
+
+    expect(() => createGitProviderResolver([first, second])).toThrow(GitProviderRegistrationError);
+  });
+
+  test.each([
+    {
+      name: "declared Pull Request support without a port",
+      providerDescriptor: descriptor({ id: "github", supportsPullRequests: true }),
+      pullRequests: undefined,
+      pullRequestReview: undefined,
+      reason: "declared_capability_missing_port",
+      capability: "pull_requests",
+    },
+    {
+      name: "declared review support without a port",
+      providerDescriptor: descriptor({
+        id: "github",
+        supportsPullRequests: true,
+        supportsPullRequestReview: true,
+      }),
+      pullRequests: pullRequestPort,
+      pullRequestReview: undefined,
+      reason: "declared_capability_missing_port",
+      capability: "pull_request_review",
+    },
+    {
+      name: "a Pull Request port without declared support",
+      providerDescriptor: descriptor({ id: "github" }),
+      pullRequests: pullRequestPort,
+      pullRequestReview: undefined,
+      reason: "undeclared_capability_has_port",
+      capability: "pull_requests",
+    },
+    {
+      name: "a review port without declared support",
+      providerDescriptor: descriptor({ id: "github" }),
+      pullRequests: undefined,
+      pullRequestReview: pullRequestReviewPort,
+      reason: "undeclared_capability_has_port",
+      capability: "pull_request_review",
+    },
+  ])(
+    "rejects $name",
+    ({ providerDescriptor, pullRequests, pullRequestReview, reason, capability }) => {
+      const providerInput: Parameters<typeof provider>[0] = { providerDescriptor };
+      if (pullRequests) {
+        providerInput.pullRequests = pullRequests;
+      }
+      if (pullRequestReview) {
+        providerInput.pullRequestReview = pullRequestReview;
+      }
+      const invalidProvider = provider(providerInput);
+
+      expect(() => createGitProviderResolver([invalidProvider])).toThrow(
+        expect.objectContaining({
+          _tag: "GitProviderRegistrationError",
+          reason,
+          capability,
+          providerId: "github",
+        }),
+      );
+    },
+  );
+
+  test("unsupported capability access fails with a typed error", async () => {
+    const basicProvider = provider({ providerDescriptor: descriptor({ id: "basic" }) });
+    const resolver = createGitProviderResolver([basicProvider]);
+    const resolved = await Effect.runPromise(
+      resolver.resolve(repoConfig({ id: "basic", enabled: true })),
+    );
+
+    const pullRequests = await Effect.runPromise(resolved.pullRequests().pipe(Effect.either));
+    const review = await Effect.runPromise(resolved.pullRequestReview().pipe(Effect.either));
+
+    expect(pullRequests._tag).toBe("Left");
+    expect(review._tag).toBe("Left");
+    if (pullRequests._tag === "Left" && review._tag === "Left") {
+      expect(pullRequests.left).toBeInstanceOf(GitProviderCapabilityError);
+      expect(review.left).toBeInstanceOf(GitProviderCapabilityError);
+    }
+  });
+
+  test("capability checks use direct typed descriptor fields", () => {
+    const github = provider({
+      providerDescriptor: descriptor({
+        id: "github",
+        supportsPullRequests: true,
+        supportsPullRequestReview: true,
+      }),
+      pullRequests: pullRequestPort,
+      pullRequestReview: pullRequestReviewPort,
+    });
+
+    expect(github.getDescriptor().capabilities.supportsPullRequests).toBe(true);
+    expect(github.getDescriptor().capabilities.supportsPullRequestReview).toBe(true);
+  });
+});

--- a/packages/host/src/application/git/git-provider-resolver.test.ts
+++ b/packages/host/src/application/git/git-provider-resolver.test.ts
@@ -13,6 +13,7 @@ import {
   GitProviderRegistrationError,
   GitProviderResolutionError,
   createGitProviderResolver,
+  type GitProviderResolver,
 } from "./git-provider-resolver";
 
 const unexpectedPortCall = <Success>(): Effect.Effect<Success, never> =>
@@ -31,7 +32,7 @@ const pullRequestPort: PullRequestProviderPort = {
   upsert: () => unexpectedPortCall(),
 };
 const pullRequestReviewPort: PullRequestReviewProviderPort = {
-  providerId: "test",
+  providerId: "github",
   readContext: () => unexpectedPortCall(),
 };
 
@@ -57,34 +58,44 @@ const provider = ({
   providerDescriptor,
   pullRequests,
   pullRequestReview,
+  asyncCapabilityAccess = false,
 }: {
   providerDescriptor: GitProviderDescriptor;
   pullRequests?: PullRequestProviderPort;
   pullRequestReview?: PullRequestReviewProviderPort;
+  asyncCapabilityAccess?: boolean;
 }): GitProviderPort => ({
   getDescriptor: () => providerDescriptor,
   repository: () => repositoryPort,
   health: () => healthPort,
-  pullRequests: () =>
-    pullRequests
-      ? Effect.succeed(pullRequests)
-      : Effect.fail(
-          new GitProviderCapabilityError({
-            providerId: providerDescriptor.id,
-            capability: "pull_requests",
-            message: `Provider '${providerDescriptor.id}' does not support Pull Requests.`,
-          }),
-        ),
-  pullRequestReview: () =>
-    pullRequestReview
-      ? Effect.succeed(pullRequestReview)
-      : Effect.fail(
-          new GitProviderCapabilityError({
-            providerId: providerDescriptor.id,
-            capability: "pull_request_review",
-            message: `Provider '${providerDescriptor.id}' does not support Pull Request review.`,
-          }),
-        ),
+  pullRequests: () => {
+    if (pullRequests) {
+      return asyncCapabilityAccess
+        ? Effect.promise(() => Promise.resolve(pullRequests))
+        : Effect.succeed(pullRequests);
+    }
+    return Effect.fail(
+      new GitProviderCapabilityError({
+        providerId: providerDescriptor.id,
+        capability: "pull_requests",
+        message: `Provider '${providerDescriptor.id}' does not support Pull Requests.`,
+      }),
+    );
+  },
+  pullRequestReview: () => {
+    if (pullRequestReview) {
+      return asyncCapabilityAccess
+        ? Effect.promise(() => Promise.resolve(pullRequestReview))
+        : Effect.succeed(pullRequestReview);
+    }
+    return Effect.fail(
+      new GitProviderCapabilityError({
+        providerId: providerDescriptor.id,
+        capability: "pull_request_review",
+        message: `Provider '${providerDescriptor.id}' does not support Pull Request review.`,
+      }),
+    );
+  },
 });
 
 const repoConfig = (providerConfig?: { id: string; enabled: boolean }) =>
@@ -96,14 +107,18 @@ const repoConfig = (providerConfig?: { id: string; enabled: boolean }) =>
     git: providerConfig ? { provider: providerConfig } : {},
   });
 
-const resolveEither = (
-  resolver: ReturnType<typeof createGitProviderResolver>,
-  config: ReturnType<typeof repoConfig>,
-) => Effect.runPromise(resolver.resolve(config).pipe(Effect.either));
+const resolveEither = (resolver: GitProviderResolver, config: ReturnType<typeof repoConfig>) =>
+  Effect.runPromise(resolver.resolve(config).pipe(Effect.either));
+
+const createResolverSync = (providers: readonly GitProviderPort[]) =>
+  Effect.runSync(createGitProviderResolver(providers));
+
+const registrationEither = (providers: readonly GitProviderPort[]) =>
+  Effect.runPromise(createGitProviderResolver(providers).pipe(Effect.either));
 
 describe("createGitProviderResolver", () => {
   test("fails with a typed error when no provider is configured", async () => {
-    const resolver = createGitProviderResolver([]);
+    const resolver = createResolverSync([]);
 
     const result = await resolveEither(resolver, repoConfig());
 
@@ -117,7 +132,7 @@ describe("createGitProviderResolver", () => {
 
   test("fails with a typed error when the configured provider is disabled", async () => {
     const github = provider({ providerDescriptor: descriptor({ id: "github" }) });
-    const resolver = createGitProviderResolver([github]);
+    const resolver = createResolverSync([github]);
 
     const result = await resolveEither(resolver, repoConfig({ id: "github", enabled: false }));
 
@@ -131,7 +146,7 @@ describe("createGitProviderResolver", () => {
 
   test("fails with a typed error when the configured provider is not registered", async () => {
     const github = provider({ providerDescriptor: descriptor({ id: "github" }) });
-    const resolver = createGitProviderResolver([github]);
+    const resolver = createResolverSync([github]);
 
     const result = await resolveEither(resolver, repoConfig({ id: "gitlab", enabled: true }));
 
@@ -146,7 +161,7 @@ describe("createGitProviderResolver", () => {
   test("resolves the exact configured GitHub provider", async () => {
     const github = provider({ providerDescriptor: descriptor({ id: "github" }) });
     const other = provider({ providerDescriptor: descriptor({ id: "gitlab" }) });
-    const resolver = createGitProviderResolver([other, github]);
+    const resolver = createResolverSync([other, github]);
 
     const resolved = await Effect.runPromise(
       resolver.resolve(repoConfig({ id: "github", enabled: true })),
@@ -158,7 +173,7 @@ describe("createGitProviderResolver", () => {
   test("copies the registered provider collection", async () => {
     const github = provider({ providerDescriptor: descriptor({ id: "github" }) });
     const registrations: GitProviderPort[] = [github];
-    const resolver = createGitProviderResolver(registrations);
+    const resolver = createResolverSync(registrations);
     registrations.push(provider({ providerDescriptor: descriptor({ id: "gitlab" }) }));
 
     const result = await resolveEither(resolver, repoConfig({ id: "gitlab", enabled: true }));
@@ -169,11 +184,67 @@ describe("createGitProviderResolver", () => {
     }
   });
 
-  test("rejects duplicate descriptor IDs", () => {
+  test("rejects duplicate descriptor IDs", async () => {
     const first = provider({ providerDescriptor: descriptor({ id: "github" }) });
     const second = provider({ providerDescriptor: descriptor({ id: "github" }) });
 
-    expect(() => createGitProviderResolver([first, second])).toThrow(GitProviderRegistrationError);
+    const result = await registrationEither([first, second]);
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(GitProviderRegistrationError);
+      expect(result.left.reason).toBe("duplicate_provider_id");
+    }
+  });
+
+  test("rejects a review port owned by another provider", async () => {
+    const foreignReviewPort: PullRequestReviewProviderPort = {
+      providerId: "gitlab",
+      readContext: () => unexpectedPortCall(),
+    };
+    const github = provider({
+      providerDescriptor: descriptor({
+        id: "github",
+        supportsPullRequests: true,
+        supportsPullRequestReview: true,
+      }),
+      pullRequests: pullRequestPort,
+      pullRequestReview: foreignReviewPort,
+    });
+
+    const result = await registrationEither([github]);
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toEqual(
+        expect.objectContaining({
+          _tag: "GitProviderRegistrationError",
+          reason: "capability_provider_id_mismatch",
+          capability: "pull_request_review",
+          providerId: "github",
+        }),
+      );
+    }
+  });
+
+  test("accepts asynchronous capability accessors", async () => {
+    const github = provider({
+      providerDescriptor: descriptor({
+        id: "github",
+        supportsPullRequests: true,
+        supportsPullRequestReview: true,
+      }),
+      pullRequests: pullRequestPort,
+      pullRequestReview: pullRequestReviewPort,
+      asyncCapabilityAccess: true,
+    });
+
+    const resolver = await Effect.runPromise(createGitProviderResolver([github]));
+    const resolved = await Effect.runPromise(
+      resolver.resolve(repoConfig({ id: "github", enabled: true })),
+    );
+
+    expect(resolved).toBe(github);
   });
 
   test.each([
@@ -215,7 +286,7 @@ describe("createGitProviderResolver", () => {
     },
   ])(
     "rejects $name",
-    ({ providerDescriptor, pullRequests, pullRequestReview, reason, capability }) => {
+    async ({ providerDescriptor, pullRequests, pullRequestReview, reason, capability }) => {
       const providerInput: Parameters<typeof provider>[0] = { providerDescriptor };
       if (pullRequests) {
         providerInput.pullRequests = pullRequests;
@@ -225,20 +296,25 @@ describe("createGitProviderResolver", () => {
       }
       const invalidProvider = provider(providerInput);
 
-      expect(() => createGitProviderResolver([invalidProvider])).toThrow(
-        expect.objectContaining({
-          _tag: "GitProviderRegistrationError",
-          reason,
-          capability,
-          providerId: "github",
-        }),
-      );
+      const result = await registrationEither([invalidProvider]);
+
+      expect(result._tag).toBe("Left");
+      if (result._tag === "Left") {
+        expect(result.left).toEqual(
+          expect.objectContaining({
+            _tag: "GitProviderRegistrationError",
+            reason,
+            capability,
+            providerId: "github",
+          }),
+        );
+      }
     },
   );
 
   test("unsupported capability access fails with a typed error", async () => {
     const basicProvider = provider({ providerDescriptor: descriptor({ id: "basic" }) });
-    const resolver = createGitProviderResolver([basicProvider]);
+    const resolver = createResolverSync([basicProvider]);
     const resolved = await Effect.runPromise(
       resolver.resolve(repoConfig({ id: "basic", enabled: true })),
     );

--- a/packages/host/src/application/git/git-provider-resolver.test.ts
+++ b/packages/host/src/application/git/git-provider-resolver.test.ts
@@ -19,13 +19,13 @@ import {
 const unexpectedPortCall = <Success>(): Effect.Effect<Success, never> =>
   Effect.die("Capability port operation is not expected in resolver tests");
 
-const repositoryPort: GitProviderRepositoryPort = {
+const repositoryPort = (): GitProviderRepositoryPort => ({
   getReadRepository: () => unexpectedPortCall(),
   getWriteContext: () => unexpectedPortCall(),
-};
-const healthPort: GitProviderHealthPort = {
+});
+const healthPort = (): GitProviderHealthPort => ({
   getStatus: () => unexpectedPortCall(),
-};
+});
 const pullRequestPort: PullRequestProviderPort = {
   findByBranch: () => unexpectedPortCall(),
   getByNumber: () => unexpectedPortCall(),
@@ -66,8 +66,8 @@ const provider = ({
   asyncCapabilityAccess?: boolean;
 }): GitProviderPort => ({
   getDescriptor: () => providerDescriptor,
-  repository: () => repositoryPort,
-  health: () => healthPort,
+  repository: repositoryPort,
+  health: healthPort,
   pullRequests: () => {
     if (pullRequests) {
       return asyncCapabilityAccess

--- a/packages/host/src/application/git/git-provider-resolver.ts
+++ b/packages/host/src/application/git/git-provider-resolver.ts
@@ -7,6 +7,7 @@ import {
   GitProviderResolutionError,
 } from "../../ports/git-provider-errors";
 import type { GitProviderPort } from "../../ports/git-provider-port";
+import type { PullRequestReviewProviderPort } from "../../ports/pull-request-review-provider-port";
 
 export {
   GitProviderCapabilityError,
@@ -18,108 +19,146 @@ export type GitProviderResolver = {
   resolve(repoConfig: RepoConfig): Effect.Effect<GitProviderPort, GitProviderResolutionError>;
 };
 
-type CapabilityRegistration = {
+type CapabilityRegistration<Port> = {
   capability: GitProviderCapability;
   declared: boolean;
-  isSupplied: () => boolean;
+  access: () => Effect.Effect<Port, GitProviderCapabilityError>;
+  validatePort?: (
+    port: Port,
+    providerId: string,
+  ) => Effect.Effect<void, GitProviderRegistrationError>;
 };
 
-const hasCapabilityPort = <Port>(
-  accessor: () => Effect.Effect<Port, GitProviderCapabilityError>,
-): boolean => Effect.runSync(accessor().pipe(Effect.either))._tag === "Right";
-
-const validateCapabilityRegistration = (
+const validateCapabilityRegistration = <Port>(
   provider: GitProviderPort,
-  registration: CapabilityRegistration,
-): void => {
-  const providerId = provider.getDescriptor().id;
-  const supplied = registration.isSupplied();
-  if (registration.declared === supplied) {
-    return;
+  registration: CapabilityRegistration<Port>,
+): Effect.Effect<void, GitProviderRegistrationError> =>
+  Effect.gen(function* () {
+    const providerId = provider.getDescriptor().id;
+    const portResult = yield* Effect.either(registration.access());
+    const supplied = portResult._tag === "Right";
+    if (registration.declared !== supplied) {
+      if (registration.declared) {
+        return yield* Effect.fail(
+          new GitProviderRegistrationError({
+            reason: "declared_capability_missing_port",
+            providerId,
+            capability: registration.capability,
+            message: `Git provider '${providerId}' declares '${registration.capability}' but does not supply its port.`,
+          }),
+        );
+      }
+
+      return yield* Effect.fail(
+        new GitProviderRegistrationError({
+          reason: "undeclared_capability_has_port",
+          providerId,
+          capability: registration.capability,
+          message: `Git provider '${providerId}' supplies '${registration.capability}' without declaring support.`,
+        }),
+      );
+    }
+
+    if (portResult._tag === "Right" && registration.validatePort) {
+      yield* registration.validatePort(portResult.right, providerId);
+    }
+  });
+
+const validateReviewPortOwner = (
+  port: PullRequestReviewProviderPort,
+  providerId: string,
+): Effect.Effect<void, GitProviderRegistrationError> => {
+  if (port.providerId === providerId) {
+    return Effect.void;
   }
 
-  if (registration.declared) {
-    throw new GitProviderRegistrationError({
-      reason: "declared_capability_missing_port",
+  return Effect.fail(
+    new GitProviderRegistrationError({
+      reason: "capability_provider_id_mismatch",
       providerId,
-      capability: registration.capability,
-      message: `Git provider '${providerId}' declares '${registration.capability}' but does not supply its port.`,
+      capability: "pull_request_review",
+      message: `Git provider '${providerId}' supplies a Pull Request review port owned by '${port.providerId}'.`,
+    }),
+  );
+};
+
+const validateProviderRegistration = (
+  provider: GitProviderPort,
+): Effect.Effect<void, GitProviderRegistrationError> =>
+  Effect.gen(function* () {
+    const { capabilities } = provider.getDescriptor();
+    yield* validateCapabilityRegistration(provider, {
+      capability: "pull_requests",
+      declared: capabilities.supportsPullRequests,
+      access: () => provider.pullRequests(),
     });
-  }
-
-  throw new GitProviderRegistrationError({
-    reason: "undeclared_capability_has_port",
-    providerId,
-    capability: registration.capability,
-    message: `Git provider '${providerId}' supplies '${registration.capability}' without declaring support.`,
+    yield* validateCapabilityRegistration(provider, {
+      capability: "pull_request_review",
+      declared: capabilities.supportsPullRequestReview,
+      access: () => provider.pullRequestReview(),
+      validatePort: validateReviewPortOwner,
+    });
   });
-};
-
-const validateProviderRegistration = (provider: GitProviderPort): void => {
-  const { capabilities } = provider.getDescriptor();
-  validateCapabilityRegistration(provider, {
-    capability: "pull_requests",
-    declared: capabilities.supportsPullRequests,
-    isSupplied: () => hasCapabilityPort(() => provider.pullRequests()),
-  });
-  validateCapabilityRegistration(provider, {
-    capability: "pull_request_review",
-    declared: capabilities.supportsPullRequestReview,
-    isSupplied: () => hasCapabilityPort(() => provider.pullRequestReview()),
-  });
-};
 
 export const createGitProviderResolver = (
   registrations: readonly GitProviderPort[],
-): GitProviderResolver => {
+): Effect.Effect<GitProviderResolver, GitProviderRegistrationError> => {
   const providers = Object.freeze([...registrations]);
-  const providersById = new Map<string, GitProviderPort>();
 
-  for (const provider of providers) {
-    validateProviderRegistration(provider);
-    const providerId = provider.getDescriptor().id;
-    if (providersById.has(providerId)) {
-      throw new GitProviderRegistrationError({
-        reason: "duplicate_provider_id",
-        providerId,
-        message: `Git provider '${providerId}' is registered more than once.`,
-      });
+  return Effect.gen(function* () {
+    const providersById = new Map<string, GitProviderPort>();
+
+    for (const provider of providers) {
+      const providerId = provider.getDescriptor().id;
+      if (providersById.has(providerId)) {
+        return yield* Effect.fail(
+          new GitProviderRegistrationError({
+            reason: "duplicate_provider_id",
+            providerId,
+            message: `Git provider '${providerId}' is registered more than once.`,
+          }),
+        );
+      }
+      providersById.set(providerId, provider);
     }
-    providersById.set(providerId, provider);
-  }
 
-  return {
-    resolve(repoConfig) {
-      const providerConfig = repoConfig.git.provider;
-      if (!providerConfig) {
-        return Effect.fail(
-          new GitProviderResolutionError({
-            reason: "not_configured",
-            message: "No Git provider is configured for this repository.",
-          }),
-        );
-      }
-      if (!providerConfig.enabled) {
-        return Effect.fail(
-          new GitProviderResolutionError({
-            reason: "disabled",
-            providerId: providerConfig.id,
-            message: `Git provider '${providerConfig.id}' is disabled for this repository.`,
-          }),
-        );
-      }
+    for (const provider of providers) {
+      yield* validateProviderRegistration(provider);
+    }
 
-      const provider = providersById.get(providerConfig.id);
-      if (!provider) {
-        return Effect.fail(
-          new GitProviderResolutionError({
-            reason: "not_registered",
-            providerId: providerConfig.id,
-            message: `Git provider '${providerConfig.id}' has no registered implementation.`,
-          }),
-        );
-      }
-      return Effect.succeed(provider);
-    },
-  };
+    return {
+      resolve(repoConfig) {
+        const providerConfig = repoConfig.git.provider;
+        if (!providerConfig) {
+          return Effect.fail(
+            new GitProviderResolutionError({
+              reason: "not_configured",
+              message: "No Git provider is configured for this repository.",
+            }),
+          );
+        }
+        if (!providerConfig.enabled) {
+          return Effect.fail(
+            new GitProviderResolutionError({
+              reason: "disabled",
+              providerId: providerConfig.id,
+              message: `Git provider '${providerConfig.id}' is disabled for this repository.`,
+            }),
+          );
+        }
+
+        const provider = providersById.get(providerConfig.id);
+        if (!provider) {
+          return Effect.fail(
+            new GitProviderResolutionError({
+              reason: "not_registered",
+              providerId: providerConfig.id,
+              message: `Git provider '${providerConfig.id}' has no registered implementation.`,
+            }),
+          );
+        }
+        return Effect.succeed(provider);
+      },
+    } satisfies GitProviderResolver;
+  });
 };

--- a/packages/host/src/application/git/git-provider-resolver.ts
+++ b/packages/host/src/application/git/git-provider-resolver.ts
@@ -1,0 +1,125 @@
+import type { RepoConfig } from "@openducktor/contracts";
+import { Effect } from "effect";
+import {
+  type GitProviderCapability,
+  GitProviderCapabilityError,
+  GitProviderRegistrationError,
+  GitProviderResolutionError,
+} from "../../ports/git-provider-errors";
+import type { GitProviderPort } from "../../ports/git-provider-port";
+
+export {
+  GitProviderCapabilityError,
+  GitProviderRegistrationError,
+  GitProviderResolutionError,
+} from "../../ports/git-provider-errors";
+
+export type GitProviderResolver = {
+  resolve(repoConfig: RepoConfig): Effect.Effect<GitProviderPort, GitProviderResolutionError>;
+};
+
+type CapabilityRegistration = {
+  capability: GitProviderCapability;
+  declared: boolean;
+  isSupplied: () => boolean;
+};
+
+const hasCapabilityPort = <Port>(
+  accessor: () => Effect.Effect<Port, GitProviderCapabilityError>,
+): boolean => Effect.runSync(accessor().pipe(Effect.either))._tag === "Right";
+
+const validateCapabilityRegistration = (
+  provider: GitProviderPort,
+  registration: CapabilityRegistration,
+): void => {
+  const providerId = provider.getDescriptor().id;
+  const supplied = registration.isSupplied();
+  if (registration.declared === supplied) {
+    return;
+  }
+
+  if (registration.declared) {
+    throw new GitProviderRegistrationError({
+      reason: "declared_capability_missing_port",
+      providerId,
+      capability: registration.capability,
+      message: `Git provider '${providerId}' declares '${registration.capability}' but does not supply its port.`,
+    });
+  }
+
+  throw new GitProviderRegistrationError({
+    reason: "undeclared_capability_has_port",
+    providerId,
+    capability: registration.capability,
+    message: `Git provider '${providerId}' supplies '${registration.capability}' without declaring support.`,
+  });
+};
+
+const validateProviderRegistration = (provider: GitProviderPort): void => {
+  const { capabilities } = provider.getDescriptor();
+  validateCapabilityRegistration(provider, {
+    capability: "pull_requests",
+    declared: capabilities.supportsPullRequests,
+    isSupplied: () => hasCapabilityPort(() => provider.pullRequests()),
+  });
+  validateCapabilityRegistration(provider, {
+    capability: "pull_request_review",
+    declared: capabilities.supportsPullRequestReview,
+    isSupplied: () => hasCapabilityPort(() => provider.pullRequestReview()),
+  });
+};
+
+export const createGitProviderResolver = (
+  registrations: readonly GitProviderPort[],
+): GitProviderResolver => {
+  const providers = Object.freeze([...registrations]);
+  const providersById = new Map<string, GitProviderPort>();
+
+  for (const provider of providers) {
+    validateProviderRegistration(provider);
+    const providerId = provider.getDescriptor().id;
+    if (providersById.has(providerId)) {
+      throw new GitProviderRegistrationError({
+        reason: "duplicate_provider_id",
+        providerId,
+        message: `Git provider '${providerId}' is registered more than once.`,
+      });
+    }
+    providersById.set(providerId, provider);
+  }
+
+  return {
+    resolve(repoConfig) {
+      const providerConfig = repoConfig.git.provider;
+      if (!providerConfig) {
+        return Effect.fail(
+          new GitProviderResolutionError({
+            reason: "not_configured",
+            message: "No Git provider is configured for this repository.",
+          }),
+        );
+      }
+      if (!providerConfig.enabled) {
+        return Effect.fail(
+          new GitProviderResolutionError({
+            reason: "disabled",
+            providerId: providerConfig.id,
+            message: `Git provider '${providerConfig.id}' is disabled for this repository.`,
+          }),
+        );
+      }
+
+      const provider = providersById.get(providerConfig.id);
+      if (!provider) {
+        return Effect.fail(
+          new GitProviderResolutionError({
+            reason: "not_registered",
+            providerId: providerConfig.id,
+            message: `Git provider '${providerConfig.id}' has no registered implementation.`,
+          }),
+        );
+      }
+      return Effect.succeed(provider);
+    },
+  };
+};

--- a/packages/host/src/application/git/git-provider-resolver.ts
+++ b/packages/host/src/application/git/git-provider-resolver.ts
@@ -1,4 +1,4 @@
-import type { RepoConfig } from "@openducktor/contracts";
+import type { GitProviderId, RepoConfig } from "@openducktor/contracts";
 import { Effect } from "effect";
 import {
   type GitProviderCapability,
@@ -25,7 +25,7 @@ export const createGitProviderResolver = (
   const providers = Object.freeze([...ports]);
 
   return Effect.gen(function* () {
-    const providersById = new Map<string, GitProviderPort>();
+    const providersById = new Map<GitProviderId, GitProviderPort>();
 
     for (const provider of providers) {
       const providerId = provider.getDescriptor().id;
@@ -86,7 +86,10 @@ type CapabilityRule<Port> = {
   capability: GitProviderCapability;
   supported: boolean;
   getPort: () => Effect.Effect<Port, GitProviderCapabilityError>;
-  checkPort?: (port: Port, providerId: string) => Effect.Effect<void, GitProviderRegistrationError>;
+  checkPort?: (
+    port: Port,
+    providerId: GitProviderId,
+  ) => Effect.Effect<void, GitProviderRegistrationError>;
 };
 
 function checkProvider(
@@ -146,7 +149,7 @@ function checkCapability<Port>(
 
 function checkReviewPortOwner(
   port: PullRequestReviewProviderPort,
-  providerId: string,
+  providerId: GitProviderId,
 ): Effect.Effect<void, GitProviderRegistrationError> {
   if (port.providerId === providerId) {
     return Effect.void;

--- a/packages/host/src/application/git/git-provider-resolver.ts
+++ b/packages/host/src/application/git/git-provider-resolver.ts
@@ -19,91 +19,10 @@ export type GitProviderResolver = {
   resolve(repoConfig: RepoConfig): Effect.Effect<GitProviderPort, GitProviderResolutionError>;
 };
 
-type CapabilityRegistration<Port> = {
-  capability: GitProviderCapability;
-  declared: boolean;
-  access: () => Effect.Effect<Port, GitProviderCapabilityError>;
-  validatePort?: (
-    port: Port,
-    providerId: string,
-  ) => Effect.Effect<void, GitProviderRegistrationError>;
-};
-
-const validateCapabilityRegistration = <Port>(
-  provider: GitProviderPort,
-  registration: CapabilityRegistration<Port>,
-): Effect.Effect<void, GitProviderRegistrationError> =>
-  Effect.gen(function* () {
-    const providerId = provider.getDescriptor().id;
-    const portResult = yield* Effect.either(registration.access());
-    const supplied = portResult._tag === "Right";
-    if (registration.declared !== supplied) {
-      if (registration.declared) {
-        return yield* Effect.fail(
-          new GitProviderRegistrationError({
-            reason: "declared_capability_missing_port",
-            providerId,
-            capability: registration.capability,
-            message: `Git provider '${providerId}' declares '${registration.capability}' but does not supply its port.`,
-          }),
-        );
-      }
-
-      return yield* Effect.fail(
-        new GitProviderRegistrationError({
-          reason: "undeclared_capability_has_port",
-          providerId,
-          capability: registration.capability,
-          message: `Git provider '${providerId}' supplies '${registration.capability}' without declaring support.`,
-        }),
-      );
-    }
-
-    if (portResult._tag === "Right" && registration.validatePort) {
-      yield* registration.validatePort(portResult.right, providerId);
-    }
-  });
-
-const validateReviewPortOwner = (
-  port: PullRequestReviewProviderPort,
-  providerId: string,
-): Effect.Effect<void, GitProviderRegistrationError> => {
-  if (port.providerId === providerId) {
-    return Effect.void;
-  }
-
-  return Effect.fail(
-    new GitProviderRegistrationError({
-      reason: "capability_provider_id_mismatch",
-      providerId,
-      capability: "pull_request_review",
-      message: `Git provider '${providerId}' supplies a Pull Request review port owned by '${port.providerId}'.`,
-    }),
-  );
-};
-
-const validateProviderRegistration = (
-  provider: GitProviderPort,
-): Effect.Effect<void, GitProviderRegistrationError> =>
-  Effect.gen(function* () {
-    const { capabilities } = provider.getDescriptor();
-    yield* validateCapabilityRegistration(provider, {
-      capability: "pull_requests",
-      declared: capabilities.supportsPullRequests,
-      access: () => provider.pullRequests(),
-    });
-    yield* validateCapabilityRegistration(provider, {
-      capability: "pull_request_review",
-      declared: capabilities.supportsPullRequestReview,
-      access: () => provider.pullRequestReview(),
-      validatePort: validateReviewPortOwner,
-    });
-  });
-
 export const createGitProviderResolver = (
-  registrations: readonly GitProviderPort[],
+  ports: readonly GitProviderPort[],
 ): Effect.Effect<GitProviderResolver, GitProviderRegistrationError> => {
-  const providers = Object.freeze([...registrations]);
+  const providers = Object.freeze([...ports]);
 
   return Effect.gen(function* () {
     const providersById = new Map<string, GitProviderPort>();
@@ -123,13 +42,13 @@ export const createGitProviderResolver = (
     }
 
     for (const provider of providers) {
-      yield* validateProviderRegistration(provider);
+      yield* checkProvider(provider);
     }
 
     return {
       resolve(repoConfig) {
-        const providerConfig = repoConfig.git.provider;
-        if (!providerConfig) {
+        const selection = repoConfig.git.provider;
+        if (!selection) {
           return Effect.fail(
             new GitProviderResolutionError({
               reason: "not_configured",
@@ -137,23 +56,23 @@ export const createGitProviderResolver = (
             }),
           );
         }
-        if (!providerConfig.enabled) {
+        if (!selection.enabled) {
           return Effect.fail(
             new GitProviderResolutionError({
               reason: "disabled",
-              providerId: providerConfig.id,
-              message: `Git provider '${providerConfig.id}' is disabled for this repository.`,
+              providerId: selection.id,
+              message: `Git provider '${selection.id}' is disabled for this repository.`,
             }),
           );
         }
 
-        const provider = providersById.get(providerConfig.id);
+        const provider = providersById.get(selection.id);
         if (!provider) {
           return Effect.fail(
             new GitProviderResolutionError({
               reason: "not_registered",
-              providerId: providerConfig.id,
-              message: `Git provider '${providerConfig.id}' has no registered implementation.`,
+              providerId: selection.id,
+              message: `Git provider '${selection.id}' has no registered implementation.`,
             }),
           );
         }
@@ -162,3 +81,83 @@ export const createGitProviderResolver = (
     } satisfies GitProviderResolver;
   });
 };
+
+type CapabilityRule<Port> = {
+  capability: GitProviderCapability;
+  supported: boolean;
+  getPort: () => Effect.Effect<Port, GitProviderCapabilityError>;
+  checkPort?: (port: Port, providerId: string) => Effect.Effect<void, GitProviderRegistrationError>;
+};
+
+function checkProvider(
+  provider: GitProviderPort,
+): Effect.Effect<void, GitProviderRegistrationError> {
+  return Effect.gen(function* () {
+    const { capabilities } = provider.getDescriptor();
+    yield* checkCapability(provider, {
+      capability: "pull_requests",
+      supported: capabilities.supportsPullRequests,
+      getPort: () => provider.pullRequests(),
+    });
+    yield* checkCapability(provider, {
+      capability: "pull_request_review",
+      supported: capabilities.supportsPullRequestReview,
+      getPort: () => provider.pullRequestReview(),
+      checkPort: checkReviewPortOwner,
+    });
+  });
+}
+
+function checkCapability<Port>(
+  provider: GitProviderPort,
+  rule: CapabilityRule<Port>,
+): Effect.Effect<void, GitProviderRegistrationError> {
+  return Effect.gen(function* () {
+    const providerId = provider.getDescriptor().id;
+    const portResult = yield* Effect.either(rule.getPort());
+    const hasPort = portResult._tag === "Right";
+    if (rule.supported !== hasPort) {
+      if (rule.supported) {
+        return yield* Effect.fail(
+          new GitProviderRegistrationError({
+            reason: "declared_capability_missing_port",
+            providerId,
+            capability: rule.capability,
+            message: `Git provider '${providerId}' declares '${rule.capability}' but does not supply its port.`,
+          }),
+        );
+      }
+
+      return yield* Effect.fail(
+        new GitProviderRegistrationError({
+          reason: "undeclared_capability_has_port",
+          providerId,
+          capability: rule.capability,
+          message: `Git provider '${providerId}' supplies '${rule.capability}' without declaring support.`,
+        }),
+      );
+    }
+
+    if (portResult._tag === "Right" && rule.checkPort) {
+      yield* rule.checkPort(portResult.right, providerId);
+    }
+  });
+}
+
+function checkReviewPortOwner(
+  port: PullRequestReviewProviderPort,
+  providerId: string,
+): Effect.Effect<void, GitProviderRegistrationError> {
+  if (port.providerId === providerId) {
+    return Effect.void;
+  }
+
+  return Effect.fail(
+    new GitProviderRegistrationError({
+      reason: "capability_provider_id_mismatch",
+      providerId,
+      capability: "pull_request_review",
+      message: `Git provider '${providerId}' supplies a Pull Request review port owned by '${port.providerId}'.`,
+    }),
+  );
+}

--- a/packages/host/src/application/pull-requests/pull-request-review-service.test.ts
+++ b/packages/host/src/application/pull-requests/pull-request-review-service.test.ts
@@ -140,9 +140,11 @@ const makeProvider = (
 };
 
 const makeService = ({
+  configuredProviderId,
   pullRequest,
   providers,
 }: {
+  configuredProviderId: GitProviderId;
   pullRequest?: PullRequest;
   providers: GitProviderPort[];
 }) => {
@@ -150,8 +152,7 @@ const makeService = ({
     getTask: () => Effect.succeed(makeTask(pullRequest)),
   };
   const workspaceSettingsService: Pick<WorkspaceSettingsService, "getRepoConfigByRepoPath"> = {
-    getRepoConfigByRepoPath: () =>
-      Effect.succeed(makeRepoConfig(pullRequest?.providerId ?? "github")),
+    getRepoConfigByRepoPath: () => Effect.succeed(makeRepoConfig(configuredProviderId)),
   };
   return createPullRequestReviewService({
     resolver: Effect.runSync(createGitProviderResolver(providers)),
@@ -165,6 +166,7 @@ describe("createPullRequestReviewService", () => {
     const githubReadContext = mock(() => Effect.succeed(makeLoadedContext("github")));
     const gitlabReadContext = mock(() => Effect.succeed(makeLoadedContext("gitlab")));
     const service = makeService({
+      configuredProviderId: "gitlab",
       pullRequest: makePullRequest("gitlab"),
       providers: [
         makeProvider("github", githubReadContext),
@@ -184,6 +186,7 @@ describe("createPullRequestReviewService", () => {
   test("does not fall back to another provider for an unsupported linked pull request", async () => {
     const githubReadContext = mock(() => Effect.succeed(makeLoadedContext("github")));
     const service = makeService({
+      configuredProviderId: "gitlab",
       pullRequest: makePullRequest("gitlab"),
       providers: [makeProvider("github", githubReadContext)],
     });
@@ -200,9 +203,35 @@ describe("createPullRequestReviewService", () => {
     expect(githubReadContext).not.toHaveBeenCalled();
   });
 
+  test("does not use a configured provider for another provider's pull request", async () => {
+    const githubReadContext = mock(() => Effect.succeed(makeLoadedContext("github")));
+    const gitlabReadContext = mock(() => Effect.succeed(makeLoadedContext("gitlab")));
+    const service = makeService({
+      configuredProviderId: "github",
+      pullRequest: makePullRequest("gitlab"),
+      providers: [
+        makeProvider("github", githubReadContext),
+        makeProvider("gitlab", gitlabReadContext),
+      ],
+    });
+
+    const context = await Effect.runPromise(
+      service.getContext({ repoPath: "/repo", taskId: "task-1" }),
+    );
+
+    expect(context).toEqual({
+      status: "unavailable",
+      providerId: "gitlab",
+      reason: "Pull request review provider 'gitlab' is not supported.",
+    });
+    expect(githubReadContext).not.toHaveBeenCalled();
+    expect(gitlabReadContext).not.toHaveBeenCalled();
+  });
+
   test("does not invoke any provider for an unlinked task", async () => {
     const githubReadContext = mock(() => Effect.succeed(makeLoadedContext("github")));
     const service = makeService({
+      configuredProviderId: "github",
       providers: [makeProvider("github", githubReadContext)],
     });
 

--- a/packages/host/src/application/pull-requests/pull-request-review-service.test.ts
+++ b/packages/host/src/application/pull-requests/pull-request-review-service.test.ts
@@ -9,6 +9,7 @@ import {
   type TaskCard,
 } from "@openducktor/contracts";
 import { Effect } from "effect";
+import { GitProviderCapabilityError } from "../../ports/git-provider-errors";
 import type { GitProviderPort, PullRequestProviderPort } from "../../ports/git-provider-port";
 import type { PullRequestReviewProviderPort } from "../../ports/pull-request-review-provider-port";
 import type { TaskReader } from "../../ports/task-repository-ports";
@@ -107,14 +108,19 @@ const makeLoadedContext = (providerId: GitProviderId): PullRequestReviewContext 
 const makeProvider = (
   providerId: GitProviderId,
   readContext: PullRequestReviewProviderPort["readContext"],
+  options: {
+    supportsReview?: boolean;
+    pullRequestReview?: GitProviderPort["pullRequestReview"];
+  } = {},
 ): GitProviderPort => {
+  const supportsReview = options.supportsReview ?? true;
   const providerDescriptor: GitProviderDescriptor = {
     id: providerId,
     label: providerId,
     description: `${providerId} provider`,
     capabilities: {
       supportsPullRequests: true,
-      supportsPullRequestReview: true,
+      supportsPullRequestReview: supportsReview,
     },
   };
   const reviewPort: PullRequestReviewProviderPort = { providerId, readContext };
@@ -135,7 +141,18 @@ const makeProvider = (
         getByNumber: () => unexpectedProviderOperation(),
         upsert: () => unexpectedProviderOperation(),
       }),
-    pullRequestReview: () => Effect.succeed(reviewPort),
+    pullRequestReview:
+      options.pullRequestReview ??
+      (() =>
+        supportsReview
+          ? Effect.succeed(reviewPort)
+          : Effect.fail(
+              new GitProviderCapabilityError({
+                providerId,
+                capability: "pull_request_review",
+                message: `Provider '${providerId}' does not support Pull Request review.`,
+              }),
+            )),
   };
 };
 
@@ -198,7 +215,27 @@ describe("createPullRequestReviewService", () => {
     expect(context).toEqual({
       status: "unavailable",
       providerId: "gitlab",
-      reason: "Pull request review provider 'gitlab' is not supported.",
+      reason: "Git provider 'gitlab' has no registered implementation.",
+    });
+    expect(githubReadContext).not.toHaveBeenCalled();
+  });
+
+  test("reports the configured provider when its implementation is not registered", async () => {
+    const githubReadContext = mock(() => Effect.succeed(makeLoadedContext("github")));
+    const service = makeService({
+      configuredProviderId: "gitlab",
+      pullRequest: makePullRequest("github"),
+      providers: [makeProvider("github", githubReadContext)],
+    });
+
+    const context = await Effect.runPromise(
+      service.getContext({ repoPath: "/repo", taskId: "task-1" }),
+    );
+
+    expect(context).toEqual({
+      status: "unavailable",
+      providerId: "github",
+      reason: "Git provider 'gitlab' has no registered implementation.",
     });
     expect(githubReadContext).not.toHaveBeenCalled();
   });
@@ -245,5 +282,60 @@ describe("createPullRequestReviewService", () => {
       reason: "Task task-1 has no linked pull request.",
     });
     expect(githubReadContext).not.toHaveBeenCalled();
+  });
+
+  test("does not read review context when the provider does not support review", async () => {
+    const readContext = mock(() => Effect.succeed(makeLoadedContext("github")));
+    const service = makeService({
+      configuredProviderId: "github",
+      pullRequest: makePullRequest("github"),
+      providers: [makeProvider("github", readContext, { supportsReview: false })],
+    });
+
+    const context = await Effect.runPromise(
+      service.getContext({ repoPath: "/repo", taskId: "task-1" }),
+    );
+
+    expect(context).toEqual({
+      status: "unavailable",
+      providerId: "github",
+      reason: "Git provider 'github' does not support Pull Request review.",
+    });
+    expect(readContext).not.toHaveBeenCalled();
+  });
+
+  test("returns a capability access failure without reading review context", async () => {
+    const readContext = mock(() => Effect.succeed(makeLoadedContext("github")));
+    const capabilityError = new GitProviderCapabilityError({
+      providerId: "github",
+      capability: "pull_request_review",
+      message: "GitHub review access is unavailable.",
+    });
+    let accessCount = 0;
+    const provider = makeProvider("github", readContext, {
+      pullRequestReview: () => {
+        accessCount += 1;
+        return accessCount === 1
+          ? Effect.succeed({ providerId: "github", readContext })
+          : Effect.fail(capabilityError);
+      },
+    });
+    const service = makeService({
+      configuredProviderId: "github",
+      pullRequest: makePullRequest("github"),
+      providers: [provider],
+    });
+
+    const context = await Effect.runPromise(
+      service.getContext({ repoPath: "/repo", taskId: "task-1" }),
+    );
+
+    expect(context).toEqual({
+      status: "unavailable",
+      providerId: "github",
+      reason: "GitHub review access is unavailable.",
+    });
+    expect(accessCount).toBe(2);
+    expect(readContext).not.toHaveBeenCalled();
   });
 });

--- a/packages/host/src/application/pull-requests/pull-request-review-service.test.ts
+++ b/packages/host/src/application/pull-requests/pull-request-review-service.test.ts
@@ -154,7 +154,7 @@ const makeService = ({
       Effect.succeed(makeRepoConfig(pullRequest?.providerId ?? "github")),
   };
   return createPullRequestReviewService({
-    resolver: createGitProviderResolver(providers),
+    resolver: Effect.runSync(createGitProviderResolver(providers)),
     taskReader,
     workspaceSettingsService,
   });

--- a/packages/host/src/application/pull-requests/pull-request-review-service.test.ts
+++ b/packages/host/src/application/pull-requests/pull-request-review-service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import {
   type GitProviderId,
+  type GitProviderDescriptor,
   type PullRequest,
   type PullRequestReviewContext,
   type RepoConfig,
@@ -8,19 +9,21 @@ import {
   type TaskCard,
 } from "@openducktor/contracts";
 import { Effect } from "effect";
+import type { GitProviderPort, PullRequestProviderPort } from "../../ports/git-provider-port";
 import type { PullRequestReviewProviderPort } from "../../ports/pull-request-review-provider-port";
 import type { TaskReader } from "../../ports/task-repository-ports";
 import type { WorkspaceSettingsService } from "../workspaces/workspace-settings-service";
+import { createGitProviderResolver } from "../git/git-provider-resolver";
 import { createPullRequestReviewService } from "./pull-request-review-service";
 
-const makeRepoConfig = (): RepoConfig =>
+const makeRepoConfig = (providerId: GitProviderId): RepoConfig =>
   repoConfigSchema.parse({
     workspaceId: "repo",
     workspaceName: "Repo",
     repoPath: "/repo",
     defaultRuntimeKind: "opencode",
     git: {
-      provider: { id: "github", enabled: true },
+      provider: { id: providerId, enabled: true },
     },
   });
 
@@ -101,21 +104,57 @@ const makeLoadedContext = (providerId: GitProviderId): PullRequestReviewContext 
   refreshedAt: "2026-07-10T08:00:00.000Z",
 });
 
+const makeProvider = (
+  providerId: GitProviderId,
+  readContext: PullRequestReviewProviderPort["readContext"],
+): GitProviderPort => {
+  const providerDescriptor: GitProviderDescriptor = {
+    id: providerId,
+    label: providerId,
+    description: `${providerId} provider`,
+    capabilities: {
+      supportsPullRequests: true,
+      supportsPullRequestReview: true,
+    },
+  };
+  const reviewPort: PullRequestReviewProviderPort = { providerId, readContext };
+  const unexpectedProviderOperation = <Success>(): Effect.Effect<Success, never> =>
+    Effect.die("Provider operation is not expected in review service tests");
+  return {
+    getDescriptor: () => providerDescriptor,
+    repository: () => ({
+      getReadRepository: () => unexpectedProviderOperation(),
+      getWriteContext: () => unexpectedProviderOperation(),
+    }),
+    health: () => ({
+      getStatus: () => unexpectedProviderOperation(),
+    }),
+    pullRequests: () =>
+      Effect.succeed<PullRequestProviderPort>({
+        findByBranch: () => unexpectedProviderOperation(),
+        getByNumber: () => unexpectedProviderOperation(),
+        upsert: () => unexpectedProviderOperation(),
+      }),
+    pullRequestReview: () => Effect.succeed(reviewPort),
+  };
+};
+
 const makeService = ({
   pullRequest,
   providers,
 }: {
   pullRequest?: PullRequest;
-  providers: PullRequestReviewProviderPort[];
+  providers: GitProviderPort[];
 }) => {
   const taskReader: Pick<TaskReader, "getTask"> = {
     getTask: () => Effect.succeed(makeTask(pullRequest)),
   };
   const workspaceSettingsService: Pick<WorkspaceSettingsService, "getRepoConfigByRepoPath"> = {
-    getRepoConfigByRepoPath: () => Effect.succeed(makeRepoConfig()),
+    getRepoConfigByRepoPath: () =>
+      Effect.succeed(makeRepoConfig(pullRequest?.providerId ?? "github")),
   };
   return createPullRequestReviewService({
-    providers,
+    resolver: createGitProviderResolver(providers),
     taskReader,
     workspaceSettingsService,
   });
@@ -128,14 +167,8 @@ describe("createPullRequestReviewService", () => {
     const service = makeService({
       pullRequest: makePullRequest("gitlab"),
       providers: [
-        {
-          providerId: "github",
-          readContext: githubReadContext,
-        },
-        {
-          providerId: "gitlab",
-          readContext: gitlabReadContext,
-        },
+        makeProvider("github", githubReadContext),
+        makeProvider("gitlab", gitlabReadContext),
       ],
     });
 
@@ -152,12 +185,7 @@ describe("createPullRequestReviewService", () => {
     const githubReadContext = mock(() => Effect.succeed(makeLoadedContext("github")));
     const service = makeService({
       pullRequest: makePullRequest("gitlab"),
-      providers: [
-        {
-          providerId: "github",
-          readContext: githubReadContext,
-        },
-      ],
+      providers: [makeProvider("github", githubReadContext)],
     });
 
     const context = await Effect.runPromise(
@@ -175,12 +203,7 @@ describe("createPullRequestReviewService", () => {
   test("does not invoke any provider for an unlinked task", async () => {
     const githubReadContext = mock(() => Effect.succeed(makeLoadedContext("github")));
     const service = makeService({
-      providers: [
-        {
-          providerId: "github",
-          readContext: githubReadContext,
-        },
-      ],
+      providers: [makeProvider("github", githubReadContext)],
     });
 
     const context = await Effect.runPromise(

--- a/packages/host/src/application/pull-requests/pull-request-review-service.ts
+++ b/packages/host/src/application/pull-requests/pull-request-review-service.ts
@@ -6,8 +6,8 @@ import {
 } from "@openducktor/contracts";
 import { Effect } from "effect";
 import { errorMessage, HostValidationError } from "../../effect/host-errors";
-import type { PullRequestReviewProviderPort } from "../../ports/pull-request-review-provider-port";
 import type { TaskReader } from "../../ports/task-repository-ports";
+import type { GitProviderResolver } from "../git/git-provider-resolver";
 import type {
   WorkspaceSettingsError,
   WorkspaceSettingsService,
@@ -47,19 +47,12 @@ const noPullRequest = (taskId: string | undefined): PullRequestReviewContext =>
     reason: taskId ? `Task ${taskId} has no linked pull request.` : "No linked pull request.",
   });
 
-const selectProvider = (
-  providers: readonly PullRequestReviewProviderPort[],
-  linkedPullRequest: PullRequest,
-): PullRequestReviewProviderPort | null => {
-  return providers.find((provider) => provider.providerId === linkedPullRequest.providerId) ?? null;
-};
-
 export const createPullRequestReviewService = ({
-  providers,
+  resolver,
   taskReader,
   workspaceSettingsService,
 }: {
-  providers: readonly PullRequestReviewProviderPort[];
+  resolver: GitProviderResolver;
   taskReader: Pick<TaskReader, "getTask">;
   workspaceSettingsService: Pick<WorkspaceSettingsService, "getRepoConfigByRepoPath">;
 }): PullRequestReviewService => {
@@ -82,23 +75,45 @@ export const createPullRequestReviewService = ({
           return noPullRequest(input.taskId);
         }
 
-        const provider = selectProvider(providers, linkedPullRequest);
-        if (!provider) {
-          const providerId = linkedPullRequest.providerId;
+        const providerId = linkedPullRequest.providerId;
+        const resolvedProvider = yield* Effect.either(resolver.resolve(repoConfig));
+        if (resolvedProvider._tag === "Left") {
+          const reason =
+            resolvedProvider.left.reason === "not_registered"
+              ? `Pull request review provider '${providerId}' is not supported.`
+              : errorMessage(resolvedProvider.left);
+          return unavailable(providerId, reason);
+        }
+
+        const provider = resolvedProvider.right;
+        const descriptor = provider.getDescriptor();
+        if (descriptor.id !== providerId) {
           return unavailable(
             providerId,
             `Pull request review provider '${providerId}' is not supported.`,
           );
         }
 
+        if (!descriptor.capabilities.supportsPullRequestReview) {
+          return unavailable(
+            providerId,
+            `Git provider '${providerId}' does not support Pull Request review.`,
+          );
+        }
+
+        const reviewProviderResult = yield* Effect.either(provider.pullRequestReview());
+        if (reviewProviderResult._tag === "Left") {
+          return unavailable(providerId, errorMessage(reviewProviderResult.left));
+        }
+        const reviewProvider = reviewProviderResult.right;
         const reviewResult = yield* Effect.either(
-          provider.readContext({
+          reviewProvider.readContext({
             repoConfig,
             linkedPullRequest,
           }),
         );
         if (reviewResult._tag === "Left") {
-          return providerError(provider.providerId, errorMessage(reviewResult.left));
+          return providerError(providerId, errorMessage(reviewResult.left));
         }
         return reviewResult.right;
       }).pipe(

--- a/packages/host/src/application/pull-requests/pull-request-review-service.ts
+++ b/packages/host/src/application/pull-requests/pull-request-review-service.ts
@@ -56,11 +56,7 @@ export const createPullRequestReviewService = ({
       const providerId = pullRequest.providerId;
       const providerResult = yield* Effect.either(resolver.resolve(repoConfig));
       if (providerResult._tag === "Left") {
-        const reason =
-          providerResult.left.reason === "not_registered"
-            ? `Pull request review provider '${providerId}' is not supported.`
-            : errorMessage(providerResult.left);
-        return unavailable(providerId, reason);
+        return unavailable(providerId, errorMessage(providerResult.left));
       }
 
       const provider = providerResult.right;

--- a/packages/host/src/application/pull-requests/pull-request-review-service.ts
+++ b/packages/host/src/application/pull-requests/pull-request-review-service.ts
@@ -26,6 +26,87 @@ export type PullRequestReviewService = {
   ): Effect.Effect<PullRequestReviewContext, PullRequestReviewServiceError>;
 };
 
+export const createPullRequestReviewService = ({
+  resolver,
+  taskReader,
+  workspaceSettingsService,
+}: {
+  resolver: GitProviderResolver;
+  taskReader: Pick<TaskReader, "getTask">;
+  workspaceSettingsService: Pick<WorkspaceSettingsService, "getRepoConfigByRepoPath">;
+}): PullRequestReviewService => ({
+  getContext(input) {
+    return Effect.gen(function* () {
+      const repoConfig = yield* workspaceSettingsService.getRepoConfigByRepoPath(input.repoPath);
+      let pullRequest: PullRequest | null = null;
+      if (input.taskId) {
+        const taskResult = yield* Effect.either(
+          taskReader.getTask({ repoPath: repoConfig.repoPath, taskId: input.taskId }),
+        );
+        if (taskResult._tag === "Left") {
+          return providerError("unknown", errorMessage(taskResult.left));
+        }
+        pullRequest = taskResult.right.pullRequest ?? null;
+      }
+
+      if (!pullRequest) {
+        return noPullRequest(input.taskId);
+      }
+
+      const providerId = pullRequest.providerId;
+      const providerResult = yield* Effect.either(resolver.resolve(repoConfig));
+      if (providerResult._tag === "Left") {
+        const reason =
+          providerResult.left.reason === "not_registered"
+            ? `Pull request review provider '${providerId}' is not supported.`
+            : errorMessage(providerResult.left);
+        return unavailable(providerId, reason);
+      }
+
+      const provider = providerResult.right;
+      const descriptor = provider.getDescriptor();
+      if (descriptor.id !== providerId) {
+        return unavailable(
+          providerId,
+          `Pull request review provider '${providerId}' is not supported.`,
+        );
+      }
+
+      if (!descriptor.capabilities.supportsPullRequestReview) {
+        return unavailable(
+          providerId,
+          `Git provider '${providerId}' does not support Pull Request review.`,
+        );
+      }
+
+      const reviewPortResult = yield* Effect.either(provider.pullRequestReview());
+      if (reviewPortResult._tag === "Left") {
+        return unavailable(providerId, errorMessage(reviewPortResult.left));
+      }
+      const reviewPort = reviewPortResult.right;
+      const contextResult = yield* Effect.either(
+        reviewPort.readContext({
+          repoConfig,
+          linkedPullRequest: pullRequest,
+        }),
+      );
+      if (contextResult._tag === "Left") {
+        return providerError(providerId, errorMessage(contextResult.left));
+      }
+      return contextResult.right;
+    }).pipe(
+      Effect.mapError((cause) =>
+        cause instanceof HostValidationError
+          ? cause
+          : new HostValidationError({
+              message: errorMessage(cause),
+              cause,
+            }),
+      ),
+    );
+  },
+});
+
 const unavailable = (providerId: GitProviderId, reason: string): PullRequestReviewContext =>
   pullRequestReviewContextSchema.parse({
     status: "unavailable",
@@ -46,86 +127,3 @@ const noPullRequest = (taskId: string | undefined): PullRequestReviewContext =>
     providerId: "unknown",
     reason: taskId ? `Task ${taskId} has no linked pull request.` : "No linked pull request.",
   });
-
-export const createPullRequestReviewService = ({
-  resolver,
-  taskReader,
-  workspaceSettingsService,
-}: {
-  resolver: GitProviderResolver;
-  taskReader: Pick<TaskReader, "getTask">;
-  workspaceSettingsService: Pick<WorkspaceSettingsService, "getRepoConfigByRepoPath">;
-}): PullRequestReviewService => {
-  return {
-    getContext(input) {
-      return Effect.gen(function* () {
-        const repoConfig = yield* workspaceSettingsService.getRepoConfigByRepoPath(input.repoPath);
-        let linkedPullRequest: PullRequest | null = null;
-        if (input.taskId) {
-          const taskResult = yield* Effect.either(
-            taskReader.getTask({ repoPath: repoConfig.repoPath, taskId: input.taskId }),
-          );
-          if (taskResult._tag === "Left") {
-            return providerError("unknown", errorMessage(taskResult.left));
-          }
-          linkedPullRequest = taskResult.right.pullRequest ?? null;
-        }
-
-        if (!linkedPullRequest) {
-          return noPullRequest(input.taskId);
-        }
-
-        const providerId = linkedPullRequest.providerId;
-        const resolvedProvider = yield* Effect.either(resolver.resolve(repoConfig));
-        if (resolvedProvider._tag === "Left") {
-          const reason =
-            resolvedProvider.left.reason === "not_registered"
-              ? `Pull request review provider '${providerId}' is not supported.`
-              : errorMessage(resolvedProvider.left);
-          return unavailable(providerId, reason);
-        }
-
-        const provider = resolvedProvider.right;
-        const descriptor = provider.getDescriptor();
-        if (descriptor.id !== providerId) {
-          return unavailable(
-            providerId,
-            `Pull request review provider '${providerId}' is not supported.`,
-          );
-        }
-
-        if (!descriptor.capabilities.supportsPullRequestReview) {
-          return unavailable(
-            providerId,
-            `Git provider '${providerId}' does not support Pull Request review.`,
-          );
-        }
-
-        const reviewProviderResult = yield* Effect.either(provider.pullRequestReview());
-        if (reviewProviderResult._tag === "Left") {
-          return unavailable(providerId, errorMessage(reviewProviderResult.left));
-        }
-        const reviewProvider = reviewProviderResult.right;
-        const reviewResult = yield* Effect.either(
-          reviewProvider.readContext({
-            repoConfig,
-            linkedPullRequest,
-          }),
-        );
-        if (reviewResult._tag === "Left") {
-          return providerError(providerId, errorMessage(reviewResult.left));
-        }
-        return reviewResult.right;
-      }).pipe(
-        Effect.mapError((cause) =>
-          cause instanceof HostValidationError
-            ? cause
-            : new HostValidationError({
-                message: errorMessage(cause),
-                cause,
-              }),
-        ),
-      );
-    },
-  };
-};

--- a/packages/host/src/application/tasks/support/github-pull-requests.test.ts
+++ b/packages/host/src/application/tasks/support/github-pull-requests.test.ts
@@ -150,10 +150,7 @@ describe("findGithubPullRequestForBranch", () => {
       findGithubPullRequestForBranch(
         dependencies,
         "/repo",
-        {
-          repository: { host: "github.com", owner: "Maxsky5", name: "openducktor" },
-          remoteName: "origin",
-        },
+        { host: "github.com", owner: "Maxsky5", name: "openducktor" },
         "odt/task-1",
         "open",
       ),

--- a/packages/host/src/application/tasks/support/github-pull-requests.ts
+++ b/packages/host/src/application/tasks/support/github-pull-requests.ts
@@ -333,13 +333,13 @@ const selectGithubPullRequestForBranch = (
 export const findGithubPullRequestForBranch = (
   dependencies: GithubCommandDependencies,
   repoPath: string,
-  context: GithubPullRequestContext,
+  repository: GitProviderRepository,
   sourceBranch: string,
   state: "open" | "all",
 ) =>
   Effect.gen(function* () {
-    const repoSlug = `${context.repository.owner}/${context.repository.name}`;
-    const payload = yield* runGithubCommand(dependencies, repoPath, context.repository.host, [
+    const repoSlug = `${repository.owner}/${repository.name}`;
+    const payload = yield* runGithubCommand(dependencies, repoPath, repository.host, [
       "api",
       "--method",
       "GET",
@@ -347,7 +347,7 @@ export const findGithubPullRequestForBranch = (
       "-f",
       `state=${state}`,
       "-f",
-      `head=${context.repository.owner}:${sourceBranch}`,
+      `head=${repository.owner}:${sourceBranch}`,
     ]);
     const parsed = yield* Effect.try({
       try: () => parseGithubPullListResponse(payload),
@@ -369,12 +369,12 @@ export const findGithubPullRequestForBranch = (
 export const fetchGithubPullRequestByNumber = (
   dependencies: GithubCommandDependencies,
   repoPath: string,
-  context: GithubPullRequestContext,
+  repository: GitProviderRepository,
   number: number,
 ) =>
   Effect.gen(function* () {
-    const repoSlug = `${context.repository.owner}/${context.repository.name}`;
-    const payload = yield* runGithubCommand(dependencies, repoPath, context.repository.host, [
+    const repoSlug = `${repository.owner}/${repository.name}`;
+    const payload = yield* runGithubCommand(dependencies, repoPath, repository.host, [
       "api",
       `repos/${repoSlug}/pulls/${number}`,
     ]);
@@ -418,7 +418,7 @@ export const fetchLinkedPullRequest = (
   return fetchGithubPullRequestByNumber(
     dependencies,
     repoPath,
-    { repository: policy.repository, remoteName: "" },
+    policy.repository,
     pullRequest.number,
   );
 };

--- a/packages/host/src/application/tasks/use-cases/detect-pull-request.ts
+++ b/packages/host/src/application/tasks/use-cases/detect-pull-request.ts
@@ -69,7 +69,7 @@ export const createTaskPullRequestDetectionUseCase = ({
       const openPullRequest = yield* findGithubPullRequestForBranch(
         dependencies,
         effectiveRepoPath,
-        githubContext,
+        githubContext.repository,
         taskContext.sourceBranch,
         "open",
       );
@@ -88,7 +88,7 @@ export const createTaskPullRequestDetectionUseCase = ({
       const pullRequest = yield* findGithubPullRequestForBranch(
         dependencies,
         effectiveRepoPath,
-        githubContext,
+        githubContext.repository,
         taskContext.sourceBranch,
         "all",
       );

--- a/packages/host/src/application/tasks/use-cases/manage-pull-requests.ts
+++ b/packages/host/src/application/tasks/use-cases/manage-pull-requests.ts
@@ -76,7 +76,7 @@ export const createTaskPullRequestManagementUseCases = ({
       const pullRequest = yield* fetchGithubPullRequestByNumber(
         dependencies,
         effectiveRepoPath,
-        githubContext,
+        githubContext.repository,
         number,
       );
       yield* taskStore.setPullRequest({

--- a/packages/host/src/composition/node/create-node-host-command-router-promise.ts
+++ b/packages/host/src/composition/node/create-node-host-command-router-promise.ts
@@ -1,0 +1,14 @@
+import { Effect } from "effect";
+import {
+  type HostCommandRouter,
+  toPromiseHostCommandRouter,
+} from "../../interface/router/host-command-router";
+import { createNodeEffectHostCommandRouter } from "./create-node-host-command-router";
+import type { CreateNodeHostCommandRouterInput } from "./node-host-command-router-types";
+
+export const createNodeHostCommandRouter = (
+  input: CreateNodeHostCommandRouterInput,
+): Promise<HostCommandRouter> =>
+  Effect.runPromise(
+    createNodeEffectHostCommandRouter(input).pipe(Effect.map(toPromiseHostCommandRouter)),
+  );

--- a/packages/host/src/composition/node/create-node-host-command-router.test.ts
+++ b/packages/host/src/composition/node/create-node-host-command-router.test.ts
@@ -17,6 +17,7 @@ import {
   type CreateNodeHostCommandRouterInput,
   createNodeEffectHostCommandRouter,
 } from "./create-node-host-command-router";
+import { createNodeHostCommandRouter } from "./create-node-host-command-router-promise";
 import { createLiveSessionFaultLogger } from "./node-host-lifecycle-logger";
 
 const runtimeDistribution = createSourceRuntimeDistribution(
@@ -84,6 +85,19 @@ const createLogger = () => {
   return { errors, infos, logger };
 };
 
+const createFailingRouterInput = (): CreateNodeHostCommandRouterInput => ({
+  mcpBridgeDiscoveryMode: "production",
+  onBackgroundFailure: () => Effect.void,
+  runtimeDistribution: {
+    ...runtimeDistribution,
+    get mode(): typeof runtimeDistribution.mode {
+      throw new Error("Default port setup failed");
+    },
+  },
+  taskEventPublicationReporter: { report: () => Effect.void },
+  terminalPty,
+});
+
 const createRouter = (input: {
   eventBus?: HostEventBusPort;
   logger: HostLifecycleLogger;
@@ -108,6 +122,29 @@ const createRouter = (input: {
 };
 
 describe("createNodeEffectHostCommandRouter", () => {
+  test("returns synchronous setup faults through the Effect channel", async () => {
+    const result = await Effect.runPromise(
+      createNodeEffectHostCommandRouter(createFailingRouterInput()).pipe(Effect.either),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toEqual(
+        expect.objectContaining({
+          _tag: "HostOperationError",
+          operation: "host.create-router",
+          message: "Default port setup failed",
+        }),
+      );
+    }
+  });
+
+  test("rejects the Promise boundary for synchronous setup faults", async () => {
+    const router = createNodeHostCommandRouter(createFailingRouterInput());
+
+    await expect(router).rejects.toThrow("Default port setup failed");
+  });
+
   test("publishes development discovery from composition mode despite ambient channel", async () => {
     const configDir = await mkdtemp(path.join(tmpdir(), "openducktor-node-host-discovery-"));
     const { logger } = createLogger();

--- a/packages/host/src/composition/node/create-node-host-command-router.test.ts
+++ b/packages/host/src/composition/node/create-node-host-command-router.test.ts
@@ -20,9 +20,8 @@ import {
 import { createNodeHostCommandRouter } from "./create-node-host-command-router-promise";
 import { createLiveSessionFaultLogger } from "./node-host-lifecycle-logger";
 
-const runtimeDistribution = createSourceRuntimeDistribution(
-  path.resolve(import.meta.dir, "../../../../.."),
-);
+const createRuntimeDistribution = () =>
+  createSourceRuntimeDistribution(path.resolve(import.meta.dir, "../../../../.."));
 
 const createRuntimeRegistry = (
   stopAllRuntimes: RuntimeRegistryPort["stopAllRuntimes"] = () => Effect.succeed([]),
@@ -89,12 +88,25 @@ const createFailingRouterInput = (): CreateNodeHostCommandRouterInput => ({
   mcpBridgeDiscoveryMode: "production",
   onBackgroundFailure: () => Effect.void,
   runtimeDistribution: {
-    ...runtimeDistribution,
-    get mode(): typeof runtimeDistribution.mode {
+    ...createRuntimeDistribution(),
+    get mode(): "source" {
       throw new Error("Default port setup failed");
     },
   },
   taskEventPublicationReporter: { report: () => Effect.void },
+  terminalPty,
+});
+
+const createAssemblyFailingRouterInput = (): CreateNodeHostCommandRouterInput => ({
+  get lifecycleLogger(): HostLifecycleLogger {
+    throw new Error("Router assembly failed");
+  },
+  mcpBridgeDiscoveryMode: "production",
+  onBackgroundFailure: () => Effect.void,
+  runtimeDistribution: createRuntimeDistribution(),
+  runtimeRegistry: createRuntimeRegistry(),
+  taskEventPublicationReporter: { report: () => Effect.void },
+  taskStore: createTaskStoreTestDouble({}),
   terminalPty,
 });
 
@@ -110,7 +122,7 @@ const createRouter = (input: {
     mcpHostBridge: createMcpHostBridge(),
     onBackgroundFailure: input.onBackgroundFailure ?? (() => Effect.void),
     taskEventPublicationReporter: { report: () => Effect.void },
-    runtimeDistribution,
+    runtimeDistribution: createRuntimeDistribution(),
     runtimeRegistry: input.runtimeRegistry ?? createRuntimeRegistry(),
     taskStore: createTaskStoreTestDouble({}),
     terminalPty,
@@ -145,6 +157,23 @@ describe("createNodeEffectHostCommandRouter", () => {
     await expect(router).rejects.toThrow("Default port setup failed");
   });
 
+  test("returns synchronous assembly faults through the Effect channel", async () => {
+    const result = await Effect.runPromise(
+      createNodeEffectHostCommandRouter(createAssemblyFailingRouterInput()).pipe(Effect.either),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toEqual(
+        expect.objectContaining({
+          _tag: "HostOperationError",
+          operation: "host.create-router",
+          message: "Router assembly failed",
+        }),
+      );
+    }
+  });
+
   test("publishes development discovery from composition mode despite ambient channel", async () => {
     const configDir = await mkdtemp(path.join(tmpdir(), "openducktor-node-host-discovery-"));
     const { logger } = createLogger();
@@ -158,7 +187,7 @@ describe("createNodeEffectHostCommandRouter", () => {
           OPENDUCKTOR_CONFIG_DIR: configDir,
           OPENDUCKTOR_DEV_INSTANCE: "browser-0123456789ab",
         },
-        runtimeDistribution,
+        runtimeDistribution: createRuntimeDistribution(),
         runtimeRegistry: createRuntimeRegistry(),
         taskEventPublicationReporter: { report: () => Effect.void },
         taskStore: createTaskStoreTestDouble({}),

--- a/packages/host/src/composition/node/create-node-host-command-router.test.ts
+++ b/packages/host/src/composition/node/create-node-host-command-router.test.ts
@@ -104,28 +104,30 @@ const createRouter = (input: {
   if (input.eventBus) {
     routerInput.eventBus = input.eventBus;
   }
-  return createNodeEffectHostCommandRouter(routerInput);
+  return Effect.runSync(createNodeEffectHostCommandRouter(routerInput));
 };
 
 describe("createNodeEffectHostCommandRouter", () => {
   test("publishes development discovery from composition mode despite ambient channel", async () => {
     const configDir = await mkdtemp(path.join(tmpdir(), "openducktor-node-host-discovery-"));
     const { logger } = createLogger();
-    const router = createNodeEffectHostCommandRouter({
-      lifecycleLogger: logger,
-      mcpBridgeDiscoveryMode: "development",
-      onBackgroundFailure: () => Effect.void,
-      processEnv: {
-        OPENDUCKTOR_CHANNEL: "production",
-        OPENDUCKTOR_CONFIG_DIR: configDir,
-        OPENDUCKTOR_DEV_INSTANCE: "browser-0123456789ab",
-      },
-      runtimeDistribution,
-      runtimeRegistry: createRuntimeRegistry(),
-      taskEventPublicationReporter: { report: () => Effect.void },
-      taskStore: createTaskStoreTestDouble({}),
-      terminalPty,
-    });
+    const router = Effect.runSync(
+      createNodeEffectHostCommandRouter({
+        lifecycleLogger: logger,
+        mcpBridgeDiscoveryMode: "development",
+        onBackgroundFailure: () => Effect.void,
+        processEnv: {
+          OPENDUCKTOR_CHANNEL: "production",
+          OPENDUCKTOR_CONFIG_DIR: configDir,
+          OPENDUCKTOR_DEV_INSTANCE: "browser-0123456789ab",
+        },
+        runtimeDistribution,
+        runtimeRegistry: createRuntimeRegistry(),
+        taskEventPublicationReporter: { report: () => Effect.void },
+        taskStore: createTaskStoreTestDouble({}),
+        terminalPty,
+      }),
+    );
 
     try {
       await Effect.runPromise(router.initialize());

--- a/packages/host/src/composition/node/create-node-host-command-router.ts
+++ b/packages/host/src/composition/node/create-node-host-command-router.ts
@@ -77,7 +77,7 @@ import type {
 } from "./node-host-command-router-types";
 import { createNodeHostDefaultPorts } from "./node-host-default-ports";
 import { createLiveSessionFaultLogger, defaultLifecycleLogger } from "./node-host-lifecycle-logger";
-import { createGitProviders, createNodeGitProviderResolver } from "./git-provider-composition";
+import { createNodeGitProviderResolver } from "./git-provider-composition";
 import { createNodeRuntimeExecutableCommandHandlers } from "./node-runtime-executable-command-handlers";
 import { createNodeTaskAssetServices } from "./node-task-asset-services";
 import { createNodeTaskEventServices } from "./node-task-event-services";
@@ -491,9 +491,9 @@ export const createNodeEffectHostCommandRouter = (input: CreateNodeHostCommandRo
   }).pipe(
     Effect.flatMap((defaultPorts) => {
       const { git, systemCommands, toolDiscovery } = defaultPorts;
-      const providers = createGitProviders({ gitPort: git, systemCommands, toolDiscovery });
-      return Effect.map(createNodeGitProviderResolver(providers), (resolver) =>
-        assembleNodeEffectHostCommandRouter(input, defaultPorts, resolver),
+      return Effect.map(
+        createNodeGitProviderResolver({ gitPort: git, systemCommands, toolDiscovery }),
+        (resolver) => assembleNodeEffectHostCommandRouter(input, defaultPorts, resolver),
       );
     }),
   );

--- a/packages/host/src/composition/node/create-node-host-command-router.ts
+++ b/packages/host/src/composition/node/create-node-host-command-router.ts
@@ -74,7 +74,7 @@ import type {
 } from "./node-host-command-router-types";
 import { createNodeHostDefaultPorts } from "./node-host-default-ports";
 import { createLiveSessionFaultLogger, defaultLifecycleLogger } from "./node-host-lifecycle-logger";
-import { createDefaultNodeGitProviderResolver } from "./git-provider-composition";
+import { createGitProviders, createNodeGitProviderResolver } from "./git-provider-composition";
 import { createNodeRuntimeExecutableCommandHandlers } from "./node-runtime-executable-command-handlers";
 import { createNodeTaskAssetServices } from "./node-task-asset-services";
 import { createNodeTaskEventServices } from "./node-task-event-services";
@@ -488,11 +488,12 @@ export const createNodeEffectHostCommandRouter = (
   input: CreateNodeHostCommandRouterInput,
 ): Effect.Effect<EffectNodeHostCommandRouter, GitProviderRegistrationError> => {
   const defaultPorts = createNodeHostDefaultPorts(input);
-  return createDefaultNodeGitProviderResolver({
+  const providers = createGitProviders({
     gitPort: defaultPorts.git,
     systemCommands: defaultPorts.systemCommands,
     toolDiscovery: defaultPorts.toolDiscovery,
-  }).pipe(
+  });
+  return createNodeGitProviderResolver(providers).pipe(
     Effect.map((resolver) => assembleNodeEffectHostCommandRouter(input, defaultPorts, resolver)),
   );
 };

--- a/packages/host/src/composition/node/create-node-host-command-router.ts
+++ b/packages/host/src/composition/node/create-node-host-command-router.ts
@@ -35,8 +35,11 @@ import { createTerminalService } from "../../application/terminals/terminal-serv
 import { loadGlobalConfig } from "../../application/workspaces/workspace-settings-model";
 import { createWorkspaceSettingsService } from "../../application/workspaces/workspace-settings-service";
 import type { GitProviderResolver } from "../../application/git/git-provider-resolver";
-import { HostOperationError, HostResourceError } from "../../effect/host-errors";
-import type { GitProviderRegistrationError } from "../../ports/git-provider-errors";
+import {
+  HostOperationError,
+  HostResourceError,
+  toHostOperationError,
+} from "../../effect/host-errors";
 import { createTerminalLaunchEnvironment } from "../../infrastructure/terminals/terminal-launch-environment";
 import { createAgentSessionLiveCommandHandlers } from "../../interface/commands/agent-session-live-command-handlers";
 import { createClaudeRuntimeCommandHandlers } from "../../interface/commands/claude-runtime-command-handlers";
@@ -326,7 +329,6 @@ const assembleNodeEffectHostCommandRouter = (
 
   let pullRequestSyncLoop: TaskSyncLoopHandle | null = null;
   let taskAssetStagingSwept = false;
-
   const stopPullRequestSyncLoop = () =>
     Effect.gen(function* () {
       if (!pullRequestSyncLoop) {
@@ -342,7 +344,6 @@ const assembleNodeEffectHostCommandRouter = (
       pullRequestSyncLoop = null;
       yield* writeHostLifecycleLog(lifecycleLogger, "info", "Pull request sync loop stopped");
     });
-
   const router = createEffectHostCommandRouter({
     initialize: () =>
       Effect.gen(function* () {
@@ -483,17 +484,16 @@ const assembleNodeEffectHostCommandRouter = (
   });
   return Object.assign(router, { taskAssetReadService, taskEventStream, terminalService });
 };
-
-export const createNodeEffectHostCommandRouter = (
-  input: CreateNodeHostCommandRouterInput,
-): Effect.Effect<EffectNodeHostCommandRouter, GitProviderRegistrationError> => {
-  const defaultPorts = createNodeHostDefaultPorts(input);
-  const providers = createGitProviders({
-    gitPort: defaultPorts.git,
-    systemCommands: defaultPorts.systemCommands,
-    toolDiscovery: defaultPorts.toolDiscovery,
-  });
-  return createNodeGitProviderResolver(providers).pipe(
-    Effect.map((resolver) => assembleNodeEffectHostCommandRouter(input, defaultPorts, resolver)),
+export const createNodeEffectHostCommandRouter = (input: CreateNodeHostCommandRouterInput) =>
+  Effect.try({
+    try: () => createNodeHostDefaultPorts(input),
+    catch: (cause) => toHostOperationError(cause, "host.create-router"),
+  }).pipe(
+    Effect.flatMap((defaultPorts) => {
+      const { git, systemCommands, toolDiscovery } = defaultPorts;
+      const providers = createGitProviders({ gitPort: git, systemCommands, toolDiscovery });
+      return Effect.map(createNodeGitProviderResolver(providers), (resolver) =>
+        assembleNodeEffectHostCommandRouter(input, defaultPorts, resolver),
+      );
+    }),
   );
-};

--- a/packages/host/src/composition/node/create-node-host-command-router.ts
+++ b/packages/host/src/composition/node/create-node-host-command-router.ts
@@ -326,7 +326,6 @@ const assembleNodeEffectHostCommandRouter = (
     taskReader: taskStore,
     logger: lifecycleLogger,
   });
-
   let pullRequestSyncLoop: TaskSyncLoopHandle | null = null;
   let taskAssetStagingSwept = false;
   const stopPullRequestSyncLoop = () =>
@@ -485,15 +484,16 @@ const assembleNodeEffectHostCommandRouter = (
   return Object.assign(router, { taskAssetReadService, taskEventStream, terminalService });
 };
 export const createNodeEffectHostCommandRouter = (input: CreateNodeHostCommandRouterInput) =>
-  Effect.try({
-    try: () => createNodeHostDefaultPorts(input),
-    catch: (cause) => toHostOperationError(cause, "host.create-router"),
-  }).pipe(
-    Effect.flatMap((defaultPorts) => {
-      const { git, systemCommands, toolDiscovery } = defaultPorts;
-      return Effect.map(
-        createNodeGitProviderResolver({ gitPort: git, systemCommands, toolDiscovery }),
-        (resolver) => assembleNodeEffectHostCommandRouter(input, defaultPorts, resolver),
-      );
-    }),
-  );
+  Effect.gen(function* () {
+    const defaultPorts = yield* Effect.try({
+      try: () => createNodeHostDefaultPorts(input),
+      catch: (cause) => toHostOperationError(cause, "host.create-router"),
+    });
+    const { git, systemCommands, toolDiscovery } = defaultPorts;
+    const providerInput = { gitPort: git, systemCommands, toolDiscovery };
+    const resolver = yield* createNodeGitProviderResolver(providerInput);
+    return yield* Effect.try({
+      try: () => assembleNodeEffectHostCommandRouter(input, defaultPorts, resolver),
+      catch: (cause) => toHostOperationError(cause, "host.create-router"),
+    });
+  });

--- a/packages/host/src/composition/node/create-node-host-command-router.ts
+++ b/packages/host/src/composition/node/create-node-host-command-router.ts
@@ -9,7 +9,6 @@ import {
   resolveMcpBridgeDiscoveryPath,
 } from "../../adapters/mcp/mcp-host-bridge-server";
 import { createOpenCodeWorkspaceRuntimeStarter } from "../../adapters/opencode/opencode-workspace-runtime-starter";
-import { createGithubPullRequestReviewAdapter } from "../../adapters/pull-requests/github/github-pull-request-review-adapter";
 import { createRuntimeRegistry } from "../../adapters/runtimes/runtime-registry";
 import { createRuntimeSessionOperations } from "../../adapters/runtimes/runtime-session-operations";
 import { createRuntimeTaskActivityGuard } from "../../adapters/runtimes/runtime-task-activity-guard";
@@ -29,7 +28,6 @@ import { createRuntimeDefinitionsService } from "../../application/runtimes/runt
 import { createRuntimeOrchestratorService } from "../../application/runtimes/runtime-orchestrator-service";
 import { readSavedRuntimeExecutablePath } from "../../application/runtimes/saved-runtime-executable";
 import { createOpenInToolsService } from "../../application/system/open-in-tools-service";
-import { createGithubCommandDependencies } from "../../application/tasks/support/github-pull-requests";
 import type { TaskSyncLoopHandle } from "../../application/tasks/sync/task-sync-service";
 import { createTaskServiceWithMutationProgress } from "../../application/tasks/task-service";
 import { createTaskWorktreeService } from "../../application/tasks/worktrees/task-worktree-service";
@@ -78,6 +76,7 @@ import type {
 } from "./node-host-command-router-types";
 import { createNodeHostDefaultPorts } from "./node-host-default-ports";
 import { createLiveSessionFaultLogger, defaultLifecycleLogger } from "./node-host-lifecycle-logger";
+import { createNodeGitProviderResolver } from "./git-provider-composition";
 import { createNodeRuntimeExecutableCommandHandlers } from "./node-runtime-executable-command-handlers";
 import { createNodeTaskAssetServices } from "./node-task-asset-services";
 import { createNodeTaskEventServices } from "./node-task-event-services";
@@ -307,16 +306,13 @@ export const createNodeEffectHostCommandRouter = (
     taskService,
     workspaceSettingsService,
   });
-  const githubCommandDependencies = createGithubCommandDependencies({
+  const gitProviderResolver = createNodeGitProviderResolver({
+    gitPort: git,
     systemCommands,
     toolDiscovery,
   });
   const pullRequestReviewService = createPullRequestReviewService({
-    providers: [
-      createGithubPullRequestReviewAdapter({
-        githubDependencies: githubCommandDependencies,
-      }),
-    ],
+    resolver: gitProviderResolver,
     taskReader: taskStore,
     workspaceSettingsService,
   });

--- a/packages/host/src/composition/node/create-node-host-command-router.ts
+++ b/packages/host/src/composition/node/create-node-host-command-router.ts
@@ -34,7 +34,9 @@ import { createTaskWorktreeService } from "../../application/tasks/worktrees/tas
 import { createTerminalService } from "../../application/terminals/terminal-service";
 import { loadGlobalConfig } from "../../application/workspaces/workspace-settings-model";
 import { createWorkspaceSettingsService } from "../../application/workspaces/workspace-settings-service";
+import type { GitProviderResolver } from "../../application/git/git-provider-resolver";
 import { HostOperationError, HostResourceError } from "../../effect/host-errors";
+import type { GitProviderRegistrationError } from "../../ports/git-provider-errors";
 import { createTerminalLaunchEnvironment } from "../../infrastructure/terminals/terminal-launch-environment";
 import { createAgentSessionLiveCommandHandlers } from "../../interface/commands/agent-session-live-command-handlers";
 import { createClaudeRuntimeCommandHandlers } from "../../interface/commands/claude-runtime-command-handlers";
@@ -56,11 +58,7 @@ import { createTaskWorktreeCommandHandlers } from "../../interface/commands/task
 import { createTerminalCommandHandlers } from "../../interface/commands/terminal-command-handlers";
 import { createWorkspaceFilesCommandHandlers } from "../../interface/commands/workspace-files-command-handlers";
 import { createWorkspaceSettingsCommandHandlers } from "../../interface/commands/workspace-settings-command-handlers";
-import {
-  createEffectHostCommandRouter,
-  type HostCommandRouter,
-  toPromiseHostCommandRouter,
-} from "../../interface/router/host-command-router";
+import { createEffectHostCommandRouter } from "../../interface/router/host-command-router";
 import {
   createStopDevServersStep,
   createStopMcpHostBridgeStep,
@@ -76,7 +74,7 @@ import type {
 } from "./node-host-command-router-types";
 import { createNodeHostDefaultPorts } from "./node-host-default-ports";
 import { createLiveSessionFaultLogger, defaultLifecycleLogger } from "./node-host-lifecycle-logger";
-import { createNodeGitProviderResolver } from "./git-provider-composition";
+import { createDefaultNodeGitProviderResolver } from "./git-provider-composition";
 import { createNodeRuntimeExecutableCommandHandlers } from "./node-runtime-executable-command-handlers";
 import { createNodeTaskAssetServices } from "./node-task-asset-services";
 import { createNodeTaskEventServices } from "./node-task-event-services";
@@ -85,8 +83,10 @@ import { resolveWorkspaceRuntimeMcpBridgeConnection } from "./workspace-runtime-
 
 export type { CreateNodeHostCommandRouterInput, EffectNodeHostCommandRouter };
 
-export const createNodeEffectHostCommandRouter = (
+const assembleNodeEffectHostCommandRouter = (
   input: CreateNodeHostCommandRouterInput,
+  defaultPorts: ReturnType<typeof createNodeHostDefaultPorts>,
+  gitProviderResolver: GitProviderResolver,
 ): EffectNodeHostCommandRouter => {
   const {
     clientVersion,
@@ -115,7 +115,7 @@ export const createNodeEffectHostCommandRouter = (
     terminalPty,
     toolDiscovery,
     worktreeFiles,
-  } = createNodeHostDefaultPorts(input);
+  } = defaultPorts;
   const codexAppServerService = createCodexAppServerService(effectiveCodexAppServer);
   const liveSessionAdapterRegistry = createLiveSessionAdapterRegistry();
   const agentSessionLiveStateService = createAgentSessionLiveStateService({
@@ -306,11 +306,6 @@ export const createNodeEffectHostCommandRouter = (
     taskService,
     workspaceSettingsService,
   });
-  const gitProviderResolver = createNodeGitProviderResolver({
-    gitPort: git,
-    systemCommands,
-    toolDiscovery,
-  });
   const pullRequestReviewService = createPullRequestReviewService({
     resolver: gitProviderResolver,
     taskReader: taskStore,
@@ -489,6 +484,15 @@ export const createNodeEffectHostCommandRouter = (
   return Object.assign(router, { taskAssetReadService, taskEventStream, terminalService });
 };
 
-export const createNodeHostCommandRouter = (
+export const createNodeEffectHostCommandRouter = (
   input: CreateNodeHostCommandRouterInput,
-): HostCommandRouter => toPromiseHostCommandRouter(createNodeEffectHostCommandRouter(input));
+): Effect.Effect<EffectNodeHostCommandRouter, GitProviderRegistrationError> => {
+  const defaultPorts = createNodeHostDefaultPorts(input);
+  return createDefaultNodeGitProviderResolver({
+    gitPort: defaultPorts.git,
+    systemCommands: defaultPorts.systemCommands,
+    toolDiscovery: defaultPorts.toolDiscovery,
+  }).pipe(
+    Effect.map((resolver) => assembleNodeEffectHostCommandRouter(input, defaultPorts, resolver)),
+  );
+};

--- a/packages/host/src/composition/node/git-provider-composition.test.ts
+++ b/packages/host/src/composition/node/git-provider-composition.test.ts
@@ -1,58 +1,21 @@
 import { expect, test } from "bun:test";
-import { repoConfigSchema, type GitProviderDescriptor } from "@openducktor/contracts";
+import { GITHUB_PROVIDER_DESCRIPTOR, repoConfigSchema } from "@openducktor/contracts";
 import { Effect } from "effect";
-import type {
-  GitProviderHealthPort,
-  GitProviderPort,
-  GitProviderRepositoryPort,
-  PullRequestProviderPort,
-} from "../../ports/git-provider-port";
-import type { PullRequestReviewProviderPort } from "../../ports/pull-request-review-provider-port";
+import { createGithubReviewTestDependencies } from "../../adapters/pull-requests/github/github-pull-request-review.test-support";
+import { createGitPortTestDouble } from "../../test-support/service-test-doubles";
 import { createNodeGitProviderResolver } from "./git-provider-composition";
 
-const unexpectedPortCall = <Success>(): Effect.Effect<Success, never> =>
-  Effect.die("Provider operation is not expected in composition tests");
-
-const descriptor: GitProviderDescriptor = {
-  id: "github",
-  label: "GitHub",
-  description: "GitHub provider",
-  capabilities: {
-    supportsPullRequests: true,
-    supportsPullRequestReview: true,
-  },
-};
-
-const repositoryPort: GitProviderRepositoryPort = {
-  getReadRepository: () => unexpectedPortCall(),
-  getWriteContext: () => unexpectedPortCall(),
-};
-
-const healthPort: GitProviderHealthPort = {
-  getStatus: () => unexpectedPortCall(),
-};
-
-const pullRequestPort: PullRequestProviderPort = {
-  findByBranch: () => unexpectedPortCall(),
-  getByNumber: () => unexpectedPortCall(),
-  upsert: () => unexpectedPortCall(),
-};
-
-const reviewPort: PullRequestReviewProviderPort = {
-  providerId: "github",
-  readContext: () => unexpectedPortCall(),
-};
-
-const asyncProvider: GitProviderPort = {
-  getDescriptor: () => descriptor,
-  repository: () => repositoryPort,
-  health: () => healthPort,
-  pullRequests: () => Effect.promise(() => Promise.resolve(pullRequestPort)),
-  pullRequestReview: () => Effect.promise(() => Promise.resolve(reviewPort)),
-};
-
-test("node composition accepts asynchronous capability registrations", async () => {
-  const resolver = await Effect.runPromise(createNodeGitProviderResolver([asyncProvider]));
+test("node composition registers the GitHub provider", async () => {
+  const githubDependencies = createGithubReviewTestDependencies(() =>
+    Effect.die("GitHub command execution is not expected in composition tests"),
+  );
+  const resolver = await Effect.runPromise(
+    createNodeGitProviderResolver({
+      gitPort: createGitPortTestDouble({}),
+      systemCommands: githubDependencies.systemCommands,
+      toolDiscovery: githubDependencies.toolDiscovery,
+    }),
+  );
   const repoConfig = repoConfigSchema.parse({
     workspaceId: "repo",
     workspaceName: "Repo",
@@ -63,5 +26,5 @@ test("node composition accepts asynchronous capability registrations", async () 
 
   const resolved = await Effect.runPromise(resolver.resolve(repoConfig));
 
-  expect(resolved).toBe(asyncProvider);
+  expect(resolved.getDescriptor()).toBe(GITHUB_PROVIDER_DESCRIPTOR);
 });

--- a/packages/host/src/composition/node/git-provider-composition.test.ts
+++ b/packages/host/src/composition/node/git-provider-composition.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import { repoConfigSchema, type GitProviderDescriptor } from "@openducktor/contracts";
+import { Effect } from "effect";
+import type {
+  GitProviderHealthPort,
+  GitProviderPort,
+  GitProviderRepositoryPort,
+  PullRequestProviderPort,
+} from "../../ports/git-provider-port";
+import type { PullRequestReviewProviderPort } from "../../ports/pull-request-review-provider-port";
+import { createNodeGitProviderResolver } from "./git-provider-composition";
+
+const unexpectedPortCall = <Success>(): Effect.Effect<Success, never> =>
+  Effect.die("Provider operation is not expected in composition tests");
+
+const descriptor: GitProviderDescriptor = {
+  id: "github",
+  label: "GitHub",
+  description: "GitHub provider",
+  capabilities: {
+    supportsPullRequests: true,
+    supportsPullRequestReview: true,
+  },
+};
+
+const repositoryPort: GitProviderRepositoryPort = {
+  getReadRepository: () => unexpectedPortCall(),
+  getWriteContext: () => unexpectedPortCall(),
+};
+
+const healthPort: GitProviderHealthPort = {
+  getStatus: () => unexpectedPortCall(),
+};
+
+const pullRequestPort: PullRequestProviderPort = {
+  findByBranch: () => unexpectedPortCall(),
+  getByNumber: () => unexpectedPortCall(),
+  upsert: () => unexpectedPortCall(),
+};
+
+const reviewPort: PullRequestReviewProviderPort = {
+  providerId: "github",
+  readContext: () => unexpectedPortCall(),
+};
+
+const asyncProvider: GitProviderPort = {
+  getDescriptor: () => descriptor,
+  repository: () => repositoryPort,
+  health: () => healthPort,
+  pullRequests: () => Effect.promise(() => Promise.resolve(pullRequestPort)),
+  pullRequestReview: () => Effect.promise(() => Promise.resolve(reviewPort)),
+};
+
+test("node composition accepts asynchronous capability registrations", async () => {
+  const resolver = await Effect.runPromise(createNodeGitProviderResolver([asyncProvider]));
+  const repoConfig = repoConfigSchema.parse({
+    workspaceId: "repo",
+    workspaceName: "Repo",
+    repoPath: "/repo",
+    defaultRuntimeKind: "opencode",
+    git: { provider: { id: "github", enabled: true } },
+  });
+
+  const resolved = await Effect.runPromise(resolver.resolve(repoConfig));
+
+  expect(resolved).toBe(asyncProvider);
+});

--- a/packages/host/src/composition/node/git-provider-composition.ts
+++ b/packages/host/src/composition/node/git-provider-composition.ts
@@ -14,10 +14,10 @@ import type { ToolDiscoveryPort } from "../../ports/tool-discovery-port";
 type GitProviderResolverEffect = Effect.Effect<GitProviderResolver, GitProviderRegistrationError>;
 
 export const createNodeGitProviderResolver = (
-  registrations: readonly GitProviderPort[],
-): GitProviderResolverEffect => createGitProviderResolver(registrations);
+  providers: readonly GitProviderPort[],
+): GitProviderResolverEffect => createGitProviderResolver(providers);
 
-export const createDefaultNodeGitProviderResolver = ({
+export const createGitProviders = ({
   gitPort,
   systemCommands,
   toolDiscovery,
@@ -25,9 +25,7 @@ export const createDefaultNodeGitProviderResolver = ({
   gitPort: GitPort;
   systemCommands: SystemCommandPort;
   toolDiscovery: ToolDiscoveryPort;
-}): GitProviderResolverEffect => {
+}): readonly GitProviderPort[] => {
   const githubDependencies = createGithubCommandDependencies({ systemCommands, toolDiscovery });
-  return createNodeGitProviderResolver([
-    new GithubProviderAdapter({ githubDependencies, gitPort }),
-  ]);
+  return [new GithubProviderAdapter({ githubDependencies, gitPort })];
 };

--- a/packages/host/src/composition/node/git-provider-composition.ts
+++ b/packages/host/src/composition/node/git-provider-composition.ts
@@ -1,4 +1,5 @@
 import { GithubProviderAdapter } from "../../adapters/git-providers/github-provider-adapter";
+import { Effect } from "effect";
 import {
   createGitProviderResolver,
   type GitProviderResolver,
@@ -18,5 +19,7 @@ export const createNodeGitProviderResolver = ({
   toolDiscovery: ToolDiscoveryPort;
 }): GitProviderResolver => {
   const githubDependencies = createGithubCommandDependencies({ systemCommands, toolDiscovery });
-  return createGitProviderResolver([new GithubProviderAdapter({ githubDependencies, gitPort })]);
+  return Effect.runSync(
+    createGitProviderResolver([new GithubProviderAdapter({ githubDependencies, gitPort })]),
+  );
 };

--- a/packages/host/src/composition/node/git-provider-composition.ts
+++ b/packages/host/src/composition/node/git-provider-composition.ts
@@ -1,24 +1,33 @@
+import { Effect } from "effect";
 import { GithubProviderAdapter } from "../../adapters/git-providers/github-provider-adapter";
-import { createGitProviderResolver } from "../../application/git/git-provider-resolver";
+import {
+  createGitProviderResolver,
+  type GitProviderResolver,
+} from "../../application/git/git-provider-resolver";
 import { createGithubCommandDependencies } from "../../application/tasks/support/github-pull-requests";
 import type { GitPort } from "../../ports/git-port";
+import type { GitProviderRegistrationError } from "../../ports/git-provider-errors";
 import type { GitProviderPort } from "../../ports/git-provider-port";
 import type { SystemCommandPort } from "../../ports/system-command-port";
 import type { ToolDiscoveryPort } from "../../ports/tool-discovery-port";
 
-export const createNodeGitProviderResolver = (registrations: readonly GitProviderPort[]) =>
-  createGitProviderResolver(registrations);
+type GitProviderResolverEffect = Effect.Effect<GitProviderResolver, GitProviderRegistrationError>;
 
-export const createDefaultNodeGitProviderResolver = (input: {
+export const createNodeGitProviderResolver = (
+  registrations: readonly GitProviderPort[],
+): GitProviderResolverEffect => createGitProviderResolver(registrations);
+
+export const createDefaultNodeGitProviderResolver = ({
+  gitPort,
+  systemCommands,
+  toolDiscovery,
+}: {
   gitPort: GitPort;
   systemCommands: SystemCommandPort;
   toolDiscovery: ToolDiscoveryPort;
-}) => {
-  const githubDependencies = createGithubCommandDependencies({
-    systemCommands: input.systemCommands,
-    toolDiscovery: input.toolDiscovery,
-  });
+}): GitProviderResolverEffect => {
+  const githubDependencies = createGithubCommandDependencies({ systemCommands, toolDiscovery });
   return createNodeGitProviderResolver([
-    new GithubProviderAdapter({ githubDependencies, gitPort: input.gitPort }),
+    new GithubProviderAdapter({ githubDependencies, gitPort }),
   ]);
 };

--- a/packages/host/src/composition/node/git-provider-composition.ts
+++ b/packages/host/src/composition/node/git-provider-composition.ts
@@ -1,25 +1,24 @@
 import { GithubProviderAdapter } from "../../adapters/git-providers/github-provider-adapter";
-import { Effect } from "effect";
-import {
-  createGitProviderResolver,
-  type GitProviderResolver,
-} from "../../application/git/git-provider-resolver";
+import { createGitProviderResolver } from "../../application/git/git-provider-resolver";
 import { createGithubCommandDependencies } from "../../application/tasks/support/github-pull-requests";
 import type { GitPort } from "../../ports/git-port";
+import type { GitProviderPort } from "../../ports/git-provider-port";
 import type { SystemCommandPort } from "../../ports/system-command-port";
 import type { ToolDiscoveryPort } from "../../ports/tool-discovery-port";
 
-export const createNodeGitProviderResolver = ({
-  gitPort,
-  systemCommands,
-  toolDiscovery,
-}: {
+export const createNodeGitProviderResolver = (registrations: readonly GitProviderPort[]) =>
+  createGitProviderResolver(registrations);
+
+export const createDefaultNodeGitProviderResolver = (input: {
   gitPort: GitPort;
   systemCommands: SystemCommandPort;
   toolDiscovery: ToolDiscoveryPort;
-}): GitProviderResolver => {
-  const githubDependencies = createGithubCommandDependencies({ systemCommands, toolDiscovery });
-  return Effect.runSync(
-    createGitProviderResolver([new GithubProviderAdapter({ githubDependencies, gitPort })]),
-  );
+}) => {
+  const githubDependencies = createGithubCommandDependencies({
+    systemCommands: input.systemCommands,
+    toolDiscovery: input.toolDiscovery,
+  });
+  return createNodeGitProviderResolver([
+    new GithubProviderAdapter({ githubDependencies, gitPort: input.gitPort }),
+  ]);
 };

--- a/packages/host/src/composition/node/git-provider-composition.ts
+++ b/packages/host/src/composition/node/git-provider-composition.ts
@@ -7,17 +7,10 @@ import {
 import { createGithubCommandDependencies } from "../../application/tasks/support/github-pull-requests";
 import type { GitPort } from "../../ports/git-port";
 import type { GitProviderRegistrationError } from "../../ports/git-provider-errors";
-import type { GitProviderPort } from "../../ports/git-provider-port";
 import type { SystemCommandPort } from "../../ports/system-command-port";
 import type { ToolDiscoveryPort } from "../../ports/tool-discovery-port";
 
-type GitProviderResolverEffect = Effect.Effect<GitProviderResolver, GitProviderRegistrationError>;
-
-export const createNodeGitProviderResolver = (
-  providers: readonly GitProviderPort[],
-): GitProviderResolverEffect => createGitProviderResolver(providers);
-
-export const createGitProviders = ({
+export const createNodeGitProviderResolver = ({
   gitPort,
   systemCommands,
   toolDiscovery,
@@ -25,7 +18,7 @@ export const createGitProviders = ({
   gitPort: GitPort;
   systemCommands: SystemCommandPort;
   toolDiscovery: ToolDiscoveryPort;
-}): readonly GitProviderPort[] => {
+}): Effect.Effect<GitProviderResolver, GitProviderRegistrationError> => {
   const githubDependencies = createGithubCommandDependencies({ systemCommands, toolDiscovery });
-  return [new GithubProviderAdapter({ githubDependencies, gitPort })];
+  return createGitProviderResolver([new GithubProviderAdapter({ githubDependencies, gitPort })]);
 };

--- a/packages/host/src/composition/node/git-provider-composition.ts
+++ b/packages/host/src/composition/node/git-provider-composition.ts
@@ -1,0 +1,22 @@
+import { GithubProviderAdapter } from "../../adapters/git-providers/github-provider-adapter";
+import {
+  createGitProviderResolver,
+  type GitProviderResolver,
+} from "../../application/git/git-provider-resolver";
+import { createGithubCommandDependencies } from "../../application/tasks/support/github-pull-requests";
+import type { GitPort } from "../../ports/git-port";
+import type { SystemCommandPort } from "../../ports/system-command-port";
+import type { ToolDiscoveryPort } from "../../ports/tool-discovery-port";
+
+export const createNodeGitProviderResolver = ({
+  gitPort,
+  systemCommands,
+  toolDiscovery,
+}: {
+  gitPort: GitPort;
+  systemCommands: SystemCommandPort;
+  toolDiscovery: ToolDiscoveryPort;
+}): GitProviderResolver => {
+  const githubDependencies = createGithubCommandDependencies({ systemCommands, toolDiscovery });
+  return createGitProviderResolver([new GithubProviderAdapter({ githubDependencies, gitPort })]);
+};

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -113,8 +113,29 @@ export { CodexSessionHistoryError } from "./ports/codex-session-history-error";
 export type { DevServerProcessPort } from "./ports/dev-server-process-port";
 export type { FilesystemPort } from "./ports/filesystem-port";
 export type { GitPort } from "./ports/git-port";
+export {
+  GitProviderCapabilityError,
+  GitProviderRegistrationError,
+  GitProviderResolutionError,
+} from "./ports/git-provider-errors";
+export type {
+  FindPullRequestByBranchInput,
+  GetPullRequestByNumberInput,
+  GitProviderHealthPort,
+  GitProviderOperationError,
+  GitProviderPort,
+  GitProviderRepositoryContext,
+  GitProviderRepositoryPort,
+  PullRequestProviderInput,
+  PullRequestProviderPort,
+  UpsertPullRequestInput,
+} from "./ports/git-provider-port";
 export type { LocalAttachmentPort } from "./ports/local-attachment-port";
 export type { OpenInToolsPort } from "./ports/open-in-tools-port";
+export type {
+  PullRequestReviewProviderInput,
+  PullRequestReviewProviderPort,
+} from "./ports/pull-request-review-provider-port";
 export type {
   RuntimeExecutableProbePort,
   RuntimeExecutableProbesByKind,

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -52,9 +52,9 @@ export {
 export {
   type CreateNodeHostCommandRouterInput,
   createNodeEffectHostCommandRouter,
-  createNodeHostCommandRouter,
   type EffectNodeHostCommandRouter,
 } from "./composition/node/create-node-host-command-router";
+export { createNodeHostCommandRouter } from "./composition/node/create-node-host-command-router-promise";
 export {
   type DevelopmentInstanceMode,
   OPENDUCKTOR_DEV_INSTANCE_ENV,

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -122,7 +122,6 @@ export type {
   FindPullRequestByBranchInput,
   GetPullRequestByNumberInput,
   GitProviderHealthPort,
-  GitProviderOperationError,
   GitProviderPort,
   GitProviderRepositoryContext,
   GitProviderRepositoryPort,

--- a/packages/host/src/ports/git-provider-errors.ts
+++ b/packages/host/src/ports/git-provider-errors.ts
@@ -20,7 +20,8 @@ export class GitProviderResolutionError extends Data.TaggedError("GitProviderRes
 export type GitProviderRegistrationFailureReason =
   | "duplicate_provider_id"
   | "declared_capability_missing_port"
-  | "undeclared_capability_has_port";
+  | "undeclared_capability_has_port"
+  | "capability_provider_id_mismatch";
 
 export class GitProviderRegistrationError extends Data.TaggedError("GitProviderRegistrationError")<{
   readonly reason: GitProviderRegistrationFailureReason;

--- a/packages/host/src/ports/git-provider-errors.ts
+++ b/packages/host/src/ports/git-provider-errors.ts
@@ -1,0 +1,30 @@
+import type { GitProviderId } from "@openducktor/contracts";
+import { Data } from "effect";
+
+export type GitProviderCapability = "pull_requests" | "pull_request_review";
+
+export class GitProviderCapabilityError extends Data.TaggedError("GitProviderCapabilityError")<{
+  readonly providerId: GitProviderId;
+  readonly capability: GitProviderCapability;
+  readonly message: string;
+}> {}
+
+export type GitProviderResolutionFailureReason = "not_configured" | "disabled" | "not_registered";
+
+export class GitProviderResolutionError extends Data.TaggedError("GitProviderResolutionError")<{
+  readonly reason: GitProviderResolutionFailureReason;
+  readonly providerId?: GitProviderId;
+  readonly message: string;
+}> {}
+
+export type GitProviderRegistrationFailureReason =
+  | "duplicate_provider_id"
+  | "declared_capability_missing_port"
+  | "undeclared_capability_has_port";
+
+export class GitProviderRegistrationError extends Data.TaggedError("GitProviderRegistrationError")<{
+  readonly reason: GitProviderRegistrationFailureReason;
+  readonly providerId: GitProviderId;
+  readonly capability?: GitProviderCapability;
+  readonly message: string;
+}> {}

--- a/packages/host/src/ports/git-provider-port.ts
+++ b/packages/host/src/ports/git-provider-port.ts
@@ -7,16 +7,9 @@ import type {
   TaskApprovalContext,
 } from "@openducktor/contracts";
 import type { Effect } from "effect";
-import type { HostValidationErrorAggregate } from "../effect/host-errors";
-import type { GitPortError } from "./git-port";
+import type { HostError } from "../effect/host-errors";
 import type { GitProviderCapabilityError } from "./git-provider-errors";
 import type { PullRequestReviewProviderPort } from "./pull-request-review-provider-port";
-import type { ToolDiscoveryError } from "./tool-discovery-port";
-
-export type GitProviderOperationError =
-  | GitPortError
-  | HostValidationErrorAggregate
-  | ToolDiscoveryError;
 
 export type GitProviderRepositoryContext = {
   repository: GitProviderRepository;
@@ -24,18 +17,12 @@ export type GitProviderRepositoryContext = {
 };
 
 export type GitProviderRepositoryPort = {
-  getReadRepository(
-    repoConfig: RepoConfig,
-  ): Effect.Effect<GitProviderRepository, GitProviderOperationError>;
-  getWriteContext(
-    repoConfig: RepoConfig,
-  ): Effect.Effect<GitProviderRepositoryContext, GitProviderOperationError>;
+  getReadRepository(repoConfig: RepoConfig): Effect.Effect<GitProviderRepository, HostError>;
+  getWriteContext(repoConfig: RepoConfig): Effect.Effect<GitProviderRepositoryContext, HostError>;
 };
 
 export type GitProviderHealthPort = {
-  getStatus(
-    repoConfig: RepoConfig,
-  ): Effect.Effect<GitProviderAvailability, GitProviderOperationError>;
+  getStatus(repoConfig: RepoConfig): Effect.Effect<GitProviderAvailability, HostError>;
 };
 
 export type PullRequestProviderInput = {
@@ -60,11 +47,9 @@ export type UpsertPullRequestInput = PullRequestProviderInput & {
 export type PullRequestProviderPort = {
   findByBranch(
     input: FindPullRequestByBranchInput,
-  ): Effect.Effect<PullRequest | undefined, GitProviderOperationError>;
-  getByNumber(
-    input: GetPullRequestByNumberInput,
-  ): Effect.Effect<PullRequest, GitProviderOperationError>;
-  upsert(input: UpsertPullRequestInput): Effect.Effect<PullRequest, GitProviderOperationError>;
+  ): Effect.Effect<PullRequest | undefined, HostError>;
+  getByNumber(input: GetPullRequestByNumberInput): Effect.Effect<PullRequest, HostError>;
+  upsert(input: UpsertPullRequestInput): Effect.Effect<PullRequest, HostError>;
 };
 
 export type GitProviderPort = {

--- a/packages/host/src/ports/git-provider-port.ts
+++ b/packages/host/src/ports/git-provider-port.ts
@@ -1,0 +1,76 @@
+import type {
+  GitProviderAvailability,
+  GitProviderDescriptor,
+  GitProviderRepository,
+  PullRequest,
+  RepoConfig,
+  TaskApprovalContext,
+} from "@openducktor/contracts";
+import type { Effect } from "effect";
+import type { HostValidationErrorAggregate } from "../effect/host-errors";
+import type { GitPortError } from "./git-port";
+import type { GitProviderCapabilityError } from "./git-provider-errors";
+import type { PullRequestReviewProviderPort } from "./pull-request-review-provider-port";
+import type { ToolDiscoveryError } from "./tool-discovery-port";
+
+export type GitProviderOperationError =
+  | GitPortError
+  | HostValidationErrorAggregate
+  | ToolDiscoveryError;
+
+export type GitProviderRepositoryContext = {
+  repository: GitProviderRepository;
+  remoteName: string;
+};
+
+export type GitProviderRepositoryPort = {
+  getReadRepository(
+    repoConfig: RepoConfig,
+  ): Effect.Effect<GitProviderRepository, GitProviderOperationError>;
+  getWriteContext(
+    repoConfig: RepoConfig,
+  ): Effect.Effect<GitProviderRepositoryContext, GitProviderOperationError>;
+};
+
+export type GitProviderHealthPort = {
+  getStatus(
+    repoConfig: RepoConfig,
+  ): Effect.Effect<GitProviderAvailability, GitProviderOperationError>;
+};
+
+export type PullRequestProviderInput = {
+  repoConfig: RepoConfig;
+};
+
+export type FindPullRequestByBranchInput = PullRequestProviderInput & {
+  sourceBranch: string;
+  state: "open" | "all";
+};
+
+export type GetPullRequestByNumberInput = PullRequestProviderInput & {
+  number: number;
+};
+
+export type UpsertPullRequestInput = PullRequestProviderInput & {
+  approval: TaskApprovalContext;
+  title: string;
+  body: string;
+};
+
+export type PullRequestProviderPort = {
+  findByBranch(
+    input: FindPullRequestByBranchInput,
+  ): Effect.Effect<PullRequest | undefined, GitProviderOperationError>;
+  getByNumber(
+    input: GetPullRequestByNumberInput,
+  ): Effect.Effect<PullRequest, GitProviderOperationError>;
+  upsert(input: UpsertPullRequestInput): Effect.Effect<PullRequest, GitProviderOperationError>;
+};
+
+export type GitProviderPort = {
+  getDescriptor(): GitProviderDescriptor;
+  repository(): GitProviderRepositoryPort;
+  health(): GitProviderHealthPort;
+  pullRequests(): Effect.Effect<PullRequestProviderPort, GitProviderCapabilityError>;
+  pullRequestReview(): Effect.Effect<PullRequestReviewProviderPort, GitProviderCapabilityError>;
+};

--- a/packages/openducktor-web/src/typescript-host-backend.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.ts
@@ -901,8 +901,9 @@ export const startTypescriptHostBackendEffect = ({
     if (providedToolPaths) {
       routerInput.providedToolPaths = providedToolPaths;
     }
-    const hostCommandRouter: EffectNodeHostCommandRouter =
-      createNodeEffectHostCommandRouter(routerInput);
+    const hostCommandRouter: EffectNodeHostCommandRouter = yield* createNodeEffectHostCommandRouter(
+      routerInput,
+    ).pipe(Effect.mapError((cause) => toWebOperationError(cause, "web.host.create-host-router")));
     const taskEventLeaseManager = createTaskEventLeaseManager({
       encodeFrame: writeTaskFrameSseEvent,
       reportDeliveryFailure: ({ cause, subscriptionId }) =>


### PR DESCRIPTION
## Summary

Repository Git provider selection lacked one typed host-side resolver, so application code could not select the configured provider or request capabilities through focused ports.

This change adds exact provider resolution, typed failures, registration checks, and focused repository, health, Pull Request, and review ports. GitHub remains the only registered provider, local Git work stays on `GitPort`, and read-only Pull Request calls no longer require a write remote. Adding more providers and issue-tracker capabilities is out of scope.

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [ ] Not applicable

## Checklist

- [x] I updated docs when behavior, workflows, runtime contracts, or setup changed
- [x] I added or updated relevant tests
- [x] I kept failures explicit instead of adding fallback logic
- [x] I linked related issues or context below

## Related Issues

OpenDucktor task `openduckto-kwvz`.

## Breaking Changes

- [ ] No breaking changes
- [x] Breaking changes are described below

`createNodeHostCommandRouter` now returns `Promise<HostCommandRouter>`. In-repo Electron and web callers await the result.

## Additional Context

`GitProviderResolver` stays an internal host module as required by the task contract.