### PR TITLE
refactor(host): keep pull request workflows provider-neutral

### DIFF
--- a/apps/electron/src/main/electron-host.test.ts
+++ b/apps/electron/src/main/electron-host.test.ts
@@ -2301,11 +2301,25 @@ describe("createElectronHostCommandRouter", () => {
       settingsConfig: createSettingsConfig(
         globalConfig({
           workspaces: {
-            repo: repoConfig(),
+            repo: repoConfig({
+              git: {
+                provider: {
+                  id: "github",
+                  enabled: true,
+                  repository: {
+                    host: "github.com",
+                    owner: "acme",
+                    name: "repo",
+                  },
+                  autoDetected: false,
+                },
+              },
+            }),
           },
           workspaceOrder: ["repo"],
         }),
       ),
+      systemCommands: createSystemCommands(),
       taskStore: {
         ...createTaskStore(),
         listTasks: () =>

--- a/bun.lock
+++ b/bun.lock
@@ -265,7 +265,7 @@
   "overrides": {
     "@hono/node-server": "^1.19.11",
     "express-rate-limit": "^8.2.2",
-    "fast-uri": "^3.1.3",
+    "fast-uri": "^3.1.6",
     "form-data": "^4.0.6",
     "hono": "^4.12.26",
     "ip-address": "^10.5.0",
@@ -1437,7 +1437,7 @@
 
     "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
     "fastdom": ["fastdom@1.0.12", "", { "dependencies": { "strictdom": "^1.0.1" } }, "sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "overrides": {
     "@hono/node-server": "^1.19.11",
     "express-rate-limit": "^8.2.2",
-    "fast-uri": "^3.1.3",
+    "fast-uri": "^3.1.6",
     "form-data": "^4.0.6",
     "hono": "^4.12.26",
     "ip-address": "^10.5.0",

--- a/packages/host/src/adapters/git-providers/github/provider-adapter.test.ts
+++ b/packages/host/src/adapters/git-providers/github/provider-adapter.test.ts
@@ -95,8 +95,12 @@ describe("GithubProviderAdapter", () => {
     );
     expect(pullRequests).toEqual(
       expect.objectContaining({
-        findByBranch: expect.any(Function),
+        providerId: "github",
+        findOpenForSourceBranch: expect.any(Function),
+        findLatestMergedForSourceBranch: expect.any(Function),
         getByNumber: expect.any(Function),
+        refresh: expect.any(Function),
+        resolvePublishRemote: expect.any(Function),
         upsert: expect.any(Function),
       }),
     );
@@ -151,7 +155,7 @@ describe("GithubProviderAdapter", () => {
     });
 
     const byBranch = await Effect.runPromise(
-      pullRequests.findByBranch({ repoConfig, sourceBranch: "odt/task-42", state: "open" }),
+      pullRequests.findOpenForSourceBranch({ repoConfig, sourceBranch: "odt/task-42" }),
     );
     const byNumber = await Effect.runPromise(pullRequests.getByNumber({ repoConfig, number: 42 }));
 

--- a/packages/host/src/adapters/git-providers/github/provider-adapter.ts
+++ b/packages/host/src/adapters/git-providers/github/provider-adapter.ts
@@ -4,11 +4,6 @@ import {
   type RepoConfig,
 } from "@openducktor/contracts";
 import { Effect } from "effect";
-import {
-  findGithubPullRequestForBranch,
-  fetchGithubPullRequestByNumber,
-  upsertGithubPullRequest,
-} from "./pull-requests";
 import type { GitPort } from "../../../ports/git-port";
 import type {
   GitProviderHealthPort,
@@ -21,6 +16,7 @@ import type { SystemCommandPort } from "../../../ports/system-command-port";
 import type { ToolDiscoveryPort } from "../../../ports/tool-discovery-port";
 import { createGithubCli } from "./cli";
 import { createGithubProviderHealthPort } from "./health";
+import { createGithubPullRequestProviderPort } from "./pull-requests";
 import { createGithubPullRequestReviewAdapter } from "./review/adapter";
 import { createGithubProviderRepositoryAdapter } from "./repository";
 
@@ -44,50 +40,16 @@ export class GithubProviderAdapter implements GitProviderPort {
       gitPort,
     });
     const getRepository = (repoConfig: RepoConfig) => repositoryPort.getRepository(repoConfig);
-    const getMapping = (repoConfig: RepoConfig) => repositoryPort.getMapping(repoConfig);
 
     this.repositoryPort = repositoryPort;
     this.healthPort = createGithubProviderHealthPort({
       githubCli,
       repositoryPort,
     });
-    this.pullRequestsPort = {
-      findByBranch: (input) =>
-        Effect.gen(function* () {
-          const { repository } = yield* getMapping(input.repoConfig);
-          const pullRequest = yield* findGithubPullRequestForBranch(
-            githubCli,
-            input.repoConfig.repoPath,
-            repository,
-            input.sourceBranch,
-            input.state,
-          );
-          return pullRequest;
-        }),
-      getByNumber: (input) =>
-        Effect.gen(function* () {
-          const repository = yield* getRepository(input.repoConfig);
-          const pullRequest = yield* fetchGithubPullRequestByNumber(
-            githubCli,
-            input.repoConfig.repoPath,
-            repository,
-            input.number,
-          );
-          return pullRequest;
-        }),
-      upsert: (input) =>
-        Effect.gen(function* () {
-          const context = yield* getMapping(input.repoConfig);
-          return yield* upsertGithubPullRequest(
-            githubCli,
-            input.repoConfig.repoPath,
-            context,
-            input.approval,
-            input.title,
-            input.body,
-          );
-        }),
-    };
+    this.pullRequestsPort = createGithubPullRequestProviderPort({
+      githubCli,
+      repositoryPort,
+    });
     this.pullRequestReviewPort = createGithubPullRequestReviewAdapter({
       githubCli,
       getRepository,

--- a/packages/host/src/adapters/git-providers/github/pull-request-model.ts
+++ b/packages/host/src/adapters/git-providers/github/pull-request-model.ts
@@ -1,6 +1,5 @@
 import {
   GITHUB_PROVIDER_DESCRIPTOR,
-  type GitProviderRepository,
   type PullRequest,
   pullRequestSchema,
 } from "@openducktor/contracts";
@@ -53,11 +52,6 @@ export type ResolvedPullRequest = {
   record: PullRequest;
   sourceBranch: string;
   targetBranch: string;
-};
-
-export type GithubPullRequestContext = {
-  repository: GitProviderRepository;
-  remoteName: string;
 };
 
 const parseGithubPullPayload = (value: JSONType): GithubPullResponse => {

--- a/packages/host/src/adapters/git-providers/github/pull-requests.test.ts
+++ b/packages/host/src/adapters/git-providers/github/pull-requests.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, test } from "bun:test";
+import {
+  repoConfigSchema,
+  type PullRequest,
+  type TaskApprovalContext,
+} from "@openducktor/contracts";
 import { Effect } from "effect";
 import { HostValidationError } from "../../../effect/host-errors";
+import type { GitProviderRepositoryPort } from "../../../ports/git-provider-port";
 import type { SystemCommandPort } from "../../../ports/system-command-port";
 import type { ToolDiscoveryPort } from "../../../ports/tool-discovery-port";
 import { createGithubCli } from "./cli";
 import { parseGithubPullListResponse, parseGithubPullResponse } from "./pull-request-model";
-import { fetchGithubPullRequestByNumber, findGithubPullRequestForBranch } from "./pull-requests";
+import { createGithubPullRequestProviderPort } from "./pull-requests";
 
 const githubPullResponse = {
   number: 42,
@@ -20,13 +26,16 @@ const githubPullResponse = {
   base: { ref: "main" },
 };
 
-const githubCliForPayload = (payload: string) =>
+const githubCliForPayload = (payload: string, calls: string[][] = []) =>
   createGithubCli({
     systemCommands: {
       resolveCommandPath: (command) => Effect.succeed(command),
       versionCommand: () => Effect.succeed("gh version 2.95.0"),
-      runCommandAllowFailure: () =>
-        Effect.succeed({ ok: true, stdout: payload, stderr: "", exitCode: 0 }),
+      runCommandAllowFailure: (_command, args) =>
+        Effect.sync(() => {
+          calls.push(args);
+          return { ok: true, stdout: payload, stderr: "", exitCode: 0 };
+        }),
     },
     toolDiscovery: {
       discoverTool: () => Effect.die("unexpected discoverTool call"),
@@ -35,6 +44,48 @@ const githubCliForPayload = (payload: string) =>
       validateToolPath: () => Effect.die("unexpected validateToolPath call"),
     },
   });
+
+const repoConfig = repoConfigSchema.parse({
+  workspaceId: "repo",
+  workspaceName: "Repo",
+  repoPath: "/repo",
+  defaultRuntimeKind: "opencode",
+  git: {
+    provider: {
+      id: "github",
+      enabled: true,
+      repository: { host: "github.com", owner: "openai", name: "openducktor" },
+    },
+  },
+});
+
+const repositoryPort: GitProviderRepositoryPort = {
+  detectRepository: () => Effect.dieMessage("unexpected repository detection"),
+  getRepository: () => Effect.succeed({ host: "github.com", owner: "openai", name: "openducktor" }),
+  getMapping: () =>
+    Effect.succeed({
+      repository: { host: "github.com", owner: "openai", name: "openducktor" },
+      remoteName: "publish",
+    }),
+};
+
+const approvalContext = (pullRequest?: PullRequest): TaskApprovalContext => {
+  const context: TaskApprovalContext = {
+    taskId: "task-42",
+    taskStatus: "human_review",
+    workingDirectory: "/worktrees/repo/task-42",
+    sourceBranch: "odt/task-42",
+    targetBranch: { branch: "main" },
+    defaultMergeMethod: "merge_commit",
+    hasUncommittedChanges: false,
+    uncommittedFileCount: 0,
+    providers: [],
+  };
+  if (pullRequest !== undefined) {
+    context.pullRequest = pullRequest;
+  }
+  return context;
+};
 
 describe("GitHub pull request response parsing", () => {
   test("parses the exact gh response fields used by task state", () => {
@@ -68,18 +119,17 @@ describe("GitHub pull request response parsing", () => {
   });
 });
 
-describe("findGithubPullRequestForBranch", () => {
+describe("GitHub Pull Request capability failures", () => {
   test("preserves the field on malformed GitHub payloads", async () => {
     const malformed = { ...githubPullResponse, head: { ref: 42 } };
 
+    const port = createGithubPullRequestProviderPort({
+      githubCli: githubCliForPayload(JSON.stringify([malformed])),
+      repositoryPort,
+    });
+
     const failure = await Effect.runPromise(
-      findGithubPullRequestForBranch(
-        githubCliForPayload(JSON.stringify([malformed])),
-        "/repo",
-        { host: "github.com", owner: "openai", name: "openducktor" },
-        "odt/task-42",
-        "open",
-      ).pipe(Effect.flip),
+      port.findOpenForSourceBranch({ repoConfig, sourceBranch: "odt/task-42" }).pipe(Effect.flip),
     );
 
     expect(failure).toBeInstanceOf(HostValidationError);
@@ -89,13 +139,13 @@ describe("findGithubPullRequestForBranch", () => {
   test("preserves the field when a pull request read returns malformed data", async () => {
     const malformed = { ...githubPullResponse, head: { ref: 42 } };
 
+    const port = createGithubPullRequestProviderPort({
+      githubCli: githubCliForPayload(JSON.stringify(malformed)),
+      repositoryPort,
+    });
+
     const failure = await Effect.runPromise(
-      fetchGithubPullRequestByNumber(
-        githubCliForPayload(JSON.stringify(malformed)),
-        "/repo",
-        { host: "github.com", owner: "openai", name: "openducktor" },
-        42,
-      ).pipe(Effect.flip),
+      port.getByNumber({ repoConfig, number: 42 }).pipe(Effect.flip),
     );
 
     expect(failure).toBeInstanceOf(HostValidationError);
@@ -135,14 +185,10 @@ describe("findGithubPullRequestForBranch", () => {
     };
     const githubCli = createGithubCli({ systemCommands, toolDiscovery });
 
+    const port = createGithubPullRequestProviderPort({ githubCli, repositoryPort });
+
     const pullRequest = await Effect.runPromise(
-      findGithubPullRequestForBranch(
-        githubCli,
-        "/repo",
-        { host: "github.com", owner: "Maxsky5", name: "openducktor" },
-        "odt/task-1",
-        "open",
-      ),
+      port.findOpenForSourceBranch({ repoConfig, sourceBranch: "odt/task-1" }),
     );
 
     expect(pullRequest).toBeUndefined();
@@ -153,5 +199,136 @@ describe("findGithubPullRequestForBranch", () => {
       CLICOLOR_FORCE: "0",
       FORCE_COLOR: "0",
     });
+  });
+});
+
+describe("createGithubPullRequestProviderPort", () => {
+  test("finds the latest merged pull request for a source branch", async () => {
+    const older = {
+      ...githubPullResponse,
+      number: 41,
+      state: "closed",
+      merged_at: "2026-05-02T09:00:00Z",
+      updated_at: "2026-05-02T09:00:00Z",
+    };
+    const latest = {
+      ...githubPullResponse,
+      number: 42,
+      state: "closed",
+      merged_at: "2026-05-02T10:00:00Z",
+    };
+    const port = createGithubPullRequestProviderPort({
+      githubCli: githubCliForPayload(JSON.stringify([latest, older])),
+      repositoryPort,
+    });
+
+    const pullRequest = await Effect.runPromise(
+      port.findLatestMergedForSourceBranch({ repoConfig, sourceBranch: "odt/task-42" }),
+    );
+
+    expect(pullRequest?.record.number).toBe(42);
+    expect(pullRequest?.record.state).toBe("merged");
+  });
+
+  test("resolves the matching remote used to publish the task branch", async () => {
+    const port = createGithubPullRequestProviderPort({
+      githubCli: githubCliForPayload("[]"),
+      repositoryPort,
+    });
+
+    await expect(Effect.runPromise(port.resolvePublishRemote({ repoConfig }))).resolves.toBe(
+      "publish",
+    );
+  });
+
+  test("rejects refresh for a linked pull request from another provider", async () => {
+    const port = createGithubPullRequestProviderPort({
+      githubCli: githubCliForPayload(JSON.stringify(githubPullResponse)),
+      repositoryPort,
+    });
+
+    const failure = await Effect.runPromise(
+      port
+        .refresh({
+          repoConfig,
+          linkedPullRequest: {
+            providerId: "gitlab",
+            number: 42,
+            url: "https://gitlab.example.com/openai/openducktor/-/merge_requests/42",
+            state: "open",
+            createdAt: "2026-05-01T10:00:00Z",
+            updatedAt: "2026-05-02T10:00:00Z",
+          },
+        })
+        .pipe(Effect.flip),
+    );
+
+    expect(failure).toBeInstanceOf(HostValidationError);
+    expect(failure).toMatchObject({ field: "pullRequest.providerId" });
+  });
+
+  test("creates a pull request with provider-private GitHub arguments", async () => {
+    const calls: string[][] = [];
+    const port = createGithubPullRequestProviderPort({
+      githubCli: githubCliForPayload(JSON.stringify(githubPullResponse), calls),
+      repositoryPort,
+    });
+
+    const pullRequest = await Effect.runPromise(
+      port.upsert({
+        repoConfig,
+        approval: approvalContext(),
+        title: "  Task 42  ",
+        body: "Task body",
+      }),
+    );
+
+    expect(pullRequest.number).toBe(42);
+    expect(calls[0]).toEqual(
+      expect.arrayContaining([
+        "--method",
+        "POST",
+        "head=odt/task-42",
+        "base=main",
+        "title=Task 42",
+        "body=Task body",
+      ]),
+    );
+  });
+
+  test("updates an existing editable pull request", async () => {
+    const calls: string[][] = [];
+    const port = createGithubPullRequestProviderPort({
+      githubCli: githubCliForPayload(JSON.stringify(githubPullResponse), calls),
+      repositoryPort,
+    });
+
+    await Effect.runPromise(
+      port.upsert({
+        repoConfig,
+        approval: approvalContext({
+          providerId: "github",
+          number: 42,
+          url: githubPullResponse.html_url,
+          state: "draft",
+          createdAt: githubPullResponse.created_at,
+          updatedAt: githubPullResponse.updated_at,
+        }),
+        title: "Task 42",
+        body: "Updated body",
+      }),
+    );
+
+    expect(calls[0]).toEqual(
+      expect.arrayContaining([
+        "--method",
+        "PATCH",
+        "repos/openai/openducktor/pulls/42",
+        "title=Task 42",
+        "body=Updated body",
+      ]),
+    );
+    expect(calls[0]).not.toContain("head=odt/task-42");
+    expect(calls[0]).not.toContain("base=main");
   });
 });

--- a/packages/host/src/adapters/git-providers/github/pull-requests.test.ts
+++ b/packages/host/src/adapters/git-providers/github/pull-requests.test.ts
@@ -209,13 +209,14 @@ describe("createGithubPullRequestProviderPort", () => {
       number: 41,
       state: "closed",
       merged_at: "2026-05-02T09:00:00Z",
-      updated_at: "2026-05-02T09:00:00Z",
+      updated_at: "2026-05-02T11:00:00Z",
     };
     const latest = {
       ...githubPullResponse,
       number: 42,
       state: "closed",
       merged_at: "2026-05-02T10:00:00Z",
+      updated_at: "2026-05-02T10:00:00Z",
     };
     const port = createGithubPullRequestProviderPort({
       githubCli: githubCliForPayload(JSON.stringify([latest, older])),

--- a/packages/host/src/adapters/git-providers/github/pull-requests.test.ts
+++ b/packages/host/src/adapters/git-providers/github/pull-requests.test.ts
@@ -69,6 +69,11 @@ const repositoryPort: GitProviderRepositoryPort = {
     }),
 };
 
+const mappedRepositoryPort: GitProviderRepositoryPort = {
+  ...repositoryPort,
+  getRepository: () => Effect.die("Expected Pull Request operation to check repository mapping"),
+};
+
 const approvalContext = (pullRequest?: PullRequest): TaskApprovalContext => {
   const context: TaskApprovalContext = {
     taskId: "task-42",
@@ -218,9 +223,10 @@ describe("createGithubPullRequestProviderPort", () => {
       merged_at: "2026-05-02T10:00:00Z",
       updated_at: "2026-05-02T10:00:00Z",
     };
+    const calls: string[][] = [];
     const port = createGithubPullRequestProviderPort({
-      githubCli: githubCliForPayload(JSON.stringify([latest, older])),
-      repositoryPort,
+      githubCli: githubCliForPayload(JSON.stringify([[latest, older]]), calls),
+      repositoryPort: mappedRepositoryPort,
     });
 
     const pullRequest = await Effect.runPromise(
@@ -229,6 +235,18 @@ describe("createGithubPullRequestProviderPort", () => {
 
     expect(pullRequest?.record.number).toBe(42);
     expect(pullRequest?.record.state).toBe("merged");
+    expect(calls[0]).toEqual(expect.arrayContaining(["--paginate", "--slurp"]));
+  });
+
+  test("checks repository mapping before reading a pull request by number", async () => {
+    const port = createGithubPullRequestProviderPort({
+      githubCli: githubCliForPayload(JSON.stringify(githubPullResponse)),
+      repositoryPort: mappedRepositoryPort,
+    });
+
+    const pullRequest = await Effect.runPromise(port.getByNumber({ repoConfig, number: 42 }));
+
+    expect(pullRequest.record.number).toBe(42);
   });
 
   test("resolves the matching remote used to publish the task branch", async () => {
@@ -265,14 +283,20 @@ describe("createGithubPullRequestProviderPort", () => {
     );
 
     expect(failure).toBeInstanceOf(HostValidationError);
-    expect(failure).toMatchObject({ field: "pullRequest.providerId" });
+    expect(failure).toMatchObject({
+      field: "pullRequest.providerId",
+      details: {
+        linkedProviderId: "gitlab",
+        configuredProviderId: "github",
+      },
+    });
   });
 
   test("creates a pull request with provider-private GitHub arguments", async () => {
     const calls: string[][] = [];
     const port = createGithubPullRequestProviderPort({
       githubCli: githubCliForPayload(JSON.stringify(githubPullResponse), calls),
-      repositoryPort,
+      repositoryPort: mappedRepositoryPort,
     });
 
     const pullRequest = await Effect.runPromise(
@@ -301,7 +325,7 @@ describe("createGithubPullRequestProviderPort", () => {
     const calls: string[][] = [];
     const port = createGithubPullRequestProviderPort({
       githubCli: githubCliForPayload(JSON.stringify(githubPullResponse), calls),
-      repositoryPort,
+      repositoryPort: mappedRepositoryPort,
     });
 
     await Effect.runPromise(

--- a/packages/host/src/adapters/git-providers/github/pull-requests.ts
+++ b/packages/host/src/adapters/git-providers/github/pull-requests.ts
@@ -33,7 +33,7 @@ export const createGithubPullRequestProviderPort = ({
 }): PullRequestProviderPort => {
   const getByNumber: PullRequestProviderPort["getByNumber"] = (input) =>
     Effect.gen(function* () {
-      const repository = yield* repositoryPort.getRepository(input.repoConfig);
+      const { repository } = yield* repositoryPort.getMapping(input.repoConfig);
       return yield* getPullRequest(githubCli, input.repoConfig.repoPath, repository, input.number);
     });
 
@@ -41,7 +41,7 @@ export const createGithubPullRequestProviderPort = ({
     providerId: GITHUB_PROVIDER_ID,
     findOpenForSourceBranch: (input) =>
       Effect.gen(function* () {
-        const repository = yield* repositoryPort.getRepository(input.repoConfig);
+        const { repository } = yield* repositoryPort.getMapping(input.repoConfig);
         const pullRequests = yield* listPullRequests(
           githubCli,
           input.repoConfig.repoPath,
@@ -56,7 +56,7 @@ export const createGithubPullRequestProviderPort = ({
       }),
     findLatestMergedForSourceBranch: (input) =>
       Effect.gen(function* () {
-        const repository = yield* repositoryPort.getRepository(input.repoConfig);
+        const { repository } = yield* repositoryPort.getMapping(input.repoConfig);
         const pullRequests = yield* listPullRequests(
           githubCli,
           input.repoConfig.repoPath,
@@ -73,16 +73,19 @@ export const createGithubPullRequestProviderPort = ({
     refresh: (input) =>
       Effect.gen(function* () {
         yield* checkPullRequestProvider(input.linkedPullRequest);
-        return yield* getByNumber({
-          repoConfig: input.repoConfig,
-          number: input.linkedPullRequest.number,
-        });
+        const repository = yield* repositoryPort.getRepository(input.repoConfig);
+        return yield* getPullRequest(
+          githubCli,
+          input.repoConfig.repoPath,
+          repository,
+          input.linkedPullRequest.number,
+        );
       }),
     resolvePublishRemote: (input) =>
       repositoryPort.getMapping(input.repoConfig).pipe(Effect.map(({ remoteName }) => remoteName)),
     upsert: (input) =>
       Effect.gen(function* () {
-        const repository = yield* repositoryPort.getRepository(input.repoConfig);
+        const { repository } = yield* repositoryPort.getMapping(input.repoConfig);
         return yield* upsertPullRequest(
           githubCli,
           input.repoConfig.repoPath,
@@ -106,7 +109,7 @@ const checkPullRequestProvider = (
       field: "pullRequest.providerId",
       message: `Pull request provider '${pullRequest.providerId}' does not match configured provider '${GITHUB_PROVIDER_ID}'.`,
       details: {
-        providerId: pullRequest.providerId,
+        linkedProviderId: pullRequest.providerId,
         configuredProviderId: GITHUB_PROVIDER_ID,
       },
     }),
@@ -165,6 +168,8 @@ const listPullRequests = (
     const repoSlug = `${repository.owner}/${repository.name}`;
     const payload = yield* runGithubApi(githubCli, repoPath, repository.host, [
       "api",
+      "--paginate",
+      "--slurp",
       "--method",
       "GET",
       `repos/${repoSlug}/pulls`,

--- a/packages/host/src/adapters/git-providers/github/pull-requests.ts
+++ b/packages/host/src/adapters/git-providers/github/pull-requests.ts
@@ -2,7 +2,6 @@ import {
   GITHUB_PROVIDER_DESCRIPTOR,
   type GitProviderRepository,
   type PullRequest,
-  type RepoConfig,
   type TaskApprovalContext,
 } from "@openducktor/contracts";
 import { Effect } from "effect";
@@ -32,35 +31,17 @@ export const createGithubPullRequestProviderPort = ({
   githubCli: GithubCli;
   repositoryPort: GitProviderRepositoryPort;
 }): PullRequestProviderPort => {
-  const getRepository = (repoConfig: RepoConfig) => repositoryPort.getRepository(repoConfig);
-
   const getByNumber: PullRequestProviderPort["getByNumber"] = (input) =>
     Effect.gen(function* () {
-      const repository = yield* getRepository(input.repoConfig);
+      const repository = yield* repositoryPort.getRepository(input.repoConfig);
       return yield* getPullRequest(githubCli, input.repoConfig.repoPath, repository, input.number);
     });
-
-  const validateLinkedPullRequest = (linkedPullRequest: PullRequest) => {
-    if (linkedPullRequest.providerId === GITHUB_PROVIDER_ID) {
-      return Effect.void;
-    }
-    return Effect.fail(
-      new HostValidationError({
-        field: "pullRequest.providerId",
-        message: `Pull request provider '${linkedPullRequest.providerId}' does not match configured provider '${GITHUB_PROVIDER_ID}'.`,
-        details: {
-          providerId: linkedPullRequest.providerId,
-          configuredProviderId: GITHUB_PROVIDER_ID,
-        },
-      }),
-    );
-  };
 
   return {
     providerId: GITHUB_PROVIDER_ID,
     findOpenForSourceBranch: (input) =>
       Effect.gen(function* () {
-        const repository = yield* getRepository(input.repoConfig);
+        const repository = yield* repositoryPort.getRepository(input.repoConfig);
         const pullRequests = yield* listPullRequests(
           githubCli,
           input.repoConfig.repoPath,
@@ -75,7 +56,7 @@ export const createGithubPullRequestProviderPort = ({
       }),
     findLatestMergedForSourceBranch: (input) =>
       Effect.gen(function* () {
-        const repository = yield* getRepository(input.repoConfig);
+        const repository = yield* repositoryPort.getRepository(input.repoConfig);
         const pullRequests = yield* listPullRequests(
           githubCli,
           input.repoConfig.repoPath,
@@ -91,7 +72,7 @@ export const createGithubPullRequestProviderPort = ({
     getByNumber,
     refresh: (input) =>
       Effect.gen(function* () {
-        yield* validateLinkedPullRequest(input.linkedPullRequest);
+        yield* checkPullRequestProvider(input.linkedPullRequest);
         return yield* getByNumber({
           repoConfig: input.repoConfig,
           number: input.linkedPullRequest.number,
@@ -101,7 +82,7 @@ export const createGithubPullRequestProviderPort = ({
       repositoryPort.getMapping(input.repoConfig).pipe(Effect.map(({ remoteName }) => remoteName)),
     upsert: (input) =>
       Effect.gen(function* () {
-        const repository = yield* getRepository(input.repoConfig);
+        const repository = yield* repositoryPort.getRepository(input.repoConfig);
         return yield* upsertPullRequest(
           githubCli,
           input.repoConfig.repoPath,
@@ -112,6 +93,24 @@ export const createGithubPullRequestProviderPort = ({
         );
       }),
   };
+};
+
+const checkPullRequestProvider = (
+  pullRequest: PullRequest | undefined,
+): Effect.Effect<void, HostValidationErrorAggregate> => {
+  if (pullRequest === undefined || pullRequest.providerId === GITHUB_PROVIDER_ID) {
+    return Effect.void;
+  }
+  return Effect.fail(
+    new HostValidationError({
+      field: "pullRequest.providerId",
+      message: `Pull request provider '${pullRequest.providerId}' does not match configured provider '${GITHUB_PROVIDER_ID}'.`,
+      details: {
+        providerId: pullRequest.providerId,
+        configuredProviderId: GITHUB_PROVIDER_ID,
+      },
+    }),
+  );
 };
 
 const toPullRequestValidationError = (cause: unknown): HostValidationErrorAggregate =>
@@ -174,11 +173,10 @@ const listPullRequests = (
       "-f",
       `head=${repository.owner}:${sourceBranch}`,
     ]);
-    const parsed = yield* Effect.try({
+    return yield* Effect.try({
       try: () => parseGithubPullListResponse(payload),
       catch: toPullRequestValidationError,
     });
-    return parsed;
   });
 
 const getPullRequest = (
@@ -210,21 +208,7 @@ const upsertPullRequest = (
   Effect.gen(function* () {
     const repoSlug = `${repository.owner}/${repository.name}`;
     const existingPullRequest = approval.pullRequest;
-    if (
-      existingPullRequest !== undefined &&
-      existingPullRequest.providerId !== GITHUB_PROVIDER_ID
-    ) {
-      return yield* Effect.fail(
-        new HostValidationError({
-          field: "pullRequest.providerId",
-          message: `Pull request provider '${existingPullRequest.providerId}' does not match configured provider '${GITHUB_PROVIDER_ID}'.`,
-          details: {
-            providerId: existingPullRequest.providerId,
-            configuredProviderId: GITHUB_PROVIDER_ID,
-          },
-        }),
-      );
-    }
+    yield* checkPullRequestProvider(existingPullRequest);
     const args =
       existingPullRequest !== undefined && isEditablePullRequest(existingPullRequest)
         ? [

--- a/packages/host/src/adapters/git-providers/github/pull-requests.ts
+++ b/packages/host/src/adapters/git-providers/github/pull-requests.ts
@@ -52,8 +52,19 @@ const selectLatestMergedPullRequestForBranch = (
 ): ResolvedPullRequest | undefined =>
   pullRequests
     .filter((pullRequest) => pullRequest.record.state === "merged")
-    .sort((left, right) => left.record.updatedAt.localeCompare(right.record.updatedAt))
-    .at(-1);
+    .map((pullRequest) => {
+      const mergedAt = pullRequest.record.mergedAt;
+      if (mergedAt === undefined) {
+        throw new HostValidationError({
+          field: "mergedAt",
+          message: `GitHub merged pull request ${pullRequest.record.number} has no merge timestamp.`,
+          details: { pullRequestNumber: pullRequest.record.number },
+        });
+      }
+      return { mergedAt, pullRequest };
+    })
+    .sort((left, right) => left.mergedAt.localeCompare(right.mergedAt))
+    .at(-1)?.pullRequest;
 
 const findGithubPullRequestsForBranch = (
   githubCli: GithubCli,
@@ -221,7 +232,10 @@ export const createGithubPullRequestProviderPort = ({
           input.sourceBranch,
           "all",
         );
-        return selectLatestMergedPullRequestForBranch(pullRequests);
+        return yield* Effect.try({
+          try: () => selectLatestMergedPullRequestForBranch(pullRequests),
+          catch: toPullRequestValidationError,
+        });
       }),
     getByNumber,
     refresh: (input) =>

--- a/packages/host/src/adapters/git-providers/github/pull-requests.ts
+++ b/packages/host/src/adapters/git-providers/github/pull-requests.ts
@@ -1,4 +1,10 @@
-import { type GitProviderRepository, type TaskApprovalContext } from "@openducktor/contracts";
+import {
+  GITHUB_PROVIDER_DESCRIPTOR,
+  type GitProviderRepository,
+  type PullRequest,
+  type RepoConfig,
+  type TaskApprovalContext,
+} from "@openducktor/contracts";
 import { Effect } from "effect";
 import { checkoutBranch } from "../../../domain/task";
 import {
@@ -6,20 +12,18 @@ import {
   type HostValidationErrorAggregate,
 } from "../../../effect/host-errors";
 import { runGithubApi, type GithubCli } from "./cli";
+import type {
+  GitProviderRepositoryPort,
+  PullRequestProviderPort,
+} from "../../../ports/git-provider-port";
 import {
-  type GithubPullRequestContext,
   isEditablePullRequest,
   parseGithubPullListResponse,
   parseGithubPullResponse,
   type ResolvedPullRequest,
 } from "./pull-request-model";
 
-export {
-  type GithubPullBranchRef,
-  type GithubPullRequestContext,
-  type GithubPullResponse,
-  type ResolvedPullRequest,
-} from "./pull-request-model";
+const GITHUB_PROVIDER_ID = GITHUB_PROVIDER_DESCRIPTOR.id;
 
 const toPullRequestValidationError = (cause: unknown): HostValidationErrorAggregate =>
   cause instanceof HostValidationError
@@ -29,17 +33,10 @@ const toPullRequestValidationError = (cause: unknown): HostValidationErrorAggreg
         cause,
       });
 
-const selectGithubPullRequestForBranch = (
-  pullRequests: ResolvedPullRequest[],
+const selectOpenPullRequestForBranch = (
+  pullRequests: readonly ResolvedPullRequest[],
   sourceBranch: string,
-  state: "open" | "all",
 ): ResolvedPullRequest | undefined => {
-  if (state === "all") {
-    return pullRequests
-      .filter((pullRequest) => pullRequest.record.state === "merged")
-      .sort((left, right) => left.record.updatedAt.localeCompare(right.record.updatedAt))
-      .at(-1);
-  }
   if (pullRequests.length > 1) {
     throw new HostValidationError({
       field: "sourceBranch",
@@ -49,7 +46,16 @@ const selectGithubPullRequestForBranch = (
   }
   return pullRequests[0];
 };
-export const findGithubPullRequestForBranch = (
+
+const selectLatestMergedPullRequestForBranch = (
+  pullRequests: readonly ResolvedPullRequest[],
+): ResolvedPullRequest | undefined =>
+  pullRequests
+    .filter((pullRequest) => pullRequest.record.state === "merged")
+    .sort((left, right) => left.record.updatedAt.localeCompare(right.record.updatedAt))
+    .at(-1);
+
+const findGithubPullRequestsForBranch = (
   githubCli: GithubCli,
   repoPath: string,
   repository: GitProviderRepository,
@@ -72,12 +78,10 @@ export const findGithubPullRequestForBranch = (
       try: () => parseGithubPullListResponse(payload),
       catch: toPullRequestValidationError,
     });
-    return yield* Effect.try({
-      try: () => selectGithubPullRequestForBranch(parsed, sourceBranch, state),
-      catch: toPullRequestValidationError,
-    });
+    return parsed;
   });
-export const fetchGithubPullRequestByNumber = (
+
+const fetchGithubPullRequestByNumber = (
   githubCli: GithubCli,
   repoPath: string,
   repository: GitProviderRepository,
@@ -94,17 +98,32 @@ export const fetchGithubPullRequestByNumber = (
       catch: toPullRequestValidationError,
     });
   });
-export const upsertGithubPullRequest = (
+const upsertGithubPullRequest = (
   githubCli: GithubCli,
   repoPath: string,
-  context: GithubPullRequestContext,
+  repository: GitProviderRepository,
   approval: TaskApprovalContext,
   title: string,
   body: string,
 ) =>
   Effect.gen(function* () {
-    const repoSlug = `${context.repository.owner}/${context.repository.name}`;
+    const repoSlug = `${repository.owner}/${repository.name}`;
     const existingPullRequest = approval.pullRequest;
+    if (
+      existingPullRequest !== undefined &&
+      existingPullRequest.providerId !== GITHUB_PROVIDER_ID
+    ) {
+      return yield* Effect.fail(
+        new HostValidationError({
+          field: "pullRequest.providerId",
+          message: `Pull request provider '${existingPullRequest.providerId}' does not match configured provider '${GITHUB_PROVIDER_ID}'.`,
+          details: {
+            providerId: existingPullRequest.providerId,
+            configuredProviderId: GITHUB_PROVIDER_ID,
+          },
+        }),
+      );
+    }
     const args =
       existingPullRequest !== undefined && isEditablePullRequest(existingPullRequest)
         ? [
@@ -131,10 +150,101 @@ export const upsertGithubPullRequest = (
             "-f",
             `body=${body}`,
           ];
-    const payload = yield* runGithubApi(githubCli, repoPath, context.repository.host, args);
+    const payload = yield* runGithubApi(githubCli, repoPath, repository.host, args);
     const pullRequest = yield* Effect.try({
       try: () => parseGithubPullResponse(payload),
       catch: toPullRequestValidationError,
     });
     return pullRequest.record;
   });
+
+export const createGithubPullRequestProviderPort = ({
+  githubCli,
+  repositoryPort,
+}: {
+  githubCli: GithubCli;
+  repositoryPort: GitProviderRepositoryPort;
+}): PullRequestProviderPort => {
+  const getRepository = (repoConfig: RepoConfig) => repositoryPort.getRepository(repoConfig);
+
+  const getByNumber: PullRequestProviderPort["getByNumber"] = (input) =>
+    Effect.gen(function* () {
+      const repository = yield* getRepository(input.repoConfig);
+      return yield* fetchGithubPullRequestByNumber(
+        githubCli,
+        input.repoConfig.repoPath,
+        repository,
+        input.number,
+      );
+    });
+
+  const validateLinkedPullRequest = (linkedPullRequest: PullRequest) => {
+    if (linkedPullRequest.providerId === GITHUB_PROVIDER_ID) {
+      return Effect.void;
+    }
+    return Effect.fail(
+      new HostValidationError({
+        field: "pullRequest.providerId",
+        message: `Pull request provider '${linkedPullRequest.providerId}' does not match configured provider '${GITHUB_PROVIDER_ID}'.`,
+        details: {
+          providerId: linkedPullRequest.providerId,
+          configuredProviderId: GITHUB_PROVIDER_ID,
+        },
+      }),
+    );
+  };
+
+  return {
+    providerId: GITHUB_PROVIDER_ID,
+    findOpenForSourceBranch: (input) =>
+      Effect.gen(function* () {
+        const repository = yield* getRepository(input.repoConfig);
+        const pullRequests = yield* findGithubPullRequestsForBranch(
+          githubCli,
+          input.repoConfig.repoPath,
+          repository,
+          input.sourceBranch,
+          "open",
+        );
+        return yield* Effect.try({
+          try: () => selectOpenPullRequestForBranch(pullRequests, input.sourceBranch),
+          catch: toPullRequestValidationError,
+        });
+      }),
+    findLatestMergedForSourceBranch: (input) =>
+      Effect.gen(function* () {
+        const repository = yield* getRepository(input.repoConfig);
+        const pullRequests = yield* findGithubPullRequestsForBranch(
+          githubCli,
+          input.repoConfig.repoPath,
+          repository,
+          input.sourceBranch,
+          "all",
+        );
+        return selectLatestMergedPullRequestForBranch(pullRequests);
+      }),
+    getByNumber,
+    refresh: (input) =>
+      Effect.gen(function* () {
+        yield* validateLinkedPullRequest(input.linkedPullRequest);
+        return yield* getByNumber({
+          repoConfig: input.repoConfig,
+          number: input.linkedPullRequest.number,
+        });
+      }),
+    resolvePublishRemote: (input) =>
+      repositoryPort.getMapping(input.repoConfig).pipe(Effect.map(({ remoteName }) => remoteName)),
+    upsert: (input) =>
+      Effect.gen(function* () {
+        const repository = yield* getRepository(input.repoConfig);
+        return yield* upsertGithubPullRequest(
+          githubCli,
+          input.repoConfig.repoPath,
+          repository,
+          input.approval,
+          input.title,
+          input.body,
+        );
+      }),
+  };
+};

--- a/packages/host/src/adapters/git-providers/github/pull-requests.ts
+++ b/packages/host/src/adapters/git-providers/github/pull-requests.ts
@@ -25,6 +25,95 @@ import {
 
 const GITHUB_PROVIDER_ID = GITHUB_PROVIDER_DESCRIPTOR.id;
 
+export const createGithubPullRequestProviderPort = ({
+  githubCli,
+  repositoryPort,
+}: {
+  githubCli: GithubCli;
+  repositoryPort: GitProviderRepositoryPort;
+}): PullRequestProviderPort => {
+  const getRepository = (repoConfig: RepoConfig) => repositoryPort.getRepository(repoConfig);
+
+  const getByNumber: PullRequestProviderPort["getByNumber"] = (input) =>
+    Effect.gen(function* () {
+      const repository = yield* getRepository(input.repoConfig);
+      return yield* getPullRequest(githubCli, input.repoConfig.repoPath, repository, input.number);
+    });
+
+  const validateLinkedPullRequest = (linkedPullRequest: PullRequest) => {
+    if (linkedPullRequest.providerId === GITHUB_PROVIDER_ID) {
+      return Effect.void;
+    }
+    return Effect.fail(
+      new HostValidationError({
+        field: "pullRequest.providerId",
+        message: `Pull request provider '${linkedPullRequest.providerId}' does not match configured provider '${GITHUB_PROVIDER_ID}'.`,
+        details: {
+          providerId: linkedPullRequest.providerId,
+          configuredProviderId: GITHUB_PROVIDER_ID,
+        },
+      }),
+    );
+  };
+
+  return {
+    providerId: GITHUB_PROVIDER_ID,
+    findOpenForSourceBranch: (input) =>
+      Effect.gen(function* () {
+        const repository = yield* getRepository(input.repoConfig);
+        const pullRequests = yield* listPullRequests(
+          githubCli,
+          input.repoConfig.repoPath,
+          repository,
+          input.sourceBranch,
+          "open",
+        );
+        return yield* Effect.try({
+          try: () => selectOpenPullRequest(pullRequests, input.sourceBranch),
+          catch: toPullRequestValidationError,
+        });
+      }),
+    findLatestMergedForSourceBranch: (input) =>
+      Effect.gen(function* () {
+        const repository = yield* getRepository(input.repoConfig);
+        const pullRequests = yield* listPullRequests(
+          githubCli,
+          input.repoConfig.repoPath,
+          repository,
+          input.sourceBranch,
+          "all",
+        );
+        return yield* Effect.try({
+          try: () => selectLatestMergedPullRequest(pullRequests),
+          catch: toPullRequestValidationError,
+        });
+      }),
+    getByNumber,
+    refresh: (input) =>
+      Effect.gen(function* () {
+        yield* validateLinkedPullRequest(input.linkedPullRequest);
+        return yield* getByNumber({
+          repoConfig: input.repoConfig,
+          number: input.linkedPullRequest.number,
+        });
+      }),
+    resolvePublishRemote: (input) =>
+      repositoryPort.getMapping(input.repoConfig).pipe(Effect.map(({ remoteName }) => remoteName)),
+    upsert: (input) =>
+      Effect.gen(function* () {
+        const repository = yield* getRepository(input.repoConfig);
+        return yield* upsertPullRequest(
+          githubCli,
+          input.repoConfig.repoPath,
+          repository,
+          input.approval,
+          input.title,
+          input.body,
+        );
+      }),
+  };
+};
+
 const toPullRequestValidationError = (cause: unknown): HostValidationErrorAggregate =>
   cause instanceof HostValidationError
     ? cause
@@ -33,7 +122,7 @@ const toPullRequestValidationError = (cause: unknown): HostValidationErrorAggreg
         cause,
       });
 
-const selectOpenPullRequestForBranch = (
+const selectOpenPullRequest = (
   pullRequests: readonly ResolvedPullRequest[],
   sourceBranch: string,
 ): ResolvedPullRequest | undefined => {
@@ -47,7 +136,7 @@ const selectOpenPullRequestForBranch = (
   return pullRequests[0];
 };
 
-const selectLatestMergedPullRequestForBranch = (
+const selectLatestMergedPullRequest = (
   pullRequests: readonly ResolvedPullRequest[],
 ): ResolvedPullRequest | undefined =>
   pullRequests
@@ -66,7 +155,7 @@ const selectLatestMergedPullRequestForBranch = (
     .sort((left, right) => left.mergedAt.localeCompare(right.mergedAt))
     .at(-1)?.pullRequest;
 
-const findGithubPullRequestsForBranch = (
+const listPullRequests = (
   githubCli: GithubCli,
   repoPath: string,
   repository: GitProviderRepository,
@@ -92,7 +181,7 @@ const findGithubPullRequestsForBranch = (
     return parsed;
   });
 
-const fetchGithubPullRequestByNumber = (
+const getPullRequest = (
   githubCli: GithubCli,
   repoPath: string,
   repository: GitProviderRepository,
@@ -109,7 +198,8 @@ const fetchGithubPullRequestByNumber = (
       catch: toPullRequestValidationError,
     });
   });
-const upsertGithubPullRequest = (
+
+const upsertPullRequest = (
   githubCli: GithubCli,
   repoPath: string,
   repository: GitProviderRepository,
@@ -168,97 +258,3 @@ const upsertGithubPullRequest = (
     });
     return pullRequest.record;
   });
-
-export const createGithubPullRequestProviderPort = ({
-  githubCli,
-  repositoryPort,
-}: {
-  githubCli: GithubCli;
-  repositoryPort: GitProviderRepositoryPort;
-}): PullRequestProviderPort => {
-  const getRepository = (repoConfig: RepoConfig) => repositoryPort.getRepository(repoConfig);
-
-  const getByNumber: PullRequestProviderPort["getByNumber"] = (input) =>
-    Effect.gen(function* () {
-      const repository = yield* getRepository(input.repoConfig);
-      return yield* fetchGithubPullRequestByNumber(
-        githubCli,
-        input.repoConfig.repoPath,
-        repository,
-        input.number,
-      );
-    });
-
-  const validateLinkedPullRequest = (linkedPullRequest: PullRequest) => {
-    if (linkedPullRequest.providerId === GITHUB_PROVIDER_ID) {
-      return Effect.void;
-    }
-    return Effect.fail(
-      new HostValidationError({
-        field: "pullRequest.providerId",
-        message: `Pull request provider '${linkedPullRequest.providerId}' does not match configured provider '${GITHUB_PROVIDER_ID}'.`,
-        details: {
-          providerId: linkedPullRequest.providerId,
-          configuredProviderId: GITHUB_PROVIDER_ID,
-        },
-      }),
-    );
-  };
-
-  return {
-    providerId: GITHUB_PROVIDER_ID,
-    findOpenForSourceBranch: (input) =>
-      Effect.gen(function* () {
-        const repository = yield* getRepository(input.repoConfig);
-        const pullRequests = yield* findGithubPullRequestsForBranch(
-          githubCli,
-          input.repoConfig.repoPath,
-          repository,
-          input.sourceBranch,
-          "open",
-        );
-        return yield* Effect.try({
-          try: () => selectOpenPullRequestForBranch(pullRequests, input.sourceBranch),
-          catch: toPullRequestValidationError,
-        });
-      }),
-    findLatestMergedForSourceBranch: (input) =>
-      Effect.gen(function* () {
-        const repository = yield* getRepository(input.repoConfig);
-        const pullRequests = yield* findGithubPullRequestsForBranch(
-          githubCli,
-          input.repoConfig.repoPath,
-          repository,
-          input.sourceBranch,
-          "all",
-        );
-        return yield* Effect.try({
-          try: () => selectLatestMergedPullRequestForBranch(pullRequests),
-          catch: toPullRequestValidationError,
-        });
-      }),
-    getByNumber,
-    refresh: (input) =>
-      Effect.gen(function* () {
-        yield* validateLinkedPullRequest(input.linkedPullRequest);
-        return yield* getByNumber({
-          repoConfig: input.repoConfig,
-          number: input.linkedPullRequest.number,
-        });
-      }),
-    resolvePublishRemote: (input) =>
-      repositoryPort.getMapping(input.repoConfig).pipe(Effect.map(({ remoteName }) => remoteName)),
-    upsert: (input) =>
-      Effect.gen(function* () {
-        const repository = yield* getRepository(input.repoConfig);
-        return yield* upsertGithubPullRequest(
-          githubCli,
-          input.repoConfig.repoPath,
-          repository,
-          input.approval,
-          input.title,
-          input.body,
-        );
-      }),
-  };
-};

--- a/packages/host/src/application/git/git-provider-resolver.test.ts
+++ b/packages/host/src/application/git/git-provider-resolver.test.ts
@@ -28,8 +28,12 @@ const healthPort = (): GitProviderHealthPort => ({
   getStatus: () => unexpectedPortCall(),
 });
 const pullRequestPort: PullRequestProviderPort = {
-  findByBranch: () => unexpectedPortCall(),
+  providerId: "github",
+  findOpenForSourceBranch: () => unexpectedPortCall(),
+  findLatestMergedForSourceBranch: () => unexpectedPortCall(),
   getByNumber: () => unexpectedPortCall(),
+  refresh: () => unexpectedPortCall(),
+  resolvePublishRemote: () => unexpectedPortCall(),
   upsert: () => unexpectedPortCall(),
 };
 const pullRequestReviewPort: PullRequestReviewProviderPort = {
@@ -222,6 +226,34 @@ describe("createGitProviderResolver", () => {
           _tag: "GitProviderRegistrationError",
           reason: "capability_provider_id_mismatch",
           capability: "pull_request_review",
+          providerId: "github",
+        }),
+      );
+    }
+  });
+
+  test("rejects a Pull Request port owned by another provider", async () => {
+    const foreignPullRequestPort: PullRequestProviderPort = {
+      ...pullRequestPort,
+      providerId: "gitlab",
+    };
+    const github = provider({
+      providerDescriptor: descriptor({
+        id: "github",
+        supportsPullRequests: true,
+      }),
+      pullRequests: foreignPullRequestPort,
+    });
+
+    const result = await registrationEither([github]);
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toEqual(
+        expect.objectContaining({
+          _tag: "GitProviderRegistrationError",
+          reason: "capability_provider_id_mismatch",
+          capability: "pull_requests",
           providerId: "github",
         }),
       );

--- a/packages/host/src/application/git/git-provider-resolver.ts
+++ b/packages/host/src/application/git/git-provider-resolver.ts
@@ -6,8 +6,7 @@ import {
   GitProviderRegistrationError,
   GitProviderResolutionError,
 } from "../../ports/git-provider-errors";
-import type { GitProviderPort, PullRequestProviderPort } from "../../ports/git-provider-port";
-import type { PullRequestReviewProviderPort } from "../../ports/pull-request-review-provider-port";
+import type { GitProviderPort } from "../../ports/git-provider-port";
 
 export {
   GitProviderCapabilityError,
@@ -82,15 +81,16 @@ export const createGitProviderResolver = (
   });
 };
 
-type CapabilityRule<Port> = {
+type CapabilityRule<Port extends { providerId: GitProviderId }> = {
   capability: GitProviderCapability;
   supported: boolean;
   getPort: () => Effect.Effect<Port, GitProviderCapabilityError>;
-  checkPort?: (
-    port: Port,
-    providerId: GitProviderId,
-  ) => Effect.Effect<void, GitProviderRegistrationError>;
 };
+
+const PORT_LABELS = {
+  pull_requests: "Pull Request",
+  pull_request_review: "Pull Request review",
+} satisfies Record<GitProviderCapability, string>;
 
 function checkProvider(
   provider: GitProviderPort,
@@ -101,18 +101,16 @@ function checkProvider(
       capability: "pull_requests",
       supported: capabilities.supportsPullRequests,
       getPort: () => provider.pullRequests(),
-      checkPort: checkPullRequestPortOwner,
     });
     yield* checkCapability(provider, {
       capability: "pull_request_review",
       supported: capabilities.supportsPullRequestReview,
       getPort: () => provider.pullRequestReview(),
-      checkPort: checkReviewPortOwner,
     });
   });
 }
 
-function checkCapability<Port>(
+function checkCapability<Port extends { providerId: GitProviderId }>(
   provider: GitProviderPort,
   rule: CapabilityRule<Port>,
 ): Effect.Effect<void, GitProviderRegistrationError> {
@@ -142,44 +140,15 @@ function checkCapability<Port>(
       );
     }
 
-    if (portResult._tag === "Right" && rule.checkPort) {
-      yield* rule.checkPort(portResult.right, providerId);
+    if (portResult._tag === "Right" && portResult.right.providerId !== providerId) {
+      return yield* Effect.fail(
+        new GitProviderRegistrationError({
+          reason: "capability_provider_id_mismatch",
+          providerId,
+          capability: rule.capability,
+          message: `Git provider '${providerId}' supplies a ${PORT_LABELS[rule.capability]} port owned by '${portResult.right.providerId}'.`,
+        }),
+      );
     }
   });
-}
-
-function checkPullRequestPortOwner(
-  port: PullRequestProviderPort,
-  providerId: GitProviderId,
-): Effect.Effect<void, GitProviderRegistrationError> {
-  if (port.providerId === providerId) {
-    return Effect.void;
-  }
-
-  return Effect.fail(
-    new GitProviderRegistrationError({
-      reason: "capability_provider_id_mismatch",
-      providerId,
-      capability: "pull_requests",
-      message: `Git provider '${providerId}' supplies a Pull Request port owned by '${port.providerId}'.`,
-    }),
-  );
-}
-
-function checkReviewPortOwner(
-  port: PullRequestReviewProviderPort,
-  providerId: GitProviderId,
-): Effect.Effect<void, GitProviderRegistrationError> {
-  if (port.providerId === providerId) {
-    return Effect.void;
-  }
-
-  return Effect.fail(
-    new GitProviderRegistrationError({
-      reason: "capability_provider_id_mismatch",
-      providerId,
-      capability: "pull_request_review",
-      message: `Git provider '${providerId}' supplies a Pull Request review port owned by '${port.providerId}'.`,
-    }),
-  );
 }

--- a/packages/host/src/application/git/git-provider-resolver.ts
+++ b/packages/host/src/application/git/git-provider-resolver.ts
@@ -6,7 +6,7 @@ import {
   GitProviderRegistrationError,
   GitProviderResolutionError,
 } from "../../ports/git-provider-errors";
-import type { GitProviderPort } from "../../ports/git-provider-port";
+import type { GitProviderPort, PullRequestProviderPort } from "../../ports/git-provider-port";
 import type { PullRequestReviewProviderPort } from "../../ports/pull-request-review-provider-port";
 
 export {
@@ -101,6 +101,7 @@ function checkProvider(
       capability: "pull_requests",
       supported: capabilities.supportsPullRequests,
       getPort: () => provider.pullRequests(),
+      checkPort: checkPullRequestPortOwner,
     });
     yield* checkCapability(provider, {
       capability: "pull_request_review",
@@ -145,6 +146,24 @@ function checkCapability<Port>(
       yield* rule.checkPort(portResult.right, providerId);
     }
   });
+}
+
+function checkPullRequestPortOwner(
+  port: PullRequestProviderPort,
+  providerId: GitProviderId,
+): Effect.Effect<void, GitProviderRegistrationError> {
+  if (port.providerId === providerId) {
+    return Effect.void;
+  }
+
+  return Effect.fail(
+    new GitProviderRegistrationError({
+      reason: "capability_provider_id_mismatch",
+      providerId,
+      capability: "pull_requests",
+      message: `Git provider '${providerId}' supplies a Pull Request port owned by '${port.providerId}'.`,
+    }),
+  );
 }
 
 function checkReviewPortOwner(

--- a/packages/host/src/application/git/git-provider-service.test.ts
+++ b/packages/host/src/application/git/git-provider-service.test.ts
@@ -46,8 +46,13 @@ describe("GitProviderService", () => {
       health: () => health,
       pullRequests: () =>
         Effect.succeed({
-          findByBranch: () => Effect.die("Unexpected findByBranch call"),
+          providerId: "github",
+          findOpenForSourceBranch: () => Effect.die("Unexpected findOpenForSourceBranch call"),
+          findLatestMergedForSourceBranch: () =>
+            Effect.die("Unexpected findLatestMergedForSourceBranch call"),
           getByNumber: () => Effect.die("Unexpected getByNumber call"),
+          refresh: () => Effect.die("Unexpected refresh call"),
+          resolvePublishRemote: () => Effect.die("Unexpected resolvePublishRemote call"),
           upsert: () => Effect.die("Unexpected upsert call"),
         }),
       pullRequestReview: () =>

--- a/packages/host/src/application/pull-requests/pull-request-provider-match.ts
+++ b/packages/host/src/application/pull-requests/pull-request-provider-match.ts
@@ -1,0 +1,25 @@
+import type { GitProviderId } from "@openducktor/contracts";
+import { Effect } from "effect";
+import { HostValidationError, type HostValidationErrorAggregate } from "../../effect/host-errors";
+
+export const requirePullRequestProviderMatch = ({
+  configuredProviderId,
+  linkedProviderId,
+  field = "pullRequest.providerId",
+}: {
+  configuredProviderId: GitProviderId;
+  linkedProviderId: string;
+  field?: string;
+}): Effect.Effect<void, HostValidationErrorAggregate> => {
+  if (linkedProviderId === configuredProviderId) {
+    return Effect.void;
+  }
+
+  return Effect.fail(
+    new HostValidationError({
+      field,
+      message: `Pull request provider '${linkedProviderId}' does not match configured provider '${configuredProviderId}'.`,
+      details: { linkedProviderId, configuredProviderId },
+    }),
+  );
+};

--- a/packages/host/src/application/pull-requests/pull-request-review-service.test.ts
+++ b/packages/host/src/application/pull-requests/pull-request-review-service.test.ts
@@ -138,8 +138,12 @@ const makeProvider = (
     }),
     pullRequests: () =>
       Effect.succeed<PullRequestProviderPort>({
-        findByBranch: () => unexpectedProviderOperation(),
+        providerId,
+        findOpenForSourceBranch: () => unexpectedProviderOperation(),
+        findLatestMergedForSourceBranch: () => unexpectedProviderOperation(),
         getByNumber: () => unexpectedProviderOperation(),
+        refresh: () => unexpectedProviderOperation(),
+        resolvePublishRemote: () => unexpectedProviderOperation(),
         upsert: () => unexpectedProviderOperation(),
       }),
     pullRequestReview:

--- a/packages/host/src/application/tasks/support/approval-readiness.ts
+++ b/packages/host/src/application/tasks/support/approval-readiness.ts
@@ -17,7 +17,6 @@ import { effectiveTargetBranchForTask } from "./task-worktree-cleanup";
 export const loadOpenApprovalContext = (
   dependencies: {
     gitPort: GitPort;
-    gitProviderResolver: GitProviderResolver;
     settingsConfig: SettingsConfigPort;
     taskWorktreeService: TaskWorktreeService;
     workspaceSettingsService: WorkspaceSettingsService;
@@ -38,7 +37,6 @@ export const loadOpenApprovalContext = (
     });
     const effectiveRepoPath = repoConfig.repoPath;
     const defaultMergeMethod = yield* loadDefaultMergeMethod(dependencies.settingsConfig);
-    const providers = yield* providerStatuses(dependencies.gitProviderResolver, repoConfig);
     const taskWorktree = yield* dependencies.taskWorktreeService.getTaskWorktree({
       repoPath: effectiveRepoPath,
       taskId,
@@ -107,7 +105,7 @@ export const loadOpenApprovalContext = (
       hasUncommittedChanges: worktreeStatus.fileStatusCounts.total > 0,
       uncommittedFileCount: worktreeStatus.fileStatusCounts.total,
       pullRequest: metadata.pullRequest,
-      providers,
+      providers: [],
       suggestedSquashCommitMessage,
     };
   });

--- a/packages/host/src/application/tasks/support/required-provider-task-dependencies.test.ts
+++ b/packages/host/src/application/tasks/support/required-provider-task-dependencies.test.ts
@@ -39,10 +39,9 @@ describe("provider-neutral task dependency gates", () => {
     });
   });
 
-  test("direct merge requires only Git and provider-neutral services", () => {
+  test("direct merge does not require a Git provider", () => {
     const devServerService = dependencyStub<DevServerService>();
     const gitPort = dependencyStub<GitPort>();
-    const gitProviderResolver = dependencyStub<GitProviderResolver>();
     const settingsConfig = dependencyStub<SettingsConfigPort>();
     const taskWorktreeService = dependencyStub<TaskWorktreeService>();
     const terminalService = dependencyStub<TaskTerminalCleanupPort>();
@@ -56,7 +55,6 @@ describe("provider-neutral task dependency gates", () => {
       requireDirectMergeDependencies({
         devServerService,
         gitPort,
-        gitProviderResolver,
         settingsConfig,
         taskWorktreeService,
         terminalService,
@@ -66,7 +64,6 @@ describe("provider-neutral task dependency gates", () => {
     ).toEqual({
       devServerService,
       gitPort,
-      gitProviderResolver,
       settingsConfig,
       taskWorktreeService,
       terminalService,

--- a/packages/host/src/application/tasks/support/required-provider-task-dependencies.test.ts
+++ b/packages/host/src/application/tasks/support/required-provider-task-dependencies.test.ts
@@ -7,7 +7,10 @@ import type { WorkspaceSettingsService } from "../../workspaces/workspace-settin
 import type { TaskTerminalCleanupPort } from "../task-service";
 import type { TaskWorktreeService } from "../worktrees/task-worktree-service";
 import { requireApprovalContextDependencies } from "./required-provider-task-dependencies";
-import { requireDirectMergeDependencies } from "./required-task-dependencies";
+import {
+  requireDirectMergeDependencies,
+  requireLinkMergedPullRequestDependencies,
+} from "./required-task-dependencies";
 
 const dependencyStub = <Dependency>(): Dependency => {
   // SAFETY: These gates only check that each value exists, then return it unchanged.
@@ -53,6 +56,39 @@ describe("provider-neutral task dependency gates", () => {
 
     expect(
       requireDirectMergeDependencies({
+        devServerService,
+        gitPort,
+        settingsConfig,
+        taskWorktreeService,
+        terminalService,
+        worktreeFiles,
+        workspaceSettingsService,
+      }),
+    ).toEqual({
+      devServerService,
+      gitPort,
+      settingsConfig,
+      taskWorktreeService,
+      terminalService,
+      worktreeFiles,
+      workspaceSettingsService,
+    });
+  });
+
+  test("merged Pull Request cleanup does not require a Git provider", () => {
+    const devServerService = dependencyStub<DevServerService>();
+    const gitPort = dependencyStub<GitPort>();
+    const settingsConfig = dependencyStub<SettingsConfigPort>();
+    const taskWorktreeService = dependencyStub<TaskWorktreeService>();
+    const terminalService = dependencyStub<TaskTerminalCleanupPort>();
+    const worktreeFiles =
+      dependencyStub<
+        NonNullable<Parameters<typeof requireLinkMergedPullRequestDependencies>[0]["worktreeFiles"]>
+      >();
+    const workspaceSettingsService = dependencyStub<WorkspaceSettingsService>();
+
+    expect(
+      requireLinkMergedPullRequestDependencies({
         devServerService,
         gitPort,
         settingsConfig,

--- a/packages/host/src/application/tasks/support/required-task-dependencies.ts
+++ b/packages/host/src/application/tasks/support/required-task-dependencies.ts
@@ -225,7 +225,6 @@ export const requireDirectMergeDependencies = ({
 export const requireLinkMergedPullRequestDependencies = ({
   devServerService,
   gitPort,
-  gitProviderResolver,
   settingsConfig,
   taskWorktreeService,
   terminalService,
@@ -234,16 +233,12 @@ export const requireLinkMergedPullRequestDependencies = ({
 }: {
   devServerService: DevServerService | undefined;
   gitPort: GitPort | undefined;
-  gitProviderResolver: GitProviderResolver | undefined;
   settingsConfig: SettingsConfigPort | undefined;
   taskWorktreeService: TaskWorktreeService | undefined;
   terminalService: TaskTerminalCleanupPort | undefined;
   worktreeFiles: WorktreeFilePort | undefined;
   workspaceSettingsService: WorkspaceSettingsService | undefined;
-}): MergedTaskCleanupDependencies & {
-  gitProviderResolver: GitProviderResolver;
-  workspaceSettingsService: WorkspaceSettingsService;
-} => {
+}): MergedTaskCleanupDependencies & { workspaceSettingsService: WorkspaceSettingsService } => {
   if (!devServerService) {
     throw missingTaskDependency(
       "Dev server service is required for task_pull_request_link_merged.",
@@ -251,11 +246,6 @@ export const requireLinkMergedPullRequestDependencies = ({
   }
   if (!gitPort) {
     throw missingTaskDependency("Git port is required for task_pull_request_link_merged.");
-  }
-  if (!gitProviderResolver) {
-    throw missingTaskDependency(
-      "Git provider resolver is required for task_pull_request_link_merged.",
-    );
   }
   if (!settingsConfig) {
     throw missingTaskDependency(
@@ -276,12 +266,10 @@ export const requireLinkMergedPullRequestDependencies = ({
     );
   }
   const dependencies: MergedTaskCleanupDependencies & {
-    gitProviderResolver: GitProviderResolver;
     workspaceSettingsService: WorkspaceSettingsService;
   } = {
     devServerService,
     gitPort,
-    gitProviderResolver,
     settingsConfig,
     taskWorktreeService,
     terminalService,

--- a/packages/host/src/application/tasks/support/required-task-dependencies.ts
+++ b/packages/host/src/application/tasks/support/required-task-dependencies.ts
@@ -177,6 +177,54 @@ export const requireMergedTaskCleanupDependencies = (
 export const requireDirectMergeDependencies = ({
   devServerService,
   gitPort,
+  settingsConfig,
+  taskWorktreeService,
+  terminalService,
+  worktreeFiles,
+  workspaceSettingsService,
+}: {
+  devServerService: DevServerService | undefined;
+  gitPort: GitPort | undefined;
+  settingsConfig: SettingsConfigPort | undefined;
+  taskWorktreeService: TaskWorktreeService | undefined;
+  terminalService: TaskTerminalCleanupPort | undefined;
+  worktreeFiles: WorktreeFilePort | undefined;
+  workspaceSettingsService: WorkspaceSettingsService | undefined;
+}): MergedTaskCleanupDependencies & { workspaceSettingsService: WorkspaceSettingsService } => {
+  if (!devServerService) {
+    throw missingTaskDependency("Dev server service is required for task_direct_merge.");
+  }
+  if (!settingsConfig) {
+    throw missingTaskDependency("Settings config port is required for task_direct_merge.");
+  }
+  if (!gitPort) {
+    throw missingTaskDependency("Git port is required for task_direct_merge.");
+  }
+  if (!taskWorktreeService) {
+    throw missingTaskDependency("Task worktree service is required for task_direct_merge.");
+  }
+  if (!terminalService) {
+    throw missingTaskDependency("Terminal service is required for task_direct_merge.");
+  }
+  if (!worktreeFiles) {
+    throw missingTaskDependency("Worktree file port is required for task_direct_merge.");
+  }
+  if (!workspaceSettingsService) {
+    throw missingTaskDependency("Workspace settings service is required for task_direct_merge.");
+  }
+  return {
+    devServerService,
+    gitPort,
+    settingsConfig,
+    taskWorktreeService,
+    terminalService,
+    worktreeFiles,
+    workspaceSettingsService,
+  };
+};
+export const requireLinkMergedPullRequestDependencies = ({
+  devServerService,
+  gitPort,
   gitProviderResolver,
   settingsConfig,
   taskWorktreeService,
@@ -197,58 +245,17 @@ export const requireDirectMergeDependencies = ({
   workspaceSettingsService: WorkspaceSettingsService;
 } => {
   if (!devServerService) {
-    throw missingTaskDependency("Dev server service is required for task_direct_merge.");
-  }
-  if (!settingsConfig) {
-    throw missingTaskDependency("Settings config port is required for task_direct_merge.");
-  }
-  if (!gitProviderResolver) {
-    throw missingTaskDependency("Git provider resolver is required for task_direct_merge.");
-  }
-  if (!gitPort) {
-    throw missingTaskDependency("Git port is required for task_direct_merge.");
-  }
-  if (!taskWorktreeService) {
-    throw missingTaskDependency("Task worktree service is required for task_direct_merge.");
-  }
-  if (!terminalService) {
-    throw missingTaskDependency("Terminal service is required for task_direct_merge.");
-  }
-  if (!worktreeFiles) {
-    throw missingTaskDependency("Worktree file port is required for task_direct_merge.");
-  }
-  if (!workspaceSettingsService) {
-    throw missingTaskDependency("Workspace settings service is required for task_direct_merge.");
-  }
-  return {
-    devServerService,
-    gitPort,
-    gitProviderResolver,
-    settingsConfig,
-    taskWorktreeService,
-    terminalService,
-    worktreeFiles,
-    workspaceSettingsService,
-  };
-};
-export const requireLinkMergedPullRequestDependencies = (
-  devServerService: DevServerService | undefined,
-  gitPort: GitPort | undefined,
-  settingsConfig: SettingsConfigPort | undefined,
-  taskWorktreeService: TaskWorktreeService | undefined,
-  terminalService: TaskTerminalCleanupPort | undefined,
-  worktreeFiles: WorktreeFilePort | undefined,
-  workspaceSettingsService: WorkspaceSettingsService | undefined,
-): MergedTaskCleanupDependencies & {
-  workspaceSettingsService: WorkspaceSettingsService;
-} => {
-  if (!devServerService) {
     throw missingTaskDependency(
       "Dev server service is required for task_pull_request_link_merged.",
     );
   }
   if (!gitPort) {
     throw missingTaskDependency("Git port is required for task_pull_request_link_merged.");
+  }
+  if (!gitProviderResolver) {
+    throw missingTaskDependency(
+      "Git provider resolver is required for task_pull_request_link_merged.",
+    );
   }
   if (!settingsConfig) {
     throw missingTaskDependency(
@@ -269,10 +276,12 @@ export const requireLinkMergedPullRequestDependencies = (
     );
   }
   const dependencies: MergedTaskCleanupDependencies & {
+    gitProviderResolver: GitProviderResolver;
     workspaceSettingsService: WorkspaceSettingsService;
   } = {
     devServerService,
     gitPort,
+    gitProviderResolver,
     settingsConfig,
     taskWorktreeService,
     terminalService,

--- a/packages/host/src/application/tasks/task-service-direct-merge.test.ts
+++ b/packages/host/src/application/tasks/task-service-direct-merge.test.ts
@@ -211,6 +211,9 @@ describe("createTaskService direct merge", () => {
     };
     const service = createTaskService({
       devServerService: createDirectMergeDevServerService(calls),
+      gitProviderResolver: {
+        resolve: () => Effect.dieMessage("direct merge must not resolve a Git provider"),
+      },
       gitPort: extendGitPort(
         createDirectMergeGitPort({
           calls,
@@ -291,7 +294,6 @@ describe("createTaskService direct merge", () => {
           },
         },
       ),
-      systemCommands: createApprovalSystemCommands(),
       taskStore,
       taskWorktreeService: createDirectMergeTaskWorktreeService("/worktrees/repo/task-1"),
       worktreeFiles: createBuildStartWorktreeFiles(calls),

--- a/packages/host/src/application/tasks/task-service-pull-request-provider.test.ts
+++ b/packages/host/src/application/tasks/task-service-pull-request-provider.test.ts
@@ -42,6 +42,12 @@ const mergedPullRequest = (providerId: string): PullRequest => ({
   mergedAt: "2026-05-02T10:00:00Z",
 });
 
+const resolvedMergedPullRequest = (providerId: string): ProviderPullRequest => ({
+  record: mergedPullRequest(providerId),
+  sourceBranch: "odt/task-42",
+  targetBranch: "main",
+});
+
 const unexpected = <Success>(): Effect.Effect<Success, never> =>
   Effect.dieMessage("unexpected provider operation");
 
@@ -113,6 +119,30 @@ const workspaceSettingsService = createBuildWorkspaceSettingsService({
   },
 });
 
+const createClosedLinkService = (persistedProviderId: string) => {
+  const provider = createProvider(gitlabDescriptor, createPullRequestPort("gitlab"));
+  const gitProviderResolver = Effect.runSync(createGitProviderResolver([provider]));
+  const setPullRequest = mock(() => Effect.succeed(true));
+  const transitionTask = mock(() => Effect.succeed(task({ status: "closed" })));
+  const service = createTaskService({
+    gitProviderResolver,
+    taskStore: {
+      listTasks: () => Effect.succeed([task({ status: "closed" })]),
+      getTaskMetadata: () =>
+        Effect.succeed({
+          spec: { markdown: "# Spec" },
+          plan: { markdown: "# Plan" },
+          pullRequest: mergedPullRequest(persistedProviderId),
+          agentSessions: [],
+        }),
+      setPullRequest,
+      transitionTask,
+    },
+    workspaceSettingsService,
+  });
+  return { service, setPullRequest, transitionTask };
+};
+
 describe("createTaskService Pull Request provider ports", () => {
   test("detects an open Pull Request through the configured provider port", async () => {
     const findOpenForSourceBranch = mock(() => Effect.succeed(resolvedPullRequest("gitlab")));
@@ -155,6 +185,51 @@ describe("createTaskService Pull Request provider ports", () => {
       repoConfig: expect.objectContaining({ repoPath: "/repo" }),
       sourceBranch: "odt/task-42",
     });
+  });
+
+  test("rejects a detected merged Pull Request from another provider", async () => {
+    const findLatestMergedForSourceBranch = mock(() =>
+      Effect.succeed(resolvedMergedPullRequest("github")),
+    );
+    const pullRequests = createPullRequestPort("gitlab", {
+      findOpenForSourceBranch: () => Effect.succeed(undefined),
+      findLatestMergedForSourceBranch,
+    });
+    const provider = createProvider(gitlabDescriptor, pullRequests);
+    const gitProviderResolver = Effect.runSync(createGitProviderResolver([provider]));
+    const setPullRequest = mock(() => Effect.succeed(true));
+    const service = createTaskService({
+      gitPort: createDirectMergeGitPort({
+        calls: [],
+        currentBranches: {
+          "/worktrees/repo/task-1": { name: "odt/task-42", detached: false },
+        },
+      }),
+      gitProviderResolver,
+      taskStore: {
+        getTask: () => Effect.succeed(task({ status: "human_review" })),
+        getTaskMetadata: () =>
+          Effect.succeed({
+            spec: { markdown: "# Spec" },
+            plan: { markdown: "# Plan" },
+            agentSessions: [],
+          }),
+        setPullRequest,
+      },
+      taskWorktreeService: createDirectMergeTaskWorktreeService("/worktrees/repo/task-1"),
+      workspaceSettingsService,
+    });
+
+    const failure = await Effect.runPromise(
+      service.detectPullRequest({ repoPath: "/repo", taskId: "task-1" }).pipe(Effect.flip),
+    );
+
+    expect(failure).toMatchObject({
+      _tag: "HostValidationError",
+      field: "pullRequest.providerId",
+    });
+    expect(findLatestMergedForSourceBranch).toHaveBeenCalledTimes(1);
+    expect(setPullRequest).not.toHaveBeenCalled();
   });
 
   test("links a Pull Request through the configured provider port", async () => {
@@ -349,7 +424,7 @@ describe("createTaskService Pull Request provider ports", () => {
     );
   });
 
-  test("rejects a detected merged Pull Request from another provider", async () => {
+  test("rejects linking a merged Pull Request from another provider", async () => {
     const pullRequests = createPullRequestPort("gitlab");
     const provider = createProvider(gitlabDescriptor, pullRequests);
     const gitProviderResolver = Effect.runSync(createGitProviderResolver([provider]));
@@ -386,5 +461,42 @@ describe("createTaskService Pull Request provider ports", () => {
       _tag: "HostValidationError",
       field: "pullRequest.providerId",
     });
+  });
+
+  test("returns a closed task unchanged when the persisted Pull Request matches the provider", async () => {
+    const { service, setPullRequest, transitionTask } = createClosedLinkService("gitlab");
+
+    const result = await Effect.runPromise(
+      service.linkMergedPullRequest({
+        repoPath: "/repo",
+        taskId: "task-1",
+        pullRequest: mergedPullRequest("gitlab"),
+      }),
+    );
+
+    expect(result).toMatchObject({ id: "task-1", status: "closed" });
+    expect(setPullRequest).not.toHaveBeenCalled();
+    expect(transitionTask).not.toHaveBeenCalled();
+  });
+
+  test("rejects a closed idempotent link when the persisted Pull Request has provider drift", async () => {
+    const { service, setPullRequest, transitionTask } = createClosedLinkService("github");
+
+    const failure = await Effect.runPromise(
+      service
+        .linkMergedPullRequest({
+          repoPath: "/repo",
+          taskId: "task-1",
+          pullRequest: mergedPullRequest("github"),
+        })
+        .pipe(Effect.flip),
+    );
+
+    expect(failure).toMatchObject({
+      _tag: "HostValidationError",
+      field: "pullRequest.providerId",
+    });
+    expect(setPullRequest).not.toHaveBeenCalled();
+    expect(transitionTask).not.toHaveBeenCalled();
   });
 });

--- a/packages/host/src/application/tasks/task-service-pull-request-provider.test.ts
+++ b/packages/host/src/application/tasks/task-service-pull-request-provider.test.ts
@@ -1,0 +1,390 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { GitProviderDescriptor, PullRequest } from "@openducktor/contracts";
+import { Effect } from "effect";
+import { GitProviderCapabilityError } from "../../ports/git-provider-errors";
+import type {
+  GitProviderPort,
+  PullRequestProviderPort,
+  ProviderPullRequest,
+} from "../../ports/git-provider-port";
+import type { PullRequestReviewProviderPort } from "../../ports/pull-request-review-provider-port";
+import { createGitProviderResolver } from "../git/git-provider-resolver";
+import {
+  createBuildSettingsConfig,
+  createBuildWorkspaceSettingsService,
+  createDirectMergeDevServerService,
+  createDirectMergeGitPort,
+  createDirectMergeTaskWorktreeService,
+  createTaskService,
+  extendGitPort,
+  type TaskStorePort,
+  task,
+} from "./test-support/task-workflow-harness";
+
+const linkedPullRequest = (providerId: string): PullRequest => ({
+  providerId,
+  number: 42,
+  url: `https://example.com/${providerId}/pull/42`,
+  state: "open",
+  createdAt: "2026-05-01T10:00:00Z",
+  updatedAt: "2026-05-02T10:00:00Z",
+});
+
+const resolvedPullRequest = (providerId: string): ProviderPullRequest => ({
+  record: linkedPullRequest(providerId),
+  sourceBranch: "odt/task-42",
+  targetBranch: "main",
+});
+
+const mergedPullRequest = (providerId: string): PullRequest => ({
+  ...linkedPullRequest(providerId),
+  state: "merged",
+  mergedAt: "2026-05-02T10:00:00Z",
+});
+
+const unexpected = <Success>(): Effect.Effect<Success, never> =>
+  Effect.dieMessage("unexpected provider operation");
+
+const createPullRequestPort = (
+  providerId: string,
+  overrides: Partial<PullRequestProviderPort> = {},
+): PullRequestProviderPort => ({
+  providerId,
+  findOpenForSourceBranch: () => unexpected(),
+  findLatestMergedForSourceBranch: () => unexpected(),
+  getByNumber: () => unexpected(),
+  refresh: () => unexpected(),
+  resolvePublishRemote: () => unexpected(),
+  upsert: () => unexpected(),
+  ...overrides,
+});
+
+const createProvider = (
+  providerDescriptor: GitProviderDescriptor,
+  pullRequests: PullRequestProviderPort,
+): GitProviderPort => {
+  const reviewPort: PullRequestReviewProviderPort = {
+    providerId: providerDescriptor.id,
+    readContext: () => unexpected(),
+  };
+  return {
+    getDescriptor: () => providerDescriptor,
+    repository: () => ({
+      detectRepository: () => unexpected(),
+      getRepository: () => unexpected(),
+      getMapping: () => unexpected(),
+    }),
+    health: () => ({ getStatus: () => unexpected() }),
+    pullRequests: () => Effect.succeed(pullRequests),
+    pullRequestReview: () =>
+      providerDescriptor.capabilities.supportsPullRequestReview
+        ? Effect.succeed(reviewPort)
+        : Effect.fail(
+            new GitProviderCapabilityError({
+              providerId: providerDescriptor.id,
+              capability: "pull_request_review",
+              message: "Pull Request review is not supported.",
+            }),
+          ),
+  };
+};
+
+const gitlabDescriptor: GitProviderDescriptor = {
+  id: "gitlab",
+  label: "GitLab",
+  description: "Test Git provider",
+  capabilities: {
+    supportsPullRequests: true,
+    supportsPullRequestReview: false,
+  },
+};
+
+const workspaceSettingsService = createBuildWorkspaceSettingsService({
+  workspaceId: "repo",
+  repoPath: "/repo",
+  hooks: { preStart: [], postComplete: [] },
+  git: {
+    provider: {
+      id: "gitlab",
+      enabled: true,
+      repository: { host: "gitlab.example.com", owner: "openai", name: "openducktor" },
+      autoDetected: false,
+    },
+  },
+});
+
+describe("createTaskService Pull Request provider ports", () => {
+  test("detects an open Pull Request through the configured provider port", async () => {
+    const findOpenForSourceBranch = mock(() => Effect.succeed(resolvedPullRequest("gitlab")));
+    const pullRequests = createPullRequestPort("gitlab", { findOpenForSourceBranch });
+    const provider = createProvider(gitlabDescriptor, pullRequests);
+    const gitProviderResolver = Effect.runSync(createGitProviderResolver([provider]));
+    const setPullRequest = mock(() => Effect.succeed(true));
+    const taskStore: TaskStorePort = {
+      getTask: () => Effect.succeed(task({ status: "human_review" })),
+      getTaskMetadata: () =>
+        Effect.succeed({
+          spec: { markdown: "# Spec" },
+          plan: { markdown: "# Plan" },
+          agentSessions: [],
+        }),
+      setPullRequest,
+    };
+    const service = createTaskService({
+      gitPort: createDirectMergeGitPort({
+        calls: [],
+        currentBranches: {
+          "/worktrees/repo/task-1": { name: "odt/task-42", detached: false },
+        },
+      }),
+      gitProviderResolver,
+      taskStore,
+      taskWorktreeService: createDirectMergeTaskWorktreeService("/worktrees/repo/task-1"),
+      workspaceSettingsService,
+    });
+
+    const result = await Effect.runPromise(
+      service.detectPullRequest({ repoPath: "/repo", taskId: "task-1" }),
+    );
+
+    expect(result).toEqual({
+      outcome: "linked",
+      pullRequest: linkedPullRequest("gitlab"),
+    });
+    expect(findOpenForSourceBranch).toHaveBeenCalledWith({
+      repoConfig: expect.objectContaining({ repoPath: "/repo" }),
+      sourceBranch: "odt/task-42",
+    });
+  });
+
+  test("links a Pull Request through the configured provider port", async () => {
+    const getByNumber = mock(() => Effect.succeed(resolvedPullRequest("gitlab")));
+    const pullRequests = createPullRequestPort("gitlab", { getByNumber });
+    const provider = createProvider(gitlabDescriptor, pullRequests);
+    const gitProviderResolver = Effect.runSync(createGitProviderResolver([provider]));
+    const setPullRequest = mock(() => Effect.succeed(true));
+    const taskStore: TaskStorePort = {
+      getTask: () => Effect.succeed(task({ status: "human_review" })),
+      getTaskMetadata: () =>
+        Effect.succeed({
+          spec: { markdown: "# Spec" },
+          plan: { markdown: "# Plan" },
+          agentSessions: [],
+        }),
+      setPullRequest,
+    };
+    const service = createTaskService({
+      gitProviderResolver,
+      taskStore,
+      workspaceSettingsService,
+    });
+
+    const result = await Effect.runPromise(
+      service.linkPullRequest({
+        repoPath: "/repo",
+        taskId: "task-1",
+        providerId: "gitlab",
+        number: 42,
+      }),
+    );
+
+    expect(result).toEqual(linkedPullRequest("gitlab"));
+    expect(getByNumber).toHaveBeenCalledWith({
+      repoConfig: expect.objectContaining({ repoPath: "/repo" }),
+      number: 42,
+    });
+    expect(setPullRequest).toHaveBeenCalledWith({
+      repoPath: "/repo",
+      taskId: "task-1",
+      pullRequest: linkedPullRequest("gitlab"),
+    });
+  });
+
+  test("rejects a Pull Request returned with a foreign provider identity", async () => {
+    const getByNumber = mock(() => Effect.succeed(resolvedPullRequest("github")));
+    const pullRequests = createPullRequestPort("gitlab", { getByNumber });
+    const provider = createProvider(gitlabDescriptor, pullRequests);
+    const gitProviderResolver = Effect.runSync(createGitProviderResolver([provider]));
+    const setPullRequest = mock(() => Effect.succeed(true));
+    const service = createTaskService({
+      gitProviderResolver,
+      taskStore: {
+        getTask: () => Effect.succeed(task({ status: "human_review" })),
+        getTaskMetadata: () =>
+          Effect.succeed({
+            spec: { markdown: "# Spec" },
+            plan: { markdown: "# Plan" },
+            agentSessions: [],
+          }),
+        setPullRequest,
+      },
+      workspaceSettingsService,
+    });
+
+    const failure = await Effect.runPromise(
+      service
+        .linkPullRequest({
+          repoPath: "/repo",
+          taskId: "task-1",
+          providerId: "gitlab",
+          number: 42,
+        })
+        .pipe(Effect.flip),
+    );
+
+    expect(failure).toMatchObject({
+      _tag: "HostValidationError",
+      field: "pullRequest.providerId",
+    });
+    expect(setPullRequest).not.toHaveBeenCalled();
+  });
+
+  test("rejects a linked Pull Request from a provider other than the configured provider", async () => {
+    const refresh = mock(() => Effect.succeed(resolvedPullRequest("github")));
+    const pullRequests = createPullRequestPort("gitlab", { refresh });
+    const provider = createProvider(gitlabDescriptor, pullRequests);
+    const gitProviderResolver = Effect.runSync(createGitProviderResolver([provider]));
+    const taskStore: TaskStorePort = {
+      listPullRequestSyncCandidates: () =>
+        Effect.succeed([
+          {
+            ...task({ status: "human_review" }),
+            pullRequest: linkedPullRequest("github"),
+          },
+        ]),
+    };
+    const service = createTaskService({
+      gitProviderResolver,
+      taskStore,
+      workspaceSettingsService,
+    });
+
+    const failure = await Effect.runPromise(
+      service.repoPullRequestSyncDetailed({ repoPath: "/repo" }).pipe(Effect.flip),
+    );
+
+    expect(failure).toMatchObject({
+      _tag: "HostValidationError",
+      field: "pullRequest.providerId",
+    });
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  test("uses the provider port to resolve the publish remote and upsert", async () => {
+    const calls: unknown[] = [];
+    const resolvePublishRemote = mock(() => Effect.succeed("publish"));
+    const upsert = mock(() => Effect.succeed(linkedPullRequest("gitlab")));
+    const pullRequests = createPullRequestPort("gitlab", {
+      resolvePublishRemote,
+      upsert,
+    });
+    const provider = createProvider(gitlabDescriptor, pullRequests);
+    const gitProviderResolver = Effect.runSync(createGitProviderResolver([provider]));
+    const taskStore: TaskStorePort = {
+      getTask: () => Effect.succeed(task({ status: "human_review" })),
+      getTaskMetadata: () =>
+        Effect.succeed({
+          spec: { markdown: "# Spec" },
+          plan: { markdown: "# Plan" },
+          agentSessions: [],
+        }),
+      setPullRequest: () => Effect.succeed(true),
+    };
+    const gitPort = extendGitPort(
+      createDirectMergeGitPort({
+        calls,
+        currentBranches: {
+          "/worktrees/repo/task-1": { name: "odt/task-42", detached: false },
+        },
+      }),
+      {
+        getWorktreeStatusSummaryData: () =>
+          Effect.succeed({
+            currentBranch: { name: "odt/task-42", detached: false },
+            fileStatuses: [],
+            fileStatusCounts: { total: 0, staged: 0, unstaged: 0 },
+            targetAheadBehind: { ahead: 1, behind: 0 },
+            upstreamAheadBehind: { outcome: "untracked", ahead: 1 },
+          }),
+        suggestedSquashCommitMessage: () => Effect.succeed("Task 42"),
+        pushBranch: (workingDirectory, branch, options) =>
+          Effect.sync(() => {
+            calls.push({ type: "pushBranch", workingDirectory, branch, options });
+            return { outcome: "pushed", remote: "publish", branch, output: "pushed" };
+          }),
+      },
+    );
+    const service = createTaskService({
+      gitPort,
+      gitProviderResolver,
+      settingsConfig: createBuildSettingsConfig(new Set(["/repo"])),
+      taskStore,
+      taskWorktreeService: createDirectMergeTaskWorktreeService("/worktrees/repo/task-1"),
+      workspaceSettingsService,
+    });
+
+    await Effect.runPromise(
+      service.upsertPullRequest({
+        repoPath: "/repo",
+        taskId: "task-1",
+        content: { title: "Task 42", body: "Task body" },
+      }),
+    );
+
+    expect(resolvePublishRemote).toHaveBeenCalledWith({
+      repoConfig: expect.objectContaining({ repoPath: "/repo" }),
+    });
+    expect(calls).toContainEqual({
+      type: "pushBranch",
+      workingDirectory: "/worktrees/repo/task-1",
+      branch: "odt/task-42",
+      options: { remote: "publish", setUpstream: true, forceWithLease: false },
+    });
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoConfig: expect.objectContaining({ repoPath: "/repo" }),
+        title: "Task 42",
+        body: "Task body",
+      }),
+    );
+  });
+
+  test("rejects a detected merged Pull Request from another provider", async () => {
+    const pullRequests = createPullRequestPort("gitlab");
+    const provider = createProvider(gitlabDescriptor, pullRequests);
+    const gitProviderResolver = Effect.runSync(createGitProviderResolver([provider]));
+    const taskStore: TaskStorePort = {
+      listTasks: () => Effect.succeed([task({ status: "human_review" })]),
+      getTaskMetadata: () =>
+        Effect.succeed({
+          spec: { markdown: "# Spec" },
+          plan: { markdown: "# Plan" },
+          agentSessions: [],
+        }),
+    };
+    const service = createTaskService({
+      devServerService: createDirectMergeDevServerService([]),
+      gitPort: createDirectMergeGitPort({ calls: [] }),
+      gitProviderResolver,
+      settingsConfig: createBuildSettingsConfig(new Set(["/repo"])),
+      taskStore,
+      taskWorktreeService: createDirectMergeTaskWorktreeService("/worktrees/repo/task-1"),
+      workspaceSettingsService,
+    });
+
+    const failure = await Effect.runPromise(
+      service
+        .linkMergedPullRequest({
+          repoPath: "/repo",
+          taskId: "task-1",
+          pullRequest: mergedPullRequest("github"),
+        })
+        .pipe(Effect.flip),
+    );
+
+    expect(failure).toMatchObject({
+      _tag: "HostValidationError",
+      field: "pullRequest.providerId",
+    });
+  });
+});

--- a/packages/host/src/application/tasks/task-service-pull-requests.test.ts
+++ b/packages/host/src/application/tasks/task-service-pull-requests.test.ts
@@ -5,7 +5,6 @@ import { createToolDiscoveryAdapter } from "../../adapters/system/tool-discovery
 import { TaskPolicyError } from "../../domain/task";
 import { HostOperationError } from "../../effect/host-errors";
 import type { GitPort } from "../../ports/git-port";
-import { GitProviderRepositoryError } from "../../ports/git-provider-errors";
 import type { SystemCommandPort } from "../../ports/system-command-port";
 import { createGitProviderResolver } from "../git/git-provider-resolver";
 import { TaskMutationProgressFailure } from "./task-mutation-progress-failure";
@@ -327,76 +326,6 @@ describe("createTaskService pull requests", () => {
     if (!(error instanceof TaskPolicyError)) throw error;
     expect(error.code).toBe("TASK_POLICY_ERROR");
   });
-  test.each([
-    ["detect", "no_matching_remote", []],
-    ["detect", "ambiguous_matching_remotes", ["origin", "upstream"]],
-    ["link", "no_matching_remote", []],
-    ["link", "ambiguous_matching_remotes", ["origin", "upstream"]],
-  ] as const)(
-    "%s pull request preserves the real provider repository error for %s",
-    async (operation, reason, remoteNames) => {
-      const calls: unknown[] = [];
-      const matchingRemotes = remoteNames.map((name) => ({
-        name,
-        url: "git@github.com:openai/openducktor.git",
-      }));
-      const gitPort = extendGitPort(
-        createDirectMergeGitPort({
-          calls,
-          currentBranches: {
-            "/worktrees/repo/task-1": { name: "odt/task-1", detached: false },
-          },
-        }),
-        { listRemotes: () => Effect.succeed(matchingRemotes) },
-      );
-      const systemCommands = createPullRequestDetectSystemCommands({
-        calls,
-        openPayload: githubPullListPayload([]),
-      });
-      const providerDependencies = await createGithubTaskDependencies(gitPort, systemCommands);
-      const service = createTaskService({
-        ...providerDependencies,
-        taskStore: {
-          getTask: () => Effect.succeed(task({ status: "human_review" })),
-          getTaskMetadata: () =>
-            Effect.succeed({
-              spec: { markdown: "# Spec" },
-              plan: { markdown: "# Plan" },
-              agentSessions: [],
-            }),
-        },
-        taskWorktreeService: createDirectMergeTaskWorktreeService("/worktrees/repo/task-1"),
-        workspaceSettingsService: createBuildWorkspaceSettingsService({
-          workspaceId: "repo",
-          repoPath: "/repo",
-          hooks: { preStart: [], postComplete: [] },
-          git: {
-            provider: {
-              id: "github",
-              enabled: true,
-              repository: { host: "github.com", owner: "openai", name: "openducktor" },
-              autoDetected: false,
-            },
-          },
-        }),
-      });
-
-      const taskInput = { repoPath: "/repo", taskId: "task-1" };
-      const error =
-        operation === "detect"
-          ? await Effect.runPromise(Effect.flip(service.detectPullRequest(taskInput)))
-          : await Effect.runPromise(
-              Effect.flip(
-                service.linkPullRequest({ ...taskInput, providerId: "github", number: 42 }),
-              ),
-            );
-
-      expect(error).toBeInstanceOf(GitProviderRepositoryError);
-      if (!(error instanceof GitProviderRepositoryError)) throw error;
-      expect(error.reason).toBe(reason);
-      expect(error.remoteNames).toEqual(remoteNames);
-    },
-  );
   test("links a pull request by number after fetching provider metadata", async () => {
     const calls: unknown[] = [];
     const taskStore: TaskStorePort = {

--- a/packages/host/src/application/tasks/use-cases/detect-pull-request.ts
+++ b/packages/host/src/application/tasks/use-cases/detect-pull-request.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import { HostValidationError } from "../../../effect/host-errors";
+import { requirePullRequestProviderMatch } from "../../pull-requests/pull-request-provider-match";
 import {
   requireDependencies,
   requirePullRequestDetectionDependencies,
@@ -60,12 +61,15 @@ export const createTaskPullRequestDetectionUseCase = ({
       );
       const provider = yield* dependencies.gitProviderResolver.resolve(repoConfig);
       const pullRequests = yield* provider.pullRequests();
-      const openPullRequest = yield* pullRequests.findByBranch({
+      const openPullRequest = yield* pullRequests.findOpenForSourceBranch({
         repoConfig,
         sourceBranch: taskContext.sourceBranch,
-        state: "open",
       });
       if (openPullRequest !== undefined) {
+        yield* requirePullRequestProviderMatch({
+          configuredProviderId: provider.getDescriptor().id,
+          linkedProviderId: openPullRequest.record.providerId,
+        });
         yield* taskStore.setPullRequest({
           repoPath: effectiveRepoPath,
           taskId,
@@ -77,12 +81,11 @@ export const createTaskPullRequestDetectionUseCase = ({
         };
       }
 
-      const pullRequest = yield* pullRequests.findByBranch({
+      const pullRequest = yield* pullRequests.findLatestMergedForSourceBranch({
         repoConfig,
         sourceBranch: taskContext.sourceBranch,
-        state: "all",
       });
-      if (pullRequest?.record.state === "merged") {
+      if (pullRequest !== undefined) {
         return {
           outcome: "merged",
           pullRequest: pullRequest.record,

--- a/packages/host/src/application/tasks/use-cases/detect-pull-request.ts
+++ b/packages/host/src/application/tasks/use-cases/detect-pull-request.ts
@@ -86,6 +86,10 @@ export const createTaskPullRequestDetectionUseCase = ({
         sourceBranch: taskContext.sourceBranch,
       });
       if (pullRequest !== undefined) {
+        yield* requirePullRequestProviderMatch({
+          configuredProviderId: provider.getDescriptor().id,
+          linkedProviderId: pullRequest.record.providerId,
+        });
         return {
           outcome: "merged",
           pullRequest: pullRequest.record,

--- a/packages/host/src/application/tasks/use-cases/direct-merge.ts
+++ b/packages/host/src/application/tasks/use-cases/direct-merge.ts
@@ -21,7 +21,6 @@ import type { CreateTaskServiceInput, TaskService } from "../task-service";
 export const createTaskDirectMergeUseCase = ({
   devServerService,
   gitPort,
-  gitProviderResolver,
   taskStore,
   settingsConfig,
   taskSessionBootstrapCoordinator,
@@ -38,7 +37,6 @@ export const createTaskDirectMergeUseCase = ({
         requireDirectMergeDependencies({
           devServerService,
           gitPort,
-          gitProviderResolver,
           settingsConfig,
           taskWorktreeService,
           terminalService,

--- a/packages/host/src/application/tasks/use-cases/link-merged-pull-request.ts
+++ b/packages/host/src/application/tasks/use-cases/link-merged-pull-request.ts
@@ -5,6 +5,7 @@ import { requirePullRequestProviderMatch } from "../../pull-requests/pull-reques
 import {
   requireDependencies,
   requireLinkMergedPullRequestDependencies,
+  requirePullRequestLinkDependencies,
 } from "../support/required-task-dependencies";
 import { createTaskCleanupProgressState } from "../support/task-cleanup-progress";
 import { runTaskRuntimeCleanup } from "../support/task-cleanup-support";
@@ -49,6 +50,27 @@ export const createTaskLinkMergedPullRequestUseCase = ({
         metadata.pullRequest?.providerId === pullRequest.providerId &&
         metadata.pullRequest.number === pullRequest.number &&
         metadata.pullRequest.state === "merged";
+
+      const providerDependencies = yield* requireDependencies(() =>
+        requirePullRequestLinkDependencies({
+          gitProviderResolver,
+          workspaceSettingsService,
+        }),
+      );
+      const repoConfig =
+        yield* providerDependencies.workspaceSettingsService.getRepoConfigByRepoPath(repoPath);
+      const provider = yield* providerDependencies.gitProviderResolver.resolve(repoConfig);
+      const configuredProviderId = provider.getDescriptor().id;
+      yield* requirePullRequestProviderMatch({
+        configuredProviderId,
+        linkedProviderId: pullRequest.providerId,
+      });
+      if (metadata.pullRequest !== undefined) {
+        yield* requirePullRequestProviderMatch({
+          configuredProviderId,
+          linkedProviderId: metadata.pullRequest.providerId,
+        });
+      }
       if (current.status === "closed" && sameExistingPullRequest) {
         return enrichTask(current, currentTasks);
       }
@@ -65,13 +87,6 @@ export const createTaskLinkMergedPullRequestUseCase = ({
           workspaceSettingsService,
         }),
       );
-      const repoConfig =
-        yield* dependencies.workspaceSettingsService.getRepoConfigByRepoPath(repoPath);
-      const provider = yield* dependencies.gitProviderResolver.resolve(repoConfig);
-      yield* requirePullRequestProviderMatch({
-        configuredProviderId: provider.getDescriptor().id,
-        linkedProviderId: pullRequest.providerId,
-      });
       yield* validatePullRequestManagementStatusEffect(current.status);
       if (metadata.directMerge !== undefined) {
         return yield* Effect.fail(

--- a/packages/host/src/application/tasks/use-cases/link-merged-pull-request.ts
+++ b/packages/host/src/application/tasks/use-cases/link-merged-pull-request.ts
@@ -79,7 +79,6 @@ export const createTaskLinkMergedPullRequestUseCase = ({
         requireLinkMergedPullRequestDependencies({
           devServerService,
           gitPort,
-          gitProviderResolver,
           settingsConfig,
           taskWorktreeService,
           terminalService,

--- a/packages/host/src/application/tasks/use-cases/link-merged-pull-request.ts
+++ b/packages/host/src/application/tasks/use-cases/link-merged-pull-request.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect";
 import { errorMessage, HostValidationError } from "../../../effect/host-errors";
 import { requireWorktreeFiles } from "../../git/git-service-inputs";
+import { requirePullRequestProviderMatch } from "../../pull-requests/pull-request-provider-match";
 import {
   requireDependencies,
   requireLinkMergedPullRequestDependencies,
@@ -29,6 +30,7 @@ type TaskBranchCleanup = {
 export const createTaskLinkMergedPullRequestUseCase = ({
   devServerService,
   gitPort,
+  gitProviderResolver,
   taskStore,
   settingsConfig,
   taskSessionBootstrapCoordinator,
@@ -52,16 +54,24 @@ export const createTaskLinkMergedPullRequestUseCase = ({
       }
 
       const dependencies = yield* requireDependencies(() =>
-        requireLinkMergedPullRequestDependencies(
+        requireLinkMergedPullRequestDependencies({
           devServerService,
           gitPort,
+          gitProviderResolver,
           settingsConfig,
           taskWorktreeService,
           terminalService,
           worktreeFiles,
           workspaceSettingsService,
-        ),
+        }),
       );
+      const repoConfig =
+        yield* dependencies.workspaceSettingsService.getRepoConfigByRepoPath(repoPath);
+      const provider = yield* dependencies.gitProviderResolver.resolve(repoConfig);
+      yield* requirePullRequestProviderMatch({
+        configuredProviderId: provider.getDescriptor().id,
+        linkedProviderId: pullRequest.providerId,
+      });
       yield* validatePullRequestManagementStatusEffect(current.status);
       if (metadata.directMerge !== undefined) {
         return yield* Effect.fail(

--- a/packages/host/src/application/tasks/use-cases/manage-pull-requests.ts
+++ b/packages/host/src/application/tasks/use-cases/manage-pull-requests.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect";
 import { ensureCleanTaskWorktree } from "../../../domain/task";
 import { HostValidationError } from "../../../effect/host-errors";
+import { requirePullRequestProviderMatch } from "../../pull-requests/pull-request-provider-match";
 import { loadOpenApprovalContext } from "../support/approval-readiness";
 import {
   requireDependencies,
@@ -55,18 +56,17 @@ export const createTaskPullRequestManagementUseCases = ({
       const effectiveRepoPath = repoConfig.repoPath;
       const provider = yield* dependencies.gitProviderResolver.resolve(repoConfig);
       const selectedProviderId = provider.getDescriptor().id;
-      if (providerId !== selectedProviderId) {
-        return yield* Effect.fail(
-          new HostValidationError({
-            field: "providerId",
-            message: `Pull request provider '${providerId}' does not match configured provider '${selectedProviderId}'.`,
-            details: { providerId, selectedProviderId },
-          }),
-        );
-      }
-      yield* provider.repository().getMapping(repoConfig);
+      yield* requirePullRequestProviderMatch({
+        configuredProviderId: selectedProviderId,
+        linkedProviderId: providerId,
+        field: "providerId",
+      });
       const pullRequests = yield* provider.pullRequests();
       const pullRequest = yield* pullRequests.getByNumber({ repoConfig, number });
+      yield* requirePullRequestProviderMatch({
+        configuredProviderId: selectedProviderId,
+        linkedProviderId: pullRequest.record.providerId,
+      });
       yield* taskStore.setPullRequest({
         repoPath: effectiveRepoPath,
         taskId,
@@ -126,13 +126,19 @@ export const createTaskPullRequestManagementUseCases = ({
         );
       }
       const provider = yield* dependencies.gitProviderResolver.resolve(repoConfig);
-      const context = yield* provider.repository().getMapping(repoConfig);
       const pullRequests = yield* provider.pullRequests();
+      if (approval.pullRequest !== undefined) {
+        yield* requirePullRequestProviderMatch({
+          configuredProviderId: provider.getDescriptor().id,
+          linkedProviderId: approval.pullRequest.providerId,
+        });
+      }
+      const remote = yield* pullRequests.resolvePublishRemote({ repoConfig });
       const pushResult = yield* dependencies.gitPort.pushBranch(
         approval.workingDirectory,
         approval.sourceBranch,
         {
-          remote: context.remoteName,
+          remote,
           setUpstream: true,
           forceWithLease: false,
         },
@@ -151,6 +157,10 @@ export const createTaskPullRequestManagementUseCases = ({
         approval,
         title: content.title,
         body: content.body,
+      });
+      yield* requirePullRequestProviderMatch({
+        configuredProviderId: provider.getDescriptor().id,
+        linkedProviderId: pullRequest.providerId,
       });
       yield* taskStore.setPullRequest({ repoPath: effectiveRepoPath, taskId, pullRequest });
       return pullRequest;

--- a/packages/host/src/application/tasks/use-cases/sync-pull-requests.ts
+++ b/packages/host/src/application/tasks/use-cases/sync-pull-requests.ts
@@ -1,5 +1,6 @@
 import type { PullRequest } from "@openducktor/contracts";
 import { Effect } from "effect";
+import { requirePullRequestProviderMatch } from "../../pull-requests/pull-request-provider-match";
 import {
   requireDependencies,
   requireMergedTaskCleanupDependencies,
@@ -66,12 +67,17 @@ export const createTaskPullRequestSyncUseCases = ({
             continue;
           }
 
-          if (pullRequest.providerId !== providerId) {
-            continue;
-          }
-          const updated = yield* pullRequests.getByNumber({
+          yield* requirePullRequestProviderMatch({
+            configuredProviderId: providerId,
+            linkedProviderId: pullRequest.providerId,
+          });
+          const updated = yield* pullRequests.refresh({
             repoConfig,
-            number: pullRequest.number,
+            linkedPullRequest: pullRequest,
+          });
+          yield* requirePullRequestProviderMatch({
+            configuredProviderId: providerId,
+            linkedProviderId: updated.record.providerId,
           });
 
           if (updated.record.state === "merged" && task.status !== "closed") {

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -120,12 +120,12 @@ export {
   GitProviderResolutionError,
 } from "./ports/git-provider-errors";
 export type {
-  FindPullRequestForSourceBranchInput,
   GetPullRequestByNumberInput,
   GitProviderHealthPort,
   GitProviderPort,
   GitProviderRepositoryMapping,
   GitProviderRepositoryPort,
+  PullRequestBranchInput,
   PullRequestProviderInput,
   PullRequestProviderPort,
   RefreshPullRequestInput,

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -120,7 +120,7 @@ export {
   GitProviderResolutionError,
 } from "./ports/git-provider-errors";
 export type {
-  FindPullRequestByBranchInput,
+  FindPullRequestForSourceBranchInput,
   GetPullRequestByNumberInput,
   GitProviderHealthPort,
   GitProviderPort,
@@ -128,6 +128,7 @@ export type {
   GitProviderRepositoryPort,
   PullRequestProviderInput,
   PullRequestProviderPort,
+  RefreshPullRequestInput,
   UpsertPullRequestInput,
 } from "./ports/git-provider-port";
 export type { LocalAttachmentPort } from "./ports/local-attachment-port";

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -128,6 +128,7 @@ export type {
   PullRequestBranchInput,
   PullRequestProviderInput,
   PullRequestProviderPort,
+  ProviderPullRequest,
   RefreshPullRequestInput,
   UpsertPullRequestInput,
 } from "./ports/git-provider-port";

--- a/packages/host/src/ports/git-provider-port.ts
+++ b/packages/host/src/ports/git-provider-port.ts
@@ -1,6 +1,7 @@
 import type {
   GitProviderDescriptor,
   GitProviderHealth,
+  GitProviderId,
   GitProviderRepository,
   PullRequest,
   RepoConfig,
@@ -42,9 +43,8 @@ export type ProviderPullRequest = {
   targetBranch: string;
 };
 
-export type FindPullRequestByBranchInput = PullRequestProviderInput & {
+export type FindPullRequestForSourceBranchInput = PullRequestProviderInput & {
   sourceBranch: string;
-  state: "open" | "all";
 };
 
 export type GetPullRequestByNumberInput = PullRequestProviderInput & {
@@ -57,13 +57,27 @@ export type UpsertPullRequestInput = PullRequestProviderInput & {
   body: string;
 };
 
+export type RefreshPullRequestInput = PullRequestProviderInput & {
+  linkedPullRequest: PullRequest;
+};
+
 export type PullRequestProviderPort = {
-  findByBranch(
-    input: FindPullRequestByBranchInput,
+  providerId: GitProviderId;
+  findOpenForSourceBranch(
+    input: FindPullRequestForSourceBranchInput,
+  ): Effect.Effect<ProviderPullRequest | undefined, HostError | GitProviderRepositoryError>;
+  findLatestMergedForSourceBranch(
+    input: FindPullRequestForSourceBranchInput,
   ): Effect.Effect<ProviderPullRequest | undefined, HostError | GitProviderRepositoryError>;
   getByNumber(
     input: GetPullRequestByNumberInput,
   ): Effect.Effect<ProviderPullRequest, HostError | GitProviderRepositoryError>;
+  refresh(
+    input: RefreshPullRequestInput,
+  ): Effect.Effect<ProviderPullRequest, HostError | GitProviderRepositoryError>;
+  resolvePublishRemote(
+    input: PullRequestProviderInput,
+  ): Effect.Effect<string, HostError | GitProviderRepositoryError>;
   upsert(
     input: UpsertPullRequestInput,
   ): Effect.Effect<PullRequest, HostError | GitProviderRepositoryError>;

--- a/packages/host/src/ports/git-provider-port.ts
+++ b/packages/host/src/ports/git-provider-port.ts
@@ -43,7 +43,7 @@ export type ProviderPullRequest = {
   targetBranch: string;
 };
 
-export type FindPullRequestForSourceBranchInput = PullRequestProviderInput & {
+export type PullRequestBranchInput = PullRequestProviderInput & {
   sourceBranch: string;
 };
 
@@ -64,10 +64,10 @@ export type RefreshPullRequestInput = PullRequestProviderInput & {
 export type PullRequestProviderPort = {
   providerId: GitProviderId;
   findOpenForSourceBranch(
-    input: FindPullRequestForSourceBranchInput,
+    input: PullRequestBranchInput,
   ): Effect.Effect<ProviderPullRequest | undefined, HostError | GitProviderRepositoryError>;
   findLatestMergedForSourceBranch(
-    input: FindPullRequestForSourceBranchInput,
+    input: PullRequestBranchInput,
   ): Effect.Effect<ProviderPullRequest | undefined, HostError | GitProviderRepositoryError>;
   getByNumber(
     input: GetPullRequestByNumberInput,


### PR DESCRIPTION
## Summary

- Move Pull Request lifecycle and review work behind provider-neutral capability ports.
- Keep GitHub API and CLI details in the GitHub adapter.
- Check the configured local remote before detection, linking, create, and update work.
- Fetch every Pull Request list page before choosing the latest merged Pull Request.
- Keep frontend migration and new providers out of scope.

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [x] `bun run deps:check`

## Checklist

- [x] No docs change was needed because public workflows and contracts stay the same.
- [x] I added or updated relevant tests.
- [x] I kept failures explicit instead of adding fallback logic.
- [x] I linked related context below.

## Related Issues

OpenDucktor task `openduckto-5326`.

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes are described below

## Additional Context

The dependency check began rejecting `fast-uri` versions below 3.1.6. The lockfile now uses 3.1.7. The updated branch passes all hosted Linux, macOS, Windows, dependency, and React checks.