### PR TITLE
fix(codex): preserve spaces in streamed chat text

### DIFF
--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -175,6 +175,45 @@ describe("Codex todo event mapper", () => {
   });
 });
 
+describe("Codex delta event mapper", () => {
+  test("preserves leading and whitespace-only assistant delta content", () => {
+    const pipeline = createCodexEventMapperPipeline();
+    const projectDelta = (delta: string) =>
+      projectCodexCanonicalEvents(
+        pipeline.runLive(
+          {
+            kind: "notification",
+            notification: {
+              method: "item/agentMessage/delta",
+              params: {
+                threadId: "thread-1",
+                turnId: "turn-1",
+                itemId: "message-1",
+                delta,
+              },
+            },
+          },
+          { source: "live", threadId: "thread-1", turnId: "turn-1" },
+        ),
+      );
+
+    expect(projectDelta(" rejected")).toEqual([
+      expect.objectContaining({
+        type: "assistant_delta",
+        messageId: "message-1",
+        delta: " rejected",
+      }),
+    ]);
+    expect(projectDelta(" ")).toEqual([
+      expect.objectContaining({
+        type: "assistant_delta",
+        messageId: "message-1",
+        delta: " ",
+      }),
+    ]);
+  });
+});
+
 describe("Codex subagent event mapper", () => {
   test("merges live spawn begin and completed events into one linked subagent row", () => {
     const pipeline = createCodexEventMapperPipeline();

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
@@ -2046,7 +2046,7 @@ describe("CodexRuntimeSessionEvents", () => {
     expect(liveMutations[0]?.transcriptEvents).toEqual([]);
   });
 
-  test("forwards normalized transcript events through the live mutation", async () => {
+  test("preserves assistant delta whitespace through the live mutation", async () => {
     let listener: RuntimeListener | null = null;
     const session = createSession("thread-transcript");
     const liveMutations: Array<{ transcriptEvents: unknown[] }> = [];
@@ -2071,19 +2071,37 @@ describe("CodexRuntimeSessionEvents", () => {
           threadId: session.threadId,
           turnId: "turn-1",
           itemId: "message-1",
-          delta: "Working",
+          delta: "QA",
+        },
+      },
+    });
+    listener?.({
+      runtimeId: "runtime-1",
+      kind: "notification",
+      message: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: session.threadId,
+          turnId: "turn-1",
+          itemId: "message-1",
+          delta: " rejected",
         },
       },
     });
     await flushRuntimeEvents();
 
-    expect(liveMutations).toHaveLength(1);
-    expect(liveMutations[0]?.transcriptEvents).toEqual([
+    expect(liveMutations.flatMap((mutation) => mutation.transcriptEvents)).toEqual([
       expect.objectContaining({
         type: "assistant_delta",
         externalSessionId: session.threadId,
         messageId: "message-1",
-        delta: "Working",
+        delta: "QA",
+      }),
+      expect.objectContaining({
+        type: "assistant_delta",
+        externalSessionId: session.threadId,
+        messageId: "message-1",
+        delta: " rejected",
       }),
     ]);
   });

--- a/packages/adapters-codex-app-server/src/event-mappers/lifecycle.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/lifecycle.ts
@@ -1,4 +1,4 @@
-import { extractStringField } from "../codex-app-server-shared";
+import { extractStringField, readCodexString } from "../codex-app-server-shared";
 import { codexItemTypeMatches, extractCodexTokenUsageTotals } from "../codex-app-server-transcript";
 import type {
   CodexCanonicalAssistantDeltaEvent,
@@ -199,8 +199,8 @@ export const deltaMapper: CodexEventMapper = {
     if (!isText && !isReasoning) {
       return emptyCodexMappingResult();
     }
-    const delta = extractStringField(input.notification.params, ["delta"]);
-    if (!delta) {
+    const delta = readCodexString(input.notification.params.delta);
+    if (delta === null || delta.length === 0) {
       return emptyCodexMappingResult();
     }
     const messageId = extractStringField(input.notification.params, ["itemId", "item_id"]);


### PR DESCRIPTION
Codex assistant text can lose leading whitespace when the app-server sends adjacent streamed deltas. This joins words in the chat transcript.

This PR keeps each delta original whitespace at the mapper boundary. It rejects only missing or empty delta values. It also adds a live runtime regression test that sends `QA` followed by ` rejected` and checks the transcript event output.

Task: `openduckto-w3l2`