### PR TITLE
docs: make project guidance clear for people and agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 OpenDucktor is a Bun monorepo. It contains an Electron desktop app and a local browser runner for AI planning and build workflows. A workspace-scoped SQLite task store is the source of truth for tasks.
 
-Use Bun and `bun run`. Do not use npm or Yarn.
+Use Bun and `bun run` for dependency installation and workspace commands. Use npm only in Trusted Publisher workflows that run `npm publish`. Do not use Yarn.
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) for setup and command details.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,226 +2,196 @@
 
 ## Project
 
-OpenDucktor is a **Bun monorepo** for an **Electron** desktop app and local browser runner that orchestrate AI planning/building workflows with a workspace-scoped **SQLite task store** as task source-of-truth.
+OpenDucktor is a Bun monorepo. It has an Electron desktop app and a local browser runner. Both run AI planning and build workflows. A workspace-scoped SQLite task store is the source of truth for tasks.
 
-Package manager: **Bun** (not npm/yarn). All workspace commands use `bun run`.
+Use Bun. Run workspace commands with `bun run`. Do not use npm or Yarn.
 
-## Critical Notice — No Fallbacks
+## Work rules
 
-- NEVER implement fallback logic to mask failures.
-- Fix root causes at the source layer where the failure originates.
-- If a call fails, return/propagate an actionable error instead of silent defaults.
-- Do not add secondary probes or alternate paths to hide broken primary behavior.
-- Do not add polling/retry loops for data that should arrive through an existing live event stream or subscription; fix the event/stream contract instead.
+- Fix a failure at the source that caused it. Return an error that tells the user what to do.
+- Keep the main path direct. Do not add a fallback, second probe, silent default, or retry that hides a failed contract.
+- Use an existing event stream or subscription for live data. Fix that contract instead of adding a polling loop.
+- Keep the code simple. Add normalization or extra checks only when a known case needs them.
+- Inspect runtime source or an official contract before you change an adapter that depends on runtime behavior.
+- Ask for human approval before you change a database schema, migration, persisted record schema, or durable SQLite task-store shape.
 
-## Critical Notice — Keep it simple
+## Code map
 
-- ALWAYS try to keep the code simple
-- AVOID "normalization" unless it's absolutely necessary
-- NEVER harden code without a good reason
-
-## Critical Notice — Runtime Source Evidence
-
-- When behavior depends on external runtime internals, inspect the runtime source or official contract before designing or changing adapters.
-- Never infer runtime behavior from memory, adapter shape, or assumptions when source evidence is available.
-
-## Critical Notice — Human Validation for Database Schema
-
-- NEVER change database schemas, migration files, persisted record schemas, or durable SQLite/task-store record shapes without explicit human validation.
-- If a fix appears to require persisting new data or changing durable storage shape, stop and ask for approval first.
-
-### Monorepo Map
-
-- `apps/electron`: Electron desktop shell, renderer bootstrap, preload bridge, packaging, and IPC transport.
-- `packages/frontend`: Shared React + Vite UI.
-- `packages/contracts`: Shared runtime schemas and IPC contracts (TS).
-- `packages/core`: Core domain services and ports.
-- `packages/host`: Effect-native TypeScript host for Electron/web transports, command routing, application use cases, and infrastructure adapters.
-- `packages/adapters-opencode-sdk`: `AgentEnginePort` adapter.
-- `packages/host-client`: Frontend IPC adapter.
-- `packages/openducktor-mcp`: MCP server exposing `odt_*` workflow tools.
+- `apps/electron` contains the Electron shell, renderer startup, preload bridge, packaging, and IPC transport.
+- `packages/frontend` contains the shared React and Vite UI.
+- `packages/contracts` contains shared runtime schemas and IPC contracts.
+- `packages/core` contains domain services and ports.
+- `packages/host` contains the Effect-native TypeScript host, command routing, use cases, and infrastructure adapters.
+- `packages/adapters-opencode-sdk` implements `AgentEnginePort` for OpenCode.
+- `packages/host-client` adapts host IPC for the frontend.
+- `packages/openducktor-mcp` exposes the `odt_*` workflow tools.
 
 ## Architecture
 
-### Hexagonal rules
+- Define ports in core or domain code. Put adapters in infrastructure code.
+- Use an existing contract instead of coupling UI code to infrastructure code.
+- Change `packages/contracts` before you change host or frontend code that uses a data contract.
 
-- Port definitions live in core/domain layers, adapters in infra layers.
-- Do not couple UI code directly to infra when contracts exist.
-- When changing data contracts, update `packages/contracts` first, then adapt host/frontend.
+### Effect in the host
 
-### Effect adoption rules
+Read [docs/effect.md](docs/effect.md) before you change a host port, service, adapter, lifecycle, or typed error.
 
-- `packages/host` is Effect-native internally. Fallible or I/O-producing host ports and application services should return `Effect.Effect<Success, Failure, Requirements>`, not raw `Promise`.
-- Keep Promise interop at explicit transport boundaries only: Electron IPC, browser HTTP/SSE, shell bridge adapters, and external package APIs that must remain Promise-compatible.
-- Expected host failures should use typed errors, preferably `Data.TaggedError`, and be propagated through the Effect error channel. Do not use generic `throw new Error(...)` for expected host failures.
-- Use `Effect.gen` for readable sequencing, `Context.Tag`/`Layer` for host dependency wiring when it clarifies composition, and `Effect.try`/`Effect.tryPromise` only to wrap synchronous or Promise-based external APIs at the boundary.
-- Do not use `catchAll`, retry, fallback, or defaulting to hide broken contracts. Retrying/polling must represent explicit product behavior and should use Effect scheduling primitives.
-- Pure domain policy code may stay synchronous when it has no I/O and no useful typed failure channel. Effect is the host execution model, not a mandate to wrap every expression.
-- `packages/contracts` remains the public Zod contract source until a separate schema ADR changes that. Do not duplicate public schemas in Effect Schema as a second source of truth.
-- TanStack Query remains the frontend cache/deduplication layer for server-owned reads. Effect may run behind host clients or query functions, but it must not introduce a competing frontend cache or request store.
+- A host port or service that performs I/O or can fail returns `Effect.Effect<Success, Failure, Requirements>`.
+- Keep Promise interop at Electron IPC, browser HTTP/SSE, shell bridges, and external APIs that require Promise values.
+- Model expected failures as typed errors. Prefer `Data.TaggedError`. Do not use `throw new Error(...)` for an expected host failure.
+- Use `Effect.gen` for steps. Use `Context.Tag` and `Layer` when they make dependency wiring clear. Use `Effect.try` and `Effect.tryPromise` at external boundaries.
+- Use `catchAll`, retry, fallback, or a default only when the product contract calls for that behavior. Use Effect schedules for an explicit retry or polling policy.
+- Keep pure policy code synchronous when it has no I/O and no useful typed failure channel.
+- Keep public Zod schemas in `packages/contracts`. Do not create a second public schema source with Effect Schema.
+- TanStack Query owns the frontend cache for server-owned reads. Effect code must not add another cache for the same data.
 
-### Replaceable boundaries
+### Runtime boundaries
 
-- TS port: `AgentEnginePort` in `packages/core/src/ports/agent-engine.ts`
+- Treat runtime definitions, runtime routes, and runtime connections as separate layers.
+- Keep shared host-visible runtime and run payloads in `packages/contracts/src/run-schemas.ts`.
+- Keep `RuntimeInstanceSummary` limited to `kind`, `runtimeId`, `repoPath`, nullable `taskId`, `role`, `workingDirectory`, `runtimeRoute`, `startedAt`, and `descriptor`. Do not add top-level `endpoint`, `port`, or duplicate `capabilities` fields.
+- Keep `runtimeId` and `runtimeRoute` in the runtime registry and adapters. UI and orchestration code carry `runtimeKind`, repository path, working directory, and session ID.
+- Pass `runtimeConnection` objects to request-scoped agent engine operations. Build adapter-specific client input at the adapter boundary.
+- Persist durable IDs and `workingDirectory`. Do not store `runtimeEndpoint`, `baseUrl`, `runtimeTransport`, or other live route data in session records or documents.
+- Resolve the route for the selected session or build. Do not fall back to the repository default runtime for history, todos, diff, or file status.
+- Define runtime capabilities in `packages/contracts/src/agent-runtime-schemas.ts`. Do not copy capability flags to runtime instance summaries.
 
-### Runtime abstraction rules
+## Frontend
 
-- Treat runtime definitions, runtime routes, and runtime connections as different layers.
-- Shared host-visible runtime/run payloads live in `packages/contracts/src/run-schemas.ts`.
-- `RuntimeInstanceSummary` is live runtime-instance metadata only: keep `kind`, `runtimeId`, `repoPath`, nullable `taskId`, `role`, `workingDirectory`, `runtimeRoute`, `startedAt`, and `descriptor`. Do not reintroduce top-level `endpoint`, `port`, or duplicate `capabilities` fields there.
-- Keep `runtimeId` and `runtimeRoute` at runtime-registry/adapter depth. UI and orchestration should carry `runtimeKind`, repository path, working directory, and session id.
-- Request-scoped agent engine operations use `runtimeConnection` objects, not raw shared `runtimeEndpoint` strings. Build adapter-local client inputs from the connection at the adapter boundary.
-- Persisted session records/documents must not store live runtime route data (`runtimeEndpoint`, `baseUrl`, `runtimeTransport`). Persist durable identifiers plus `workingDirectory`, then resolve a live route only at the adapter call boundary.
-- Keep runtime routing fail-fast. Never fall back from a session/build runtime to the repo default runtime when loading session history, todos, diff, or file status.
-- Keep runtime capability definitions in runtime descriptors (`packages/contracts/src/agent-runtime-schemas.ts`). Do not duplicate capability booleans onto runtime-instance summaries.
+- Wire state contexts in `packages/frontend/src/state/app-state-provider.tsx`.
+- Put domain operations in focused hooks under `packages/frontend/src/state/{lifecycle,operations,tasks}`.
+- Use operation-specific flags such as `isLoadingTasks` and `isLoadingChecks`.
+- Put shared types in `packages/frontend/src/types`. Put feature constants in `constants.ts`.
+- During an async form submission, disable the full form, show loading in the submit button, and keep error or success feedback visible.
+- Replace nested ternaries with named booleans, helper functions, lookup maps, or `if` statements.
+
+### TanStack Query
+
+Read [docs/tanstack-query-cache-strategy.md](docs/tanstack-query-cache-strategy.md) before you add or change a frontend read from the host or backend.
+
+- Use TanStack Query for server-owned data that can be reused, refreshed, invalidated, or deduplicated.
+- Define query keys and option builders in a focused module under `packages/frontend/src/state/queries`.
+- Use `useQuery`, `useQueries`, or `useSuspenseQuery` for backend data read during render.
+- Use `queryClient.fetchQuery`, `ensureQueryData`, `prefetchQuery`, or cache invalidation for an imperative read.
+- After a mutation, update or invalidate each cache entry that the mutation changed.
+- Derive UI state from query results. Copy data only when the copy is a user-editable draft.
+- Keep transient UI state, form drafts, modal state, live transcripts, tool output, and pending permission or question state outside TanStack Query.
+- Keep a provider API stable when only its read path must move to TanStack Query.
+
+### Theme and components
+
+The app uses shadcn semantic tokens with Tailwind CSS v4. It supports light and dark themes. Tokens are in `packages/frontend/src/styles.css`.
+
+| Purpose | Use | Do not use |
+|---|---|---|
+| Page background | `bg-background` | `bg-white`, `bg-slate-50` |
+| Card or surface | `bg-card` | `bg-white` |
+| Main text | `text-foreground` | `text-gray-900` |
+| Secondary text | `text-muted-foreground` | `text-gray-500` |
+| Layout border | `border-border` | `border-gray-200` |
+| Input border | `border-input` | `border-gray-300` |
+| Subtle surface | `bg-muted` | `bg-gray-100` |
+| Interactive accent | `bg-primary`, `text-primary-foreground` | `bg-sky-600` |
+| Destructive action | `bg-destructive`, `text-destructive` | `bg-red-500` |
+| Sidebar | `bg-sidebar`, `text-sidebar-foreground`, `border-sidebar-border` | Hardcoded colors |
+
+- Hardcoded colors may mark status, Kanban lane themes, or small badges and tags.
+- Use light status backgrounds and dark status text. Include dark-theme classes.
+- Do not use a gradient for a surface or component.
+- Apply semantic tokens with `className` at the use site. Do not change a base shadcn component to add hardcoded colors.
+- Use components from `packages/frontend/src/components/ui` when one exists.
+
+## Host and task store
+
+- Keep host command APIs typed and schema-validated.
+- Return actionable typed errors for expected host failures.
+- Keep blocking work off the UI thread.
+- Reuse known repository readiness. Do not repeat costly setup.
+- Treat the SQLite task store as the only source of truth for tasks.
+- Store only durable task and workflow state in task records.
+- Rebuild pending permissions, questions, runtime routes, transcripts, and tool streams from the live runtime, event stream, or runtime history. Do not persist them in the task store.
+- Find task actions in `packages/contracts/src/task-schemas.ts`. Read `docs/task-workflow-*.md` before you change a task state or action.
+
+## MCP and Agent Studio contract
+
+Change all affected layers together when you change this contract.
+
+| Part | Source |
+|---|---|
+| Server name | `openducktor` |
+| Tool schemas | `ODT_TOOL_SCHEMAS` in `packages/openducktor-mcp/src/lib.ts` |
+| Workflow tools | `odt_read_task`, `odt_read_task_assets`, `odt_read_task_documents`, `odt_set_spec`, `odt_set_plan`, `odt_build_blocked`, `odt_build_resumed`, `odt_build_completed`, `odt_set_pull_request`, `odt_qa_approved`, and `odt_qa_rejected` |
+| Role policy | `AGENT_ROLE_TOOL_POLICY` in `packages/core/src/types/agent-orchestrator.ts` |
+- All roles can call the three read tools. `spec` adds `odt_set_spec`. `planner` adds `odt_set_plan`. `build` adds `odt_build_*` and `odt_set_pull_request`. `qa` adds `odt_qa_*`.
+- Normalize tools in `packages/core/src/services/odt-workflow-tools.ts`.
+- Agent Studio starts in `packages/frontend/src/pages/agents/agents-page.tsx` and its `use-agent-studio-*.ts` hooks.
+- Runtime and session orchestration lives in `packages/frontend/src/state/operations/use-agent-orchestrator-operations.ts`.
+
+Do not rename an `odt_*` tool or change a role allowlist in one layer. Update MCP, core, adapters, host, and frontend code in the same change.
+
+## Tests
+
+- Add deep tests for changed non-frontend behavior in `packages/host`, `packages/core`, adapters, and MCP.
+- Add frontend tests for changed frontend behavior.
+- Keep production APIs, constructors, options, and exported types independent from test needs. Use a local fake, dependency injection, or a test helper around an existing boundary.
+- Prefer a direct function parameter or `spyOn` over `mock.module(...)`.
+
+### Bun module mocks
+
+- Mock the source module that owns an export. Do not mock a shared barrel such as `@/state`, `@/components`, or another `index.ts` file.
+- Match the exact import string used by production code. A mock for `./bar` does not replace `@/foo/bar`.
+- Scope `mock.module(...)` to the smallest test span. Bun can interleave files in one process, so a file-wide module mock can leak to another suite.
+- Restore the exact module ID by remocking it to a real module captured before the mock. You can instead load the real module through a path that was not mocked.
+- Do not use `mock.restore()` to clean up `mock.module(...)`. It acts on the whole process and can remove mocks from another test.
+
+### Test isolation
+
+- Give each TanStack Query test an isolated query client. Use `QueryProvider` with `useIsolatedClient`.
+- Add the smallest required context providers when a test uses an app-state hook such as `useWorkspaceState`. This rule also applies to `renderToStaticMarkup` tests.
+- Do not mutate `host`, a shared query client, an exported adapter, or another singleton when a local seam can replace it. If no local seam exists, restore the value in `finally` or `afterEach`.
+- Return new nested objects and arrays from each fixture. Do not share mutable nested data across tests.
+- Use a focused hook or module test for routing and orchestration rules. Use a broad page test only when the page integration is the behavior under test.
+
+### Async and flaky tests
+
+- Give async query, portal, and render waits an explicit timeout. Keep each wait shorter than the Bun test timeout.
+- Run flake checks in sequence. Parallel Bun runs can hide a shared-process leak or cause a false failure.
+
+### Browser validation
+
+Use `agent-browser` against the live app and real OpenDucktor backend for browser end-to-end checks. Ask the user to start `bun run browser:dev`. Do not start it yourself.
 
 ## Commands
 
-Run from repo root unless stated otherwise:
+Run these commands from the repository root.
 
 ```sh
-bun install                  # install deps
-bun run dev                  # frontend dev server
-bun run electron:dev         # Electron desktop dev server
-bun run browser:dev          # local browser runner
-bun run typecheck            # typecheck all workspaces
-bun run lint                 # lint all workspaces
-bun run test                 # test all workspaces
-bun run build                # build all workspaces
+bun install
+bun run dev
+bun run electron:dev
+bun run browser:dev
+bun run typecheck
+bun run lint
+bun run test
+bun run build
 ```
 
-Package-level targets for focused iteration:
+Run a focused workspace test with this form:
 
 ```sh
 bun run --filter @openducktor/frontend test
 ```
 
-## Styling & Theming (Critical)
+## Documentation
 
-The app uses **Shadcn semantic tokens** with **Tailwind CSS v4**. A dark theme exists. All styling must be theme-aware.
+- Write project prose in ASD-STE100 Simplified Technical English. Keep code, command names, paths, schema fields, and other exact technical terms unchanged.
+- Use sentence case for headings. Use one idea per sentence. Prefer active voice and short words.
+- Put each Markdown paragraph and list item on one physical line.
+- State facts, rules, steps, and completion checks. Remove sales language, filler, stock AI phrases, and vague claims.
+- Do not use em dashes, decorative emojis, or bold text as decoration.
+- Keep one source for each rule. Link to branch-specific details instead of copying them into this file.
 
-### Token system
+## Finish
 
-Tokens are CSS custom properties in `packages/frontend/src/styles.css` (`:root` light, `.dark` dark) mapped to Tailwind via `@theme inline`. **Always use semantic tokens:**
-
-| Purpose | Use | Never use |
-|---|---|---|
-| Page background | `bg-background` | `bg-white`, `bg-slate-50` |
-| Card/surface | `bg-card` | `bg-white` |
-| Text (primary) | `text-foreground` | `text-gray-900` |
-| Text (secondary) | `text-muted-foreground` | `text-gray-500` |
-| Borders (layout) | `border-border` | `border-gray-200` |
-| Borders (inputs) | `border-input` | `border-gray-300` |
-| Subtle surfaces | `bg-muted` | `bg-gray-100` |
-| Interactive accent | `bg-primary` / `text-primary-foreground` | `bg-sky-600` |
-| Destructive | `bg-destructive` / `text-destructive` | `bg-red-500` |
-| Sidebar | `bg-sidebar`, `text-sidebar-foreground`, `border-sidebar-border` | Hardcoded equivalents |
-
-### Hardcoded colors — only acceptable for
-
-- **Status indicators**: `bg-emerald-*` (success), `bg-sky-*` (info), `bg-amber-*` (warning), `bg-rose-*` (error).
-- **Kanban lane themes**: accent colors in `kanban-theme.ts`.
-- **Badges/tags**: small decorative elements with semantic meaning.
-
-Prefer light shades for backgrounds (`bg-sky-50`) and dark for text (`text-sky-700`).
-
-### Styling rules
-
-1. Never hardcode gray-scale for structural UI. Always use semantic tokens.
-2. NEVER use gradient backgrounds (`bg-gradient-*`) for surfaces/components.
-3. Use `className` props and semantic tokens at usage sites — never override base shadcn component files with hardcoded colors.
-4. Every new UI element must work in both light and dark themes.
-5. Use shadcn components from `packages/frontend/src/components/ui`. Avoid native browser-styled controls when a project component exists.
-
-## Frontend Patterns
-
-- State management contexts are wired in `packages/frontend/src/state/app-state-provider.tsx`.
-- Domain operations live in focused hooks under `packages/frontend/src/state/{lifecycle,operations,tasks}`.
-- Use operation-specific loading flags (`isLoadingTasks`, `isLoadingChecks`), not generic busy flags.
-- Centralize shared types under `packages/frontend/src/types`; use feature-level `constants.ts` over magic strings.
-- For async form submissions: disable the full form scope, show in-button loading, and preserve pending/error/success feedback.
-- Avoid nested ternaries in app and test code. Prefer named booleans, helper functions, lookup maps, or explicit `if`/`else` control flow so state rules stay readable.
-
-### TanStack Query Rules
-
-- TanStack Query is the default cache and deduplication layer for frontend reads that come from the backend or host adapters.
-- MUST use TanStack Query for server-owned read data that can be requested from multiple places, reused across screens, refreshed, invalidated after mutations, or deduplicated in flight.
-- MUST use TanStack Query for stable host reads such as settings snapshots, repo config, runtime definitions, tasks/runs lists, branches/current branch, diagnostics, session lists, and git status snapshots unless there is a documented exception.
-- MUST define query keys and query option builders in focused modules under `packages/frontend/src/state/queries`.
-- MUST use `useQuery` / `useQueries` / `useSuspenseQuery` in React render paths that read backend-owned data.
-- MUST use `queryClient.fetchQuery`, `ensureQueryData`, `prefetchQuery`, or cache invalidation APIs for imperative backend reads outside render paths.
-- MUST invalidate or update the relevant TanStack Query cache entries after any mutation that changes cached server data.
-- MUST prefer deriving UI state from query results over copying query data into local component state unless the copied state is a true user-editable draft.
-- MUST NOT add new ad hoc request caches, singleton in-flight maps, or `useEffect`+`useState` fetch loops for backend reads when TanStack Query can own that data.
-- MUST NOT use TanStack Query as the primary store for transient UI state, local form drafts, modal visibility, optimistic text input, or event-stream assembly.
-- MUST NOT move live streaming agent transcript state, in-progress tool output, pending permission/question interactions, or other event-driven session state into TanStack Query unless the underlying data becomes request/response based.
-- When adapting existing provider APIs, it is acceptable to keep the provider contract stable while making the underlying read path use TanStack Query.
-
-## Backend / Host
-
-- Keep host command APIs typed and schema-validated.
-- Expected host failures should be actionable typed errors.
-- Keep blocking work off the UI thread.
-- Do not re-run expensive repo initialization when cached readiness is known.
-
-## SQLite Task Store & Task Model
-
-- The SQLite task store is the sole source of truth for tasks.
-- Task-store records must store durable task/workflow state only. Do not persist transient runtime or session interaction state there.
-- Never serialize pending permissions, pending questions, live runtime routes, in-progress transcripts, tool streaming state, or other recoverable live-only values into task-store records. Rehydrate those from the live runtime, event stream, or runtime-owned history instead.
-- Task actions defined in `packages/contracts/src/task-schemas.ts` (`taskActionSchema`).
-- Detailed workflow docs: `docs/task-workflow-*.md`
-
-## MCP & Agent Studio Contract (Critical)
-
-Keep this contract stable. If you change any item below, update all related layers together.
-
-- MCP server name: `openducktor`.
-- Tool schemas: `packages/openducktor-mcp/src/lib.ts` (`ODT_TOOL_SCHEMAS`).
-- Workflow tools: `odt_read_task`, `odt_read_task_assets`, `odt_read_task_documents`, `odt_set_spec`, `odt_set_plan`, `odt_build_blocked`, `odt_build_resumed`, `odt_build_completed`, `odt_set_pull_request`, `odt_qa_approved`, `odt_qa_rejected`.
-- Role-to-tool policy: `packages/core/src/types/agent-orchestrator.ts` (`AGENT_ROLE_TOOL_POLICY`).
-- Role allowlist: all roles may use `odt_read_task`, `odt_read_task_assets`, and `odt_read_task_documents`; `spec` adds `odt_set_spec`; `planner` adds `odt_set_plan`; `build` adds `odt_build_*` and `odt_set_pull_request`; `qa` adds `odt_qa_*`.
-- Workflow tool normalization: `packages/core/src/services/odt-workflow-tools.ts`.
-- Agent Studio root: `packages/frontend/src/pages/agents/agents-page.tsx`; orchestration in `use-agent-studio-*.ts` hooks.
-- Runtime/session orchestration: `packages/frontend/src/state/operations/use-agent-orchestrator-operations.ts`.
-- Do not rename `odt_*` tools or change role allowlists in a single layer — update MCP, core, adapter, and frontend together.
-
-## Testing
-
-- All non-frontend code must be deeply tested (`packages/host`, `packages/core`, adapters, MCP).
-- Frontend tests are required for touched behavior.
-- Always run relevant checks before finishing — see Commands section above.
-- NEVER change production APIs, constructors, options, or exported types only to make tests easier or faster. Test-only seams must come from narrower test helpers, local fakes around existing boundaries, or refactoring that improves production design on its own merits.
-- In Bun tests, NEVER mock shared re-export barrels such as `@/state`, `@/components`, or other `index.ts` aggregator modules. Mock the source module that owns the export instead (for example `@/state/app-state-provider`), otherwise Bun can bind an incomplete export surface and leak that mock across files.
-- In Bun tests, register `mock.module(...)` in scoped setup (`beforeAll`/`beforeEach`) only when you truly need a module seam. Prefer dependency injection, direct function parameters, or `spyOn`-style seams over module replacement whenever possible.
-- In Bun tests, NEVER keep `mock.module(...)` active for the lifetime of a whole file via `beforeAll`/`afterAll`. Bun can interleave files in one process, so file-lifetime module mocks can leak into unrelated suites. Prefer no module mock at all; if unavoidable, scope it to the smallest possible test surface and restore it immediately after that scope.
-- In Bun tests, NEVER use `mock.restore()` as cleanup for `mock.module(...)`. `mock.restore()` is process-wide, can wipe unrelated spies/mocks in concurrently running files, and Bun docs do not treat it as reliable module-mock teardown.
-- In Bun tests, if you register `mock.module(...)`, you MUST restore that exact module id in teardown by remocking it back to the real module (or equivalent exact-id cleanup). Do not leave module mocks active beyond the suite, and do not replace cleanup with nothing.
-- In Bun tests, if one file needs the real implementation while another keeps a module mock, remock the exact module id back to the real implementation or import the real module through an isolated path. Do not use process-wide global restore for module cleanup in shared suite runs.
-- In Bun tests, when restoring a mocked module id, NEVER load the "real" module through that same mocked specifier while the mock is still active. Capture the real module before mocking, or restore from a non-mocked source path; otherwise the restore can silently re-import the mock.
-- In Bun tests, the mocked module id MUST exactly match the import string used by the code under test. If production code imports `@/foo/bar`, do not mock `./bar` and assume Bun will unify them.
-- In Bun tests, if the code under test imports a dependency through a relative path or other non-barrel specifier, mock that exact import string in the test. Do not rely on mocking only an upstream alias or barrel module and assume Bun will route the dependency through it.
-- Do not mutate shared singletons in tests when a local seam is possible. Avoid patching process-wide objects such as `host`, shared query clients, exported adapters, or other module-level state unless there is no narrower option and the test restores the mutation in `finally`/`afterEach`.
-- Prefer dependency injection or hook parameters over module mocks when testing logic that depends on host adapters, TanStack Query hooks, or app-state hooks. Small explicit seams are more stable than process-wide module replacement.
-- For hook tests that only need one app-state selector or one host read, prefer mocking that exact hook/function seam over wiring a larger fake provider or store graph. This keeps the test faster and less sensitive to CI scheduling.
-- Any test that exercises code using TanStack Query MUST provide its own isolated query client. Use `QueryProvider` with `useIsolatedClient` in tests; never rely on the app-global query client or on cache state left by previous tests.
-- Any test that renders a hook/component using app-state hooks such as `useWorkspaceState` MUST provide the minimal required context providers explicitly. Do not rely on ambient providers from unrelated test setup.
-- Render-only tests using `renderToStaticMarkup` still need the same required providers as client-rendered tests if the component calls hooks that depend on Query/context state.
-- When a test only needs to verify that one dependency receives the right inputs, prefer a focused hook test with injected fakes over a component-level module mock. This avoids coupling the assertion to Bun’s module cache behavior.
-- Treat default short polling windows as suspicious in CI. If a test waits for async query work or portal/render scheduling, use an explicit timeout with `waitFor(...)` or the harness wait helper instead of assuming `200ms` is enough.
-- Any explicit test wait timeout must stay below the enclosing Bun test timeout. Do not write waits that can outlive the suite timeout, because CI will report a generic test timeout instead of the real failing assertion.
-- When chasing flakes, run verification commands sequentially, not in parallel. Parallel local verification can create false negatives by contending for the same Bun test process resources and obscuring the real leak.
-- Prefer focused hook/module tests over broad page-level integration tests when asserting orchestration or routing behavior. Broad page tests with React Query, routers, and heavy module mocking are much more likely to leak handles and hang the Bun runner.
-- Test fixtures must return isolated nested data. Never share mutable nested objects or arrays between tests through top-level fixture constants.
-
-### Browser App Testing
-
-- For end-to-end UI validation in browser mode, use `agent-browser` against the live app served by the real OpenDucktor backend.
-- Treat browser mode as the default way to validate UI work in this repo when browser automation is sufficient.
-- Do **not** run `bun run browser:dev` yourself.
-- Ask the user to start `bun run browser:dev`, then connect to the running app in the browser.
-
-## Workflow
-
-- Use Conventional Commits.
-- Verify touched areas with relevant checks before finishing.
+- Run the checks that cover the changed code or documents.
+- Use a Conventional Commit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ Use Bun. Run workspace commands with `bun run`. Do not use npm or Yarn.
 - Fix the cause in the source layer.
 - If a call fails, return or propagate an error that tells the user what to do.
 - Do not add a second probe or an alternate path to hide a failure in the main path.
-- Do not add a poll or retry loop for data that must come from an existing live event stream or subscription. Fix the event or stream contract.
+- Do not add a poll or retry loop for data that must come from an existing live event stream or subscription.
+- Fix the event or stream contract.
 
 ### Keep code simple
 
@@ -47,7 +48,8 @@ Use Bun. Run workspace commands with `bun run`. Do not use npm or Yarn.
 
 ### Hexagonal rules
 
-- Define ports in core or domain code. Put adapters in infrastructure code.
+- Define ports in core or domain code.
+- Put adapters in infrastructure code.
 - Use an existing contract instead of coupling UI code to infrastructure code.
 - Change `packages/contracts` before you change host or frontend code that uses a data contract.
 
@@ -55,14 +57,24 @@ Use Bun. Run workspace commands with `bun run`. Do not use npm or Yarn.
 
 Read [docs/effect.md](docs/effect.md) before you change a host port, service, adapter, lifecycle, or typed error.
 
-- `packages/host` is Effect-native. A host port or application service that performs I/O or can fail must return `Effect.Effect<Success, Failure, Requirements>`, not a raw `Promise`.
+- Treat `packages/host` as Effect-native.
+- A host port or application service that performs I/O or can fail must return `Effect.Effect<Success, Failure, Requirements>`, not a raw `Promise`.
 - Keep Promise interop at explicit transport boundaries: Electron IPC, browser HTTP/SSE, shell bridge adapters, and external package APIs that require Promise values.
-- Model expected host failures as typed errors. Prefer `Data.TaggedError`. Propagate them through the Effect error channel. Do not use `throw new Error(...)` for an expected host failure.
-- Use `Effect.gen` for clear sequences. Use `Context.Tag` and `Layer` when they make host dependency wiring clear. Use `Effect.try` and `Effect.tryPromise` only at synchronous or Promise-based external boundaries.
-- Do not use `catchAll`, retry, fallback, or a default to hide a failed contract. A retry or poll must be explicit product behavior and must use an Effect schedule.
-- Keep pure domain policy code synchronous when it has no I/O and no useful typed failure channel. Do not wrap every expression in Effect.
-- Keep public Zod schemas in `packages/contracts` until a separate schema ADR changes this rule. Do not create a second public schema source with Effect Schema.
-- Use TanStack Query as the frontend cache and deduplication layer for server-owned reads. Effect can run behind a host client or query function, but it must not add a second frontend cache or request store.
+- Model expected host failures as typed errors.
+- Prefer `Data.TaggedError` for expected host failures.
+- Propagate expected failures through the Effect error channel.
+- Do not use `throw new Error(...)` for an expected host failure.
+- Use `Effect.gen` for clear sequences.
+- Use `Context.Tag` and `Layer` when they make host dependency wiring clear.
+- Use `Effect.try` and `Effect.tryPromise` only at synchronous or Promise-based external boundaries.
+- Do not use `catchAll`, retry, fallback, or a default to hide a failed contract.
+- Use an Effect schedule when a retry or poll is explicit product behavior.
+- Keep pure domain policy code synchronous when it has no I/O and no useful typed failure channel.
+- Do not wrap every expression in Effect.
+- Keep public Zod schemas in `packages/contracts` until a separate schema ADR changes this rule.
+- Do not create a second public schema source with Effect Schema.
+- Use TanStack Query as the frontend cache and deduplication layer for server-owned reads.
+- Do not use Effect to add a second frontend cache or request store behind a host client or query function.
 
 ### Replaceable boundaries
 
@@ -72,12 +84,19 @@ Read [docs/effect.md](docs/effect.md) before you change a host port, service, ad
 
 - Treat runtime definitions, runtime routes, and runtime connections as separate layers.
 - Keep shared host-visible runtime and run payloads in `packages/contracts/src/run-schemas.ts`.
-- Keep `RuntimeInstanceSummary` limited to `kind`, `runtimeId`, `repoPath`, nullable `taskId`, `role`, `workingDirectory`, `runtimeRoute`, `startedAt`, and `descriptor`. Do not add top-level `endpoint`, `port`, or duplicate `capabilities` fields.
-- Keep `runtimeId` and `runtimeRoute` in the runtime registry and adapters. UI and orchestration code must carry `runtimeKind`, repository path, working directory, and session ID.
-- Pass `runtimeConnection` objects to request-scoped agent engine operations. Build adapter-specific client input at the adapter boundary.
-- Do not store `runtimeEndpoint`, `baseUrl`, `runtimeTransport`, or other live route data in persisted session records or documents. Store durable IDs and `workingDirectory`, then resolve the live route at the adapter call boundary.
-- Resolve the route for the selected session or build. Do not fall back to the repository default runtime for history, todos, diff, or file status.
-- Define runtime capabilities in `packages/contracts/src/agent-runtime-schemas.ts`. Do not copy capability flags to runtime instance summaries.
+- Keep `RuntimeInstanceSummary` limited to `kind`, `runtimeId`, `repoPath`, nullable `taskId`, `role`, `workingDirectory`, `runtimeRoute`, `startedAt`, and `descriptor`.
+- Do not add top-level `endpoint`, `port`, or duplicate `capabilities` fields to `RuntimeInstanceSummary`.
+- Keep `runtimeId` and `runtimeRoute` in the runtime registry and adapters.
+- Make UI and orchestration code carry `runtimeKind`, repository path, working directory, and session ID.
+- Pass `runtimeConnection` objects to request-scoped agent engine operations.
+- Build adapter-specific client input at the adapter boundary.
+- Do not store `runtimeEndpoint`, `baseUrl`, `runtimeTransport`, or other live route data in persisted session records or documents.
+- Store durable IDs and `workingDirectory` in session records.
+- Resolve the live route at the adapter call boundary.
+- Resolve the route for the selected session or build.
+- Do not fall back to the repository default runtime for history, todos, diff, or file status.
+- Define runtime capabilities in `packages/contracts/src/agent-runtime-schemas.ts`.
+- Do not copy capability flags to runtime instance summaries.
 
 ## Commands
 
@@ -122,22 +141,28 @@ The app uses shadcn semantic tokens with Tailwind CSS v4. It supports light and 
 - Use hardcoded colors for status indicators: `bg-emerald-*` for success, `bg-sky-*` for information, `bg-amber-*` for a warning, and `bg-rose-*` for an error.
 - Use the accent colors in `kanban-theme.ts` for Kanban lane themes.
 - Use hardcoded colors for small badges and tags that have semantic meaning.
-- Prefer a light background such as `bg-sky-50` and dark text such as `text-sky-700`. Add dark-theme classes.
+- Prefer a light background such as `bg-sky-50` and dark text such as `text-sky-700`.
+- Add dark-theme classes.
 
 ### Styling rules
 
-1. NEVER use hardcoded gray colors for structural UI. Use semantic tokens.
+1. Use semantic tokens for structural UI instead of hardcoded gray colors.
 2. NEVER use a gradient background such as `bg-gradient-*` for a surface or component.
-3. Apply semantic tokens with `className` at the use site. Do not change a base shadcn component to add hardcoded colors.
+3. Apply semantic tokens with `className` at the use site.
 4. Make each new UI element work in light and dark themes.
-5. Use components from `packages/frontend/src/components/ui` when one exists. Do not use a native browser-styled control in its place.
+5. Do not change a base shadcn component to add hardcoded colors.
+6. Use components from `packages/frontend/src/components/ui` when one exists.
+7. Do not use a native browser-styled control when a project component exists.
 
 ## Frontend
 
 - Wire state contexts in `packages/frontend/src/state/app-state-provider.tsx`.
 - Put domain operations in focused hooks under `packages/frontend/src/state/{lifecycle,operations,tasks}`.
-- Use operation-specific flags such as `isLoadingTasks` and `isLoadingChecks`. Do not use a generic busy flag.
-- Put shared types in `packages/frontend/src/types`. Put feature constants in `constants.ts`. Do not use magic strings.
+- Use operation-specific flags such as `isLoadingTasks` and `isLoadingChecks`.
+- Do not use a generic busy flag.
+- Put shared types in `packages/frontend/src/types`.
+- Put feature constants in `constants.ts`.
+- Do not use magic strings.
 - During an async form submission, disable the full form, show loading in the submit button, and keep pending, error, or success feedback visible.
 - Replace nested ternaries in app and test code with named booleans, helper functions, lookup maps, or explicit `if` and `else` statements.
 
@@ -151,7 +176,8 @@ Read [docs/tanstack-query-cache-strategy.md](docs/tanstack-query-cache-strategy.
 - MUST use `useQuery`, `useQueries`, or `useSuspenseQuery` in React render paths that read backend-owned data.
 - MUST use `queryClient.fetchQuery`, `ensureQueryData`, `prefetchQuery`, or cache invalidation APIs for imperative backend reads outside render paths.
 - MUST invalidate or update each TanStack Query cache entry after a mutation changes its server data.
-- MUST derive UI state from query results. Copy query data to local component state only when the copy is a user-editable draft.
+- MUST derive UI state from query results.
+- Copy query data to local component state only when the copy is a user-editable draft.
 - MUST NOT add an ad hoc request cache, singleton in-flight map, or `useEffect` and `useState` fetch loop for a backend read that TanStack Query can own.
 - MUST NOT use TanStack Query as the main store for transient UI state, form drafts, modal state, optimistic text input, or event-stream assembly.
 - MUST NOT move live agent transcripts, in-progress tool output, pending permission or question state, or other event-driven session state into TanStack Query unless the data becomes request-response data.
@@ -162,13 +188,15 @@ Read [docs/tanstack-query-cache-strategy.md](docs/tanstack-query-cache-strategy.
 - Keep host command APIs typed and schema-validated.
 - Return actionable typed errors for expected host failures.
 - Keep blocking work off the UI thread.
-- Reuse known repository readiness. Do not repeat costly repository setup.
+- Reuse known repository readiness.
+- Do not repeat costly repository setup.
 
 ## SQLite task store
 
 - Treat the SQLite task store as the only source of truth for tasks.
 - Store only durable task and workflow state in task records.
-- Do not store pending permissions, pending questions, live runtime routes, in-progress transcripts, tool stream state, or other recoverable live-only values in task records. Rebuild them from the live runtime, event stream, or runtime history.
+- Do not store pending permissions, pending questions, live runtime routes, in-progress transcripts, tool stream state, or other recoverable live-only values in task records.
+- Rebuild live-only values from the live runtime, event stream, or runtime history.
 - Find task actions in `packages/contracts/src/task-schemas.ts` under `taskActionSchema`.
 - Read the applicable `docs/task-workflow-*.md` file before you change a task state or action.
 
@@ -182,9 +210,11 @@ Keep this contract stable. If you change one item, update all affected layers in
 - Role policy: `AGENT_ROLE_TOOL_POLICY` in `packages/core/src/types/agent-orchestrator.ts`.
 - Role allowlist: all roles can call `odt_read_task`, `odt_read_task_assets`, and `odt_read_task_documents`; `spec` adds `odt_set_spec`; `planner` adds `odt_set_plan`; `build` adds `odt_build_*` and `odt_set_pull_request`; `qa` adds `odt_qa_*`.
 - Workflow tool normalization: `packages/core/src/services/odt-workflow-tools.ts`.
-- Agent Studio root: `packages/frontend/src/pages/agents/agents-page.tsx`. Orchestration is in the `use-agent-studio-*.ts` hooks.
+- Agent Studio root: `packages/frontend/src/pages/agents/agents-page.tsx`.
+- Agent Studio orchestration: `use-agent-studio-*.ts` hooks.
 - Runtime and session orchestration: `packages/frontend/src/state/operations/use-agent-orchestrator-operations.ts`.
-- Do not rename an `odt_*` tool or change a role allowlist in one layer. Update MCP, core, adapters, host, and frontend code in the same change.
+- Do not rename an `odt_*` tool or change a role allowlist in one layer.
+- Update MCP, core, adapters, host, and frontend code in the same change.
 
 ## Tests
 
@@ -193,37 +223,55 @@ Keep this contract stable. If you change one item, update all affected layers in
 - Add deep tests for changed non-frontend behavior in `packages/host`, `packages/core`, adapters, and MCP.
 - Add frontend tests for changed frontend behavior.
 - Run the checks that cover each changed area before you finish.
-- NEVER change a production API, constructor, option, or exported type only to make a test easier or faster. Use a narrow test helper, a local fake around an existing boundary, or a refactor that improves the production design.
+- NEVER change a production API, constructor, option, or exported type only to make a test easier or faster.
+- Use a narrow test helper, a local fake around an existing boundary, or a refactor that improves the production design.
 
 ### Bun module mocks
 
-- NEVER mock a shared re-export barrel such as `@/state`, `@/components`, or another `index.ts` module. Mock the source module that owns the export, such as `@/state/app-state-provider`.
-- Register `mock.module(...)` in scoped setup only when you need a module seam. Prefer dependency injection, a direct function parameter, or `spyOn`.
-- NEVER keep `mock.module(...)` active for the life of a file through `beforeAll` and `afterAll`. Bun can interleave files in one process. Scope a module mock to the smallest test span and restore it at once.
-- NEVER use `mock.restore()` to clean up `mock.module(...)`. It acts on the whole process and can remove mocks from another test.
-- After `mock.module(...)`, restore the exact module ID by remocking it to the real module or by using an equivalent exact-ID cleanup. Do not leave the module mock active after its test scope.
-- If one file needs the real implementation while another file keeps a module mock, remock the exact module ID to the real implementation or import the real module through an isolated path. Do not use a process-wide restore.
-- NEVER load the real module through the mocked specifier while the mock is active. Capture the real module before the mock, or restore it from a source path that is not mocked.
-- Match the exact import string that the production code uses. A mock for `./bar` does not replace `@/foo/bar`.
-- If production code imports a dependency through a relative path or other non-barrel specifier, mock that exact import string. Do not mock only an upstream alias or barrel.
+- NEVER mock a shared re-export barrel such as `@/state`, `@/components`, or another `index.ts` module.
+- Mock the source module that owns the export, such as `@/state/app-state-provider`.
+- Register `mock.module(...)` in scoped setup only when you need a module seam.
+- Prefer dependency injection, a direct function parameter, or `spyOn`.
+- NEVER keep `mock.module(...)` active for the life of a file through `beforeAll` and `afterAll`.
+- Account for Bun interleaving test files in one process.
+- Scope a module mock to the smallest test span and restore it at once.
+- NEVER use `mock.restore()` to clean up `mock.module(...)`.
+- Do not remove mocks from other tests through process-wide cleanup.
+- After `mock.module(...)`, restore the exact module ID by remocking it to the real module or by using an equivalent exact-ID cleanup.
+- Do not leave a module mock active after its test scope.
+- If one file needs the real implementation while another file keeps a module mock, remock the exact module ID to the real implementation or import the real module through an isolated path.
+- Do not use a process-wide restore.
+- NEVER load the real module through the mocked specifier while the mock is active.
+- Capture the real module before the mock, or restore it from a source path that is not mocked.
+- Match the exact import string that the production code uses.
+- A mock for `./bar` does not replace `@/foo/bar`.
+- If production code imports a dependency through a relative path or other non-barrel specifier, mock that exact import string.
+- Do not mock only an upstream alias or barrel.
 
 ### Test isolation
 
-- Do not mutate `host`, a shared query client, an exported adapter, or another module-level singleton when a local seam can replace it. If no local seam exists, restore the mutation in `finally` or `afterEach`.
+- Do not mutate `host`, a shared query client, an exported adapter, or another module-level singleton when a local seam can replace it.
+- If no local seam exists, restore the mutation in `finally` or `afterEach`.
 - Prefer dependency injection or hook parameters over module mocks for code that uses host adapters, TanStack Query hooks, or app-state hooks.
 - If a hook test needs one app-state selector or one host read, mock that exact hook or function instead of a larger provider or store graph.
-- Give each test that uses TanStack Query its own isolated query client. Use `QueryProvider` with `useIsolatedClient`. Do not use the app-global query client or cache state from another test.
+- Give each test that uses TanStack Query its own isolated query client.
+- Use `QueryProvider` with `useIsolatedClient`.
+- Do not use the app-global query client or cache state from another test.
 - Provide the smallest required context providers when a test uses an app-state hook such as `useWorkspaceState`.
 - A `renderToStaticMarkup` test needs the same required providers as a client-rendered test when the component uses Query or context state.
 - If a test only checks that one dependency receives the correct input, use a focused hook test with an injected fake instead of a component-level module mock.
-- Prefer a focused hook or module test over a broad page test for orchestration or routing behavior. Broad page tests with React Query, routers, and heavy module mocks can leak handles and stop the Bun runner.
-- Return new nested objects and arrays from each fixture. Do not share mutable nested data between tests.
+- Prefer a focused hook or module test over a broad page test for orchestration or routing behavior.
+- Avoid broad page tests with React Query, routers, and heavy module mocks because they can leak handles and stop the Bun runner.
+- Return new nested objects and arrays from each fixture.
+- Do not share mutable nested data between tests.
 
 ### Async and flaky tests
 
-- Treat a short default polling window as unsafe in CI. For async query work or portal and render scheduling, use an explicit timeout with `waitFor(...)` or the test harness wait helper.
+- Treat a short default polling window as unsafe in CI.
+- For async query work or portal and render scheduling, use an explicit timeout with `waitFor(...)` or the test harness wait helper.
 - Keep each explicit wait timeout below the Bun test timeout.
-- Run flake checks in sequence. Parallel local checks can compete for the same Bun test process resources and hide the cause of a leak.
+- Run flake checks in sequence.
+- Do not run local flake checks in parallel because they can compete for the same Bun test process resources and hide the cause of a leak.
 
 ### Browser validation
 
@@ -242,7 +290,8 @@ Keep this contract stable. If you change one item, update all affected layers in
 - State facts, rules, steps, and completion checks.
 - Remove sales language, filler, stock AI phrases, and vague claims.
 - Do not use em dashes, decorative emojis, or bold text as decoration.
-- Keep one source for each rule. Link to branch-specific details instead of copying them into this file.
+- Keep one source for each rule.
+- Link to branch-specific details instead of copying them into this file.
 
 ## Finish
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,164 +2,82 @@
 
 ## Project
 
-OpenDucktor is a Bun monorepo. It has an Electron desktop app and a local browser runner. Both run AI planning and build workflows. A workspace-scoped SQLite task store is the source of truth for tasks.
+OpenDucktor is a Bun monorepo. It contains an Electron desktop app and a local browser runner. Both run AI planning and build workflows. A workspace-scoped SQLite task store is the source of truth for tasks.
 
 Use Bun. Run workspace commands with `bun run`. Do not use npm or Yarn.
 
-## Work rules
+## Hard rules
 
-- Fix a failure at the source that caused it. Return an error that tells the user what to do.
-- Keep the main path direct. Do not add a fallback, second probe, silent default, or retry that hides a failed contract.
-- Use an existing event stream or subscription for live data. Fix that contract instead of adding a polling loop.
-- Keep the code simple. Add normalization or extra checks only when a known case needs them.
-- Inspect runtime source or an official contract before you change an adapter that depends on runtime behavior.
-- Ask for human approval before you change a database schema, migration, persisted record schema, or durable SQLite task-store shape.
+### Do not hide failures
 
-## Code map
+- NEVER add fallback logic that hides a failure.
+- Fix the cause in the source layer.
+- If a call fails, return or propagate an error that tells the user what to do.
+- Do not add a second probe or an alternate path to hide a failure in the main path.
+- Do not add a poll or retry loop for data that must come from an existing live event stream or subscription. Fix the event or stream contract.
 
-- `apps/electron` contains the Electron shell, renderer startup, preload bridge, packaging, and IPC transport.
-- `packages/frontend` contains the shared React and Vite UI.
-- `packages/contracts` contains shared runtime schemas and IPC contracts.
-- `packages/core` contains domain services and ports.
-- `packages/host` contains the Effect-native TypeScript host, command routing, use cases, and infrastructure adapters.
-- `packages/adapters-opencode-sdk` implements `AgentEnginePort` for OpenCode.
-- `packages/host-client` adapts host IPC for the frontend.
-- `packages/openducktor-mcp` exposes the `odt_*` workflow tools.
+### Keep code simple
+
+- Keep the main path direct.
+- Add normalization or extra checks only when a known case needs them.
+- Do not add defensive code without a clear reason.
+
+### Verify runtime behavior
+
+- Inspect the runtime source or an official contract before you design or change an adapter that depends on external runtime behavior.
+- Do not infer runtime behavior from memory, an adapter shape, or an assumption when source evidence is available.
+
+### Get approval before durable data changes
+
+- NEVER change a database schema, migration file, persisted record schema, or durable SQLite task-store record shape without explicit human approval.
+- If a change needs new persisted data or a change to durable storage, stop and ask for approval.
+
+## Monorepo map
+
+- `apps/electron`: Electron desktop shell, renderer startup, preload bridge, packaging, and IPC transport.
+- `packages/frontend`: Shared React and Vite UI.
+- `packages/contracts`: Shared runtime schemas and IPC contracts.
+- `packages/core`: Core domain services and ports.
+- `packages/host`: Effect-native TypeScript host for Electron and web transports, command routing, application use cases, and infrastructure adapters.
+- `packages/adapters-opencode-sdk`: `AgentEnginePort` adapter.
+- `packages/host-client`: Frontend IPC adapter.
+- `packages/openducktor-mcp`: MCP server that exposes `odt_*` workflow tools.
 
 ## Architecture
+
+### Hexagonal rules
 
 - Define ports in core or domain code. Put adapters in infrastructure code.
 - Use an existing contract instead of coupling UI code to infrastructure code.
 - Change `packages/contracts` before you change host or frontend code that uses a data contract.
 
-### Effect in the host
+### Effect rules
 
 Read [docs/effect.md](docs/effect.md) before you change a host port, service, adapter, lifecycle, or typed error.
 
-- A host port or service that performs I/O or can fail returns `Effect.Effect<Success, Failure, Requirements>`.
-- Keep Promise interop at Electron IPC, browser HTTP/SSE, shell bridges, and external APIs that require Promise values.
-- Model expected failures as typed errors. Prefer `Data.TaggedError`. Do not use `throw new Error(...)` for an expected host failure.
-- Use `Effect.gen` for steps. Use `Context.Tag` and `Layer` when they make dependency wiring clear. Use `Effect.try` and `Effect.tryPromise` at external boundaries.
-- Use `catchAll`, retry, fallback, or a default only when the product contract calls for that behavior. Use Effect schedules for an explicit retry or polling policy.
-- Keep pure policy code synchronous when it has no I/O and no useful typed failure channel.
-- Keep public Zod schemas in `packages/contracts`. Do not create a second public schema source with Effect Schema.
-- TanStack Query owns the frontend cache for server-owned reads. Effect code must not add another cache for the same data.
+- `packages/host` is Effect-native. A host port or application service that performs I/O or can fail must return `Effect.Effect<Success, Failure, Requirements>`, not a raw `Promise`.
+- Keep Promise interop at explicit transport boundaries: Electron IPC, browser HTTP/SSE, shell bridge adapters, and external package APIs that require Promise values.
+- Model expected host failures as typed errors. Prefer `Data.TaggedError`. Propagate them through the Effect error channel. Do not use `throw new Error(...)` for an expected host failure.
+- Use `Effect.gen` for clear sequences. Use `Context.Tag` and `Layer` when they make host dependency wiring clear. Use `Effect.try` and `Effect.tryPromise` only at synchronous or Promise-based external boundaries.
+- Do not use `catchAll`, retry, fallback, or a default to hide a failed contract. A retry or poll must be explicit product behavior and must use an Effect schedule.
+- Keep pure domain policy code synchronous when it has no I/O and no useful typed failure channel. Do not wrap every expression in Effect.
+- Keep public Zod schemas in `packages/contracts` until a separate schema ADR changes this rule. Do not create a second public schema source with Effect Schema.
+- Use TanStack Query as the frontend cache and deduplication layer for server-owned reads. Effect can run behind a host client or query function, but it must not add a second frontend cache or request store.
 
-### Runtime boundaries
+### Replaceable boundaries
+
+- TS port: `AgentEnginePort` in `packages/core/src/ports/agent-engine.ts`.
+
+### Runtime rules
 
 - Treat runtime definitions, runtime routes, and runtime connections as separate layers.
 - Keep shared host-visible runtime and run payloads in `packages/contracts/src/run-schemas.ts`.
 - Keep `RuntimeInstanceSummary` limited to `kind`, `runtimeId`, `repoPath`, nullable `taskId`, `role`, `workingDirectory`, `runtimeRoute`, `startedAt`, and `descriptor`. Do not add top-level `endpoint`, `port`, or duplicate `capabilities` fields.
-- Keep `runtimeId` and `runtimeRoute` in the runtime registry and adapters. UI and orchestration code carry `runtimeKind`, repository path, working directory, and session ID.
+- Keep `runtimeId` and `runtimeRoute` in the runtime registry and adapters. UI and orchestration code must carry `runtimeKind`, repository path, working directory, and session ID.
 - Pass `runtimeConnection` objects to request-scoped agent engine operations. Build adapter-specific client input at the adapter boundary.
-- Persist durable IDs and `workingDirectory`. Do not store `runtimeEndpoint`, `baseUrl`, `runtimeTransport`, or other live route data in session records or documents.
+- Do not store `runtimeEndpoint`, `baseUrl`, `runtimeTransport`, or other live route data in persisted session records or documents. Store durable IDs and `workingDirectory`, then resolve the live route at the adapter call boundary.
 - Resolve the route for the selected session or build. Do not fall back to the repository default runtime for history, todos, diff, or file status.
 - Define runtime capabilities in `packages/contracts/src/agent-runtime-schemas.ts`. Do not copy capability flags to runtime instance summaries.
-
-## Frontend
-
-- Wire state contexts in `packages/frontend/src/state/app-state-provider.tsx`.
-- Put domain operations in focused hooks under `packages/frontend/src/state/{lifecycle,operations,tasks}`.
-- Use operation-specific flags such as `isLoadingTasks` and `isLoadingChecks`.
-- Put shared types in `packages/frontend/src/types`. Put feature constants in `constants.ts`.
-- During an async form submission, disable the full form, show loading in the submit button, and keep error or success feedback visible.
-- Replace nested ternaries with named booleans, helper functions, lookup maps, or `if` statements.
-
-### TanStack Query
-
-Read [docs/tanstack-query-cache-strategy.md](docs/tanstack-query-cache-strategy.md) before you add or change a frontend read from the host or backend.
-
-- Use TanStack Query for server-owned data that can be reused, refreshed, invalidated, or deduplicated.
-- Define query keys and option builders in a focused module under `packages/frontend/src/state/queries`.
-- Use `useQuery`, `useQueries`, or `useSuspenseQuery` for backend data read during render.
-- Use `queryClient.fetchQuery`, `ensureQueryData`, `prefetchQuery`, or cache invalidation for an imperative read.
-- After a mutation, update or invalidate each cache entry that the mutation changed.
-- Derive UI state from query results. Copy data only when the copy is a user-editable draft.
-- Keep transient UI state, form drafts, modal state, live transcripts, tool output, and pending permission or question state outside TanStack Query.
-- Keep a provider API stable when only its read path must move to TanStack Query.
-
-### Theme and components
-
-The app uses shadcn semantic tokens with Tailwind CSS v4. It supports light and dark themes. Tokens are in `packages/frontend/src/styles.css`.
-
-| Purpose | Use | Do not use |
-|---|---|---|
-| Page background | `bg-background` | `bg-white`, `bg-slate-50` |
-| Card or surface | `bg-card` | `bg-white` |
-| Main text | `text-foreground` | `text-gray-900` |
-| Secondary text | `text-muted-foreground` | `text-gray-500` |
-| Layout border | `border-border` | `border-gray-200` |
-| Input border | `border-input` | `border-gray-300` |
-| Subtle surface | `bg-muted` | `bg-gray-100` |
-| Interactive accent | `bg-primary`, `text-primary-foreground` | `bg-sky-600` |
-| Destructive action | `bg-destructive`, `text-destructive` | `bg-red-500` |
-| Sidebar | `bg-sidebar`, `text-sidebar-foreground`, `border-sidebar-border` | Hardcoded colors |
-
-- Hardcoded colors may mark status, Kanban lane themes, or small badges and tags.
-- Use light status backgrounds and dark status text. Include dark-theme classes.
-- Do not use a gradient for a surface or component.
-- Apply semantic tokens with `className` at the use site. Do not change a base shadcn component to add hardcoded colors.
-- Use components from `packages/frontend/src/components/ui` when one exists.
-
-## Host and task store
-
-- Keep host command APIs typed and schema-validated.
-- Return actionable typed errors for expected host failures.
-- Keep blocking work off the UI thread.
-- Reuse known repository readiness. Do not repeat costly setup.
-- Treat the SQLite task store as the only source of truth for tasks.
-- Store only durable task and workflow state in task records.
-- Rebuild pending permissions, questions, runtime routes, transcripts, and tool streams from the live runtime, event stream, or runtime history. Do not persist them in the task store.
-- Find task actions in `packages/contracts/src/task-schemas.ts`. Read `docs/task-workflow-*.md` before you change a task state or action.
-
-## MCP and Agent Studio contract
-
-Change all affected layers together when you change this contract.
-
-| Part | Source |
-|---|---|
-| Server name | `openducktor` |
-| Tool schemas | `ODT_TOOL_SCHEMAS` in `packages/openducktor-mcp/src/lib.ts` |
-| Workflow tools | `odt_read_task`, `odt_read_task_assets`, `odt_read_task_documents`, `odt_set_spec`, `odt_set_plan`, `odt_build_blocked`, `odt_build_resumed`, `odt_build_completed`, `odt_set_pull_request`, `odt_qa_approved`, and `odt_qa_rejected` |
-| Role policy | `AGENT_ROLE_TOOL_POLICY` in `packages/core/src/types/agent-orchestrator.ts` |
-- All roles can call the three read tools. `spec` adds `odt_set_spec`. `planner` adds `odt_set_plan`. `build` adds `odt_build_*` and `odt_set_pull_request`. `qa` adds `odt_qa_*`.
-- Normalize tools in `packages/core/src/services/odt-workflow-tools.ts`.
-- Agent Studio starts in `packages/frontend/src/pages/agents/agents-page.tsx` and its `use-agent-studio-*.ts` hooks.
-- Runtime and session orchestration lives in `packages/frontend/src/state/operations/use-agent-orchestrator-operations.ts`.
-
-Do not rename an `odt_*` tool or change a role allowlist in one layer. Update MCP, core, adapters, host, and frontend code in the same change.
-
-## Tests
-
-- Add deep tests for changed non-frontend behavior in `packages/host`, `packages/core`, adapters, and MCP.
-- Add frontend tests for changed frontend behavior.
-- Keep production APIs, constructors, options, and exported types independent from test needs. Use a local fake, dependency injection, or a test helper around an existing boundary.
-- Prefer a direct function parameter or `spyOn` over `mock.module(...)`.
-
-### Bun module mocks
-
-- Mock the source module that owns an export. Do not mock a shared barrel such as `@/state`, `@/components`, or another `index.ts` file.
-- Match the exact import string used by production code. A mock for `./bar` does not replace `@/foo/bar`.
-- Scope `mock.module(...)` to the smallest test span. Bun can interleave files in one process, so a file-wide module mock can leak to another suite.
-- Restore the exact module ID by remocking it to a real module captured before the mock. You can instead load the real module through a path that was not mocked.
-- Do not use `mock.restore()` to clean up `mock.module(...)`. It acts on the whole process and can remove mocks from another test.
-
-### Test isolation
-
-- Give each TanStack Query test an isolated query client. Use `QueryProvider` with `useIsolatedClient`.
-- Add the smallest required context providers when a test uses an app-state hook such as `useWorkspaceState`. This rule also applies to `renderToStaticMarkup` tests.
-- Do not mutate `host`, a shared query client, an exported adapter, or another singleton when a local seam can replace it. If no local seam exists, restore the value in `finally` or `afterEach`.
-- Return new nested objects and arrays from each fixture. Do not share mutable nested data across tests.
-- Use a focused hook or module test for routing and orchestration rules. Use a broad page test only when the page integration is the behavior under test.
-
-### Async and flaky tests
-
-- Give async query, portal, and render waits an explicit timeout. Keep each wait shorter than the Bun test timeout.
-- Run flake checks in sequence. Parallel Bun runs can hide a shared-process leak or cause a false failure.
-
-### Browser validation
-
-Use `agent-browser` against the live app and real OpenDucktor backend for browser end-to-end checks. Ask the user to start `bun run browser:dev`. Do not start it yourself.
 
 ## Commands
 
@@ -176,22 +94,158 @@ bun run test
 bun run build
 ```
 
-Run a focused workspace test with this form:
+Run a focused workspace test with this form.
 
 ```sh
 bun run --filter @openducktor/frontend test
 ```
 
+## Styling and themes
+
+The app uses shadcn semantic tokens with Tailwind CSS v4. It supports light and dark themes. Tokens are in `packages/frontend/src/styles.css`.
+
+| Purpose | Use | Do not use |
+|---|---|---|
+| Page background | `bg-background` | `bg-white`, `bg-slate-50` |
+| Card or surface | `bg-card` | `bg-white` |
+| Main text | `text-foreground` | `text-gray-900` |
+| Secondary text | `text-muted-foreground` | `text-gray-500` |
+| Layout border | `border-border` | `border-gray-200` |
+| Input border | `border-input` | `border-gray-300` |
+| Subtle surface | `bg-muted` | `bg-gray-100` |
+| Interactive accent | `bg-primary`, `text-primary-foreground` | `bg-sky-600` |
+| Destructive action | `bg-destructive`, `text-destructive` | `bg-red-500` |
+| Sidebar | `bg-sidebar`, `text-sidebar-foreground`, `border-sidebar-border` | Hardcoded colors |
+
+### Allowed hardcoded colors
+
+- Use hardcoded colors for status indicators: `bg-emerald-*` for success, `bg-sky-*` for information, `bg-amber-*` for a warning, and `bg-rose-*` for an error.
+- Use the accent colors in `kanban-theme.ts` for Kanban lane themes.
+- Use hardcoded colors for small badges and tags that have semantic meaning.
+- Prefer a light background such as `bg-sky-50` and dark text such as `text-sky-700`. Add dark-theme classes.
+
+### Styling rules
+
+1. NEVER use hardcoded gray colors for structural UI. Use semantic tokens.
+2. NEVER use a gradient background such as `bg-gradient-*` for a surface or component.
+3. Apply semantic tokens with `className` at the use site. Do not change a base shadcn component to add hardcoded colors.
+4. Make each new UI element work in light and dark themes.
+5. Use components from `packages/frontend/src/components/ui` when one exists. Do not use a native browser-styled control in its place.
+
+## Frontend
+
+- Wire state contexts in `packages/frontend/src/state/app-state-provider.tsx`.
+- Put domain operations in focused hooks under `packages/frontend/src/state/{lifecycle,operations,tasks}`.
+- Use operation-specific flags such as `isLoadingTasks` and `isLoadingChecks`. Do not use a generic busy flag.
+- Put shared types in `packages/frontend/src/types`. Put feature constants in `constants.ts`. Do not use magic strings.
+- During an async form submission, disable the full form, show loading in the submit button, and keep pending, error, or success feedback visible.
+- Replace nested ternaries in app and test code with named booleans, helper functions, lookup maps, or explicit `if` and `else` statements.
+
+### TanStack Query rules
+
+Read [docs/tanstack-query-cache-strategy.md](docs/tanstack-query-cache-strategy.md) before you add or change a frontend read from the host or backend.
+
+- MUST use TanStack Query for server-owned read data that can be requested from more than one place, reused across screens, refreshed, invalidated after a mutation, or deduplicated in flight.
+- MUST use TanStack Query for stable host reads such as settings snapshots, repository configuration, runtime definitions, task and run lists, branches and the current branch, diagnostics, session lists, and Git status snapshots unless a documented exception applies.
+- MUST define query keys and query option builders in focused modules under `packages/frontend/src/state/queries`.
+- MUST use `useQuery`, `useQueries`, or `useSuspenseQuery` in React render paths that read backend-owned data.
+- MUST use `queryClient.fetchQuery`, `ensureQueryData`, `prefetchQuery`, or cache invalidation APIs for imperative backend reads outside render paths.
+- MUST invalidate or update each TanStack Query cache entry after a mutation changes its server data.
+- MUST derive UI state from query results. Copy query data to local component state only when the copy is a user-editable draft.
+- MUST NOT add an ad hoc request cache, singleton in-flight map, or `useEffect` and `useState` fetch loop for a backend read that TanStack Query can own.
+- MUST NOT use TanStack Query as the main store for transient UI state, form drafts, modal state, optimistic text input, or event-stream assembly.
+- MUST NOT move live agent transcripts, in-progress tool output, pending permission or question state, or other event-driven session state into TanStack Query unless the data becomes request-response data.
+- Keep an existing provider API stable when only its read path must move to TanStack Query.
+
+## Host
+
+- Keep host command APIs typed and schema-validated.
+- Return actionable typed errors for expected host failures.
+- Keep blocking work off the UI thread.
+- Reuse known repository readiness. Do not repeat costly repository setup.
+
+## SQLite task store
+
+- Treat the SQLite task store as the only source of truth for tasks.
+- Store only durable task and workflow state in task records.
+- Do not store pending permissions, pending questions, live runtime routes, in-progress transcripts, tool stream state, or other recoverable live-only values in task records. Rebuild them from the live runtime, event stream, or runtime history.
+- Find task actions in `packages/contracts/src/task-schemas.ts` under `taskActionSchema`.
+- Read the applicable `docs/task-workflow-*.md` file before you change a task state or action.
+
+## MCP and Agent Studio contract
+
+Keep this contract stable. If you change one item, update all affected layers in the same change.
+
+- Server name: `openducktor`.
+- Tool schemas: `ODT_TOOL_SCHEMAS` in `packages/openducktor-mcp/src/lib.ts`.
+- Workflow tools: `odt_read_task`, `odt_read_task_assets`, `odt_read_task_documents`, `odt_set_spec`, `odt_set_plan`, `odt_build_blocked`, `odt_build_resumed`, `odt_build_completed`, `odt_set_pull_request`, `odt_qa_approved`, and `odt_qa_rejected`.
+- Role policy: `AGENT_ROLE_TOOL_POLICY` in `packages/core/src/types/agent-orchestrator.ts`.
+- Role allowlist: all roles can call `odt_read_task`, `odt_read_task_assets`, and `odt_read_task_documents`; `spec` adds `odt_set_spec`; `planner` adds `odt_set_plan`; `build` adds `odt_build_*` and `odt_set_pull_request`; `qa` adds `odt_qa_*`.
+- Workflow tool normalization: `packages/core/src/services/odt-workflow-tools.ts`.
+- Agent Studio root: `packages/frontend/src/pages/agents/agents-page.tsx`. Orchestration is in the `use-agent-studio-*.ts` hooks.
+- Runtime and session orchestration: `packages/frontend/src/state/operations/use-agent-orchestrator-operations.ts`.
+- Do not rename an `odt_*` tool or change a role allowlist in one layer. Update MCP, core, adapters, host, and frontend code in the same change.
+
+## Tests
+
+### Coverage
+
+- Add deep tests for changed non-frontend behavior in `packages/host`, `packages/core`, adapters, and MCP.
+- Add frontend tests for changed frontend behavior.
+- Run the checks that cover each changed area before you finish.
+- NEVER change a production API, constructor, option, or exported type only to make a test easier or faster. Use a narrow test helper, a local fake around an existing boundary, or a refactor that improves the production design.
+
+### Bun module mocks
+
+- NEVER mock a shared re-export barrel such as `@/state`, `@/components`, or another `index.ts` module. Mock the source module that owns the export, such as `@/state/app-state-provider`.
+- Register `mock.module(...)` in scoped setup only when you need a module seam. Prefer dependency injection, a direct function parameter, or `spyOn`.
+- NEVER keep `mock.module(...)` active for the life of a file through `beforeAll` and `afterAll`. Bun can interleave files in one process. Scope a module mock to the smallest test span and restore it at once.
+- NEVER use `mock.restore()` to clean up `mock.module(...)`. It acts on the whole process and can remove mocks from another test.
+- After `mock.module(...)`, restore the exact module ID by remocking it to the real module or by using an equivalent exact-ID cleanup. Do not leave the module mock active after its test scope.
+- If one file needs the real implementation while another file keeps a module mock, remock the exact module ID to the real implementation or import the real module through an isolated path. Do not use a process-wide restore.
+- NEVER load the real module through the mocked specifier while the mock is active. Capture the real module before the mock, or restore it from a source path that is not mocked.
+- Match the exact import string that the production code uses. A mock for `./bar` does not replace `@/foo/bar`.
+- If production code imports a dependency through a relative path or other non-barrel specifier, mock that exact import string. Do not mock only an upstream alias or barrel.
+
+### Test isolation
+
+- Do not mutate `host`, a shared query client, an exported adapter, or another module-level singleton when a local seam can replace it. If no local seam exists, restore the mutation in `finally` or `afterEach`.
+- Prefer dependency injection or hook parameters over module mocks for code that uses host adapters, TanStack Query hooks, or app-state hooks.
+- If a hook test needs one app-state selector or one host read, mock that exact hook or function instead of a larger provider or store graph.
+- Give each test that uses TanStack Query its own isolated query client. Use `QueryProvider` with `useIsolatedClient`. Do not use the app-global query client or cache state from another test.
+- Provide the smallest required context providers when a test uses an app-state hook such as `useWorkspaceState`.
+- A `renderToStaticMarkup` test needs the same required providers as a client-rendered test when the component uses Query or context state.
+- If a test only checks that one dependency receives the correct input, use a focused hook test with an injected fake instead of a component-level module mock.
+- Prefer a focused hook or module test over a broad page test for orchestration or routing behavior. Broad page tests with React Query, routers, and heavy module mocks can leak handles and stop the Bun runner.
+- Return new nested objects and arrays from each fixture. Do not share mutable nested data between tests.
+
+### Async and flaky tests
+
+- Treat a short default polling window as unsafe in CI. For async query work or portal and render scheduling, use an explicit timeout with `waitFor(...)` or the test harness wait helper.
+- Keep each explicit wait timeout below the Bun test timeout.
+- Run flake checks in sequence. Parallel local checks can compete for the same Bun test process resources and hide the cause of a leak.
+
+### Browser validation
+
+- Use `agent-browser` against the live app and real OpenDucktor backend for browser end-to-end checks.
+- Use browser mode as the default UI validation path when browser automation can cover the change.
+- Do not start `bun run browser:dev`.
+- Ask the user to start `bun run browser:dev`, then connect to the running app.
+
 ## Documentation
 
-- Write project prose in ASD-STE100 Simplified Technical English. Keep code, command names, paths, schema fields, and other exact technical terms unchanged.
-- Use sentence case for headings. Use one idea per sentence. Prefer active voice and short words.
+- Write project prose in ASD-STE100 Simplified Technical English.
+- Keep code, command names, paths, schema fields, and other exact technical terms unchanged.
+- Use sentence case for headings.
+- Use active voice, one idea per sentence, and short common words when they keep the exact meaning.
 - Put each Markdown paragraph and list item on one physical line.
-- State facts, rules, steps, and completion checks. Remove sales language, filler, stock AI phrases, and vague claims.
+- State facts, rules, steps, and completion checks.
+- Remove sales language, filler, stock AI phrases, and vague claims.
 - Do not use em dashes, decorative emojis, or bold text as decoration.
 - Keep one source for each rule. Link to branch-specific details instead of copying them into this file.
 
 ## Finish
 
 - Run the checks that cover the changed code or documents.
+- Run GitNexus `detect_changes()` before you commit.
 - Use a Conventional Commit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,36 +2,36 @@
 
 ## Project
 
-OpenDucktor is a Bun monorepo. It contains an Electron desktop app and a local browser runner. Both run AI planning and build workflows. A workspace-scoped SQLite task store is the source of truth for tasks.
+OpenDucktor is a Bun monorepo. It contains an Electron desktop app and a local browser runner for AI planning and build workflows. A workspace-scoped SQLite task store is the source of truth for tasks.
 
-Use Bun. Run workspace commands with `bun run`. Do not use npm or Yarn.
+Use Bun and `bun run`. Do not use npm or Yarn.
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) for setup and command details.
 
 ## Hard rules
 
-### Do not hide failures
+### Expose failures
 
-- NEVER add fallback logic that hides a failure.
-- Fix the cause in the source layer.
-- If a call fails, return or propagate an error that tells the user what to do.
-- Do not add a second probe or an alternate path to hide a failure in the main path.
-- Do not add a poll or retry loop for data that must come from an existing live event stream or subscription.
-- Fix the event or stream contract.
+- Fix failures in the source layer.
+- Return or propagate an error that tells the user what to do.
+- Do not add fallback logic, a second probe, or an alternate path that hides a failure.
+- Do not poll or retry data that must come from an existing live event stream or subscription.
 
 ### Keep code simple
 
 - Keep the main path direct.
-- Add normalization or extra checks only when a known case needs them.
-- Do not add defensive code without a clear reason.
+- Add normalization or extra checks only for a known case.
+- Add defensive code only when a clear risk requires it.
 
 ### Verify runtime behavior
 
-- Inspect the runtime source or an official contract before you design or change an adapter that depends on external runtime behavior.
-- Do not infer runtime behavior from memory, an adapter shape, or an assumption when source evidence is available.
+- Inspect runtime source or an official contract before you change an adapter that depends on external runtime behavior.
+- Do not infer available runtime behavior from memory or an adapter shape.
 
-### Get approval before durable data changes
+### Protect durable data
 
-- NEVER change a database schema, migration file, persisted record schema, or durable SQLite task-store record shape without explicit human approval.
-- If a change needs new persisted data or a change to durable storage, stop and ask for approval.
+- Get human approval before you change a database schema, migration file, persisted record schema, or durable SQLite task-store record shape.
+- Stop and ask for approval when a change needs new persisted data or a durable storage change.
 
 ## Monorepo map
 
@@ -39,262 +39,96 @@ Use Bun. Run workspace commands with `bun run`. Do not use npm or Yarn.
 - `packages/frontend`: Shared React and Vite UI.
 - `packages/contracts`: Shared runtime schemas and IPC contracts.
 - `packages/core`: Core domain services and ports.
-- `packages/host`: Effect-native TypeScript host for Electron and web transports, command routing, application use cases, and infrastructure adapters.
+- `packages/host`: Effect-native TypeScript host, command routing, use cases, and infrastructure adapters.
 - `packages/adapters-opencode-sdk`: `AgentEnginePort` adapter.
 - `packages/host-client`: Frontend IPC adapter.
-- `packages/openducktor-mcp`: MCP server that exposes `odt_*` workflow tools.
+- `packages/openducktor-mcp`: MCP server for `odt_*` workflow tools.
 
 ## Architecture
-
-### Hexagonal rules
 
 - Define ports in core or domain code.
 - Put adapters in infrastructure code.
 - Use an existing contract instead of coupling UI code to infrastructure code.
-- Change `packages/contracts` before you change host or frontend code that uses a data contract.
+- Change `packages/contracts` before the host or frontend code that uses a data contract.
 
-### Effect rules
+### Effect
 
 Read [docs/effect.md](docs/effect.md) before you change a host port, service, adapter, lifecycle, or typed error.
 
-- Treat `packages/host` as Effect-native.
-- A host port or application service that performs I/O or can fail must return `Effect.Effect<Success, Failure, Requirements>`, not a raw `Promise`.
-- Keep Promise interop at explicit transport boundaries: Electron IPC, browser HTTP/SSE, shell bridge adapters, and external package APIs that require Promise values.
-- Model expected host failures as typed errors.
-- Prefer `Data.TaggedError` for expected host failures.
-- Propagate expected failures through the Effect error channel.
-- Do not use `throw new Error(...)` for an expected host failure.
-- Use `Effect.gen` for clear sequences.
-- Use `Context.Tag` and `Layer` when they make host dependency wiring clear.
-- Use `Effect.try` and `Effect.tryPromise` only at synchronous or Promise-based external boundaries.
-- Do not use `catchAll`, retry, fallback, or a default to hide a failed contract.
-- Use an Effect schedule when a retry or poll is explicit product behavior.
-- Keep pure domain policy code synchronous when it has no I/O and no useful typed failure channel.
-- Do not wrap every expression in Effect.
-- Keep public Zod schemas in `packages/contracts` until a separate schema ADR changes this rule.
-- Do not create a second public schema source with Effect Schema.
-- Use TanStack Query as the frontend cache and deduplication layer for server-owned reads.
-- Do not use Effect to add a second frontend cache or request store behind a host client or query function.
+- Return `Effect.Effect<Success, Failure, Requirements>` from host ports and services that perform I/O or can fail.
+- Keep Promise interop at transport and external package boundaries.
+- Model expected failures as typed errors in the Effect error channel.
+- Keep public Zod schemas in `packages/contracts`.
 
-### Replaceable boundaries
+### Runtimes
 
-- TS port: `AgentEnginePort` in `packages/core/src/ports/agent-engine.ts`.
+Read [docs/runtime-integration-guide.md](docs/runtime-integration-guide.md) before you change a runtime, route, session, history, capability, prompt, approval, or catalog.
 
-### Runtime rules
-
-- Treat runtime definitions, runtime routes, and runtime connections as separate layers.
-- Keep shared host-visible runtime and run payloads in `packages/contracts/src/run-schemas.ts`.
-- Keep `RuntimeInstanceSummary` limited to `kind`, `runtimeId`, `repoPath`, nullable `taskId`, `role`, `workingDirectory`, `runtimeRoute`, `startedAt`, and `descriptor`.
-- Do not add top-level `endpoint`, `port`, or duplicate `capabilities` fields to `RuntimeInstanceSummary`.
-- Keep `runtimeId` and `runtimeRoute` in the runtime registry and adapters.
-- Make UI and orchestration code carry `runtimeKind`, repository path, working directory, and session ID.
-- Pass `runtimeConnection` objects to request-scoped agent engine operations.
-- Build adapter-specific client input at the adapter boundary.
-- Do not store `runtimeEndpoint`, `baseUrl`, `runtimeTransport`, or other live route data in persisted session records or documents.
-- Store durable IDs and `workingDirectory` in session records.
-- Resolve the live route at the adapter call boundary.
-- Resolve the route for the selected session or build.
-- Do not fall back to the repository default runtime for history, todos, diff, or file status.
-- Define runtime capabilities in `packages/contracts/src/agent-runtime-schemas.ts`.
-- Do not copy capability flags to runtime instance summaries.
-
-## Commands
-
-Run these commands from the repository root.
-
-```sh
-bun install
-bun run dev
-bun run electron:dev
-bun run browser:dev
-bun run typecheck
-bun run lint
-bun run test
-bun run build
-```
-
-Run a focused workspace test with this form.
-
-```sh
-bun run --filter @openducktor/frontend test
-```
-
-## Styling and themes
-
-The app uses shadcn semantic tokens with Tailwind CSS v4. It supports light and dark themes. Tokens are in `packages/frontend/src/styles.css`.
-
-| Purpose | Use | Do not use |
-|---|---|---|
-| Page background | `bg-background` | `bg-white`, `bg-slate-50` |
-| Card or surface | `bg-card` | `bg-white` |
-| Main text | `text-foreground` | `text-gray-900` |
-| Secondary text | `text-muted-foreground` | `text-gray-500` |
-| Layout border | `border-border` | `border-gray-200` |
-| Input border | `border-input` | `border-gray-300` |
-| Subtle surface | `bg-muted` | `bg-gray-100` |
-| Interactive accent | `bg-primary`, `text-primary-foreground` | `bg-sky-600` |
-| Destructive action | `bg-destructive`, `text-destructive` | `bg-red-500` |
-| Sidebar | `bg-sidebar`, `text-sidebar-foreground`, `border-sidebar-border` | Hardcoded colors |
-
-### Allowed hardcoded colors
-
-- Use hardcoded colors for status indicators: `bg-emerald-*` for success, `bg-sky-*` for information, `bg-amber-*` for a warning, and `bg-rose-*` for an error.
-- Use the accent colors in `kanban-theme.ts` for Kanban lane themes.
-- Use hardcoded colors for small badges and tags that have semantic meaning.
-- Prefer a light background such as `bg-sky-50` and dark text such as `text-sky-700`.
-- Add dark-theme classes.
-
-### Styling rules
-
-1. Use semantic tokens for structural UI instead of hardcoded gray colors.
-2. NEVER use a gradient background such as `bg-gradient-*` for a surface or component.
-3. Apply semantic tokens with `className` at the use site.
-4. Make each new UI element work in light and dark themes.
-5. Do not change a base shadcn component to add hardcoded colors.
-6. Use components from `packages/frontend/src/components/ui` when one exists.
-7. Do not use a native browser-styled control when a project component exists.
+- Keep runtime definitions, routes, and connections separate.
+- Keep live route data out of persisted session records and documents.
+- Resolve the route for the selected session or build at the adapter call boundary.
+- Do not use the repository default runtime as a fallback for a selected session or build.
 
 ## Frontend
 
-- Wire state contexts in `packages/frontend/src/state/app-state-provider.tsx`.
-- Put domain operations in focused hooks under `packages/frontend/src/state/{lifecycle,operations,tasks}`.
-- Use operation-specific flags such as `isLoadingTasks` and `isLoadingChecks`.
-- Do not use a generic busy flag.
-- Put shared types in `packages/frontend/src/types`.
-- Put feature constants in `constants.ts`.
-- Do not use magic strings.
-- During an async form submission, disable the full form, show loading in the submit button, and keep pending, error, or success feedback visible.
-- Replace nested ternaries in app and test code with named booleans, helper functions, lookup maps, or explicit `if` and `else` statements.
-
-### TanStack Query rules
+Read [docs/frontend-guidelines.md](docs/frontend-guidelines.md) before you change frontend state, forms, components, or themes.
 
 Read [docs/tanstack-query-cache-strategy.md](docs/tanstack-query-cache-strategy.md) before you add or change a frontend read from the host or backend.
 
-- MUST use TanStack Query for server-owned read data that can be requested from more than one place, reused across screens, refreshed, invalidated after a mutation, or deduplicated in flight.
-- MUST use TanStack Query for stable host reads such as settings snapshots, repository configuration, runtime definitions, task and run lists, branches and the current branch, diagnostics, session lists, and Git status snapshots unless a documented exception applies.
-- MUST define query keys and query option builders in focused modules under `packages/frontend/src/state/queries`.
-- MUST use `useQuery`, `useQueries`, or `useSuspenseQuery` in React render paths that read backend-owned data.
-- MUST use `queryClient.fetchQuery`, `ensureQueryData`, `prefetchQuery`, or cache invalidation APIs for imperative backend reads outside render paths.
-- MUST invalidate or update each TanStack Query cache entry after a mutation changes its server data.
-- MUST derive UI state from query results.
-- Copy query data to local component state only when the copy is a user-editable draft.
-- MUST NOT add an ad hoc request cache, singleton in-flight map, or `useEffect` and `useState` fetch loop for a backend read that TanStack Query can own.
-- MUST NOT use TanStack Query as the main store for transient UI state, form drafts, modal state, optimistic text input, or event-stream assembly.
-- MUST NOT move live agent transcripts, in-progress tool output, pending permission or question state, or other event-driven session state into TanStack Query unless the data becomes request-response data.
-- Keep an existing provider API stable when only its read path must move to TanStack Query.
+- Use TanStack Query for server-owned reads.
+- Keep transient UI state and live event streams outside TanStack Query.
+- Use existing shadcn components and semantic theme tokens.
+- Make each UI change work in light and dark themes.
+
+## Task data and workflow
+
+- Treat the SQLite task store as the only source of truth for tasks.
+- Store only durable task and workflow state in task records.
+- Rebuild live state from the runtime, event stream, or runtime history.
+- Read the applicable `docs/task-workflow-*.md` file before you change a task state or action.
 
 ## Host
 
 - Keep host command APIs typed and schema-validated.
 - Return actionable typed errors for expected host failures.
 - Keep blocking work off the UI thread.
-- Reuse known repository readiness.
-- Do not repeat costly repository setup.
+- Reuse known repository readiness. Do not repeat costly repository setup.
 
-## SQLite task store
+## MCP and Agent Studio
 
-- Treat the SQLite task store as the only source of truth for tasks.
-- Store only durable task and workflow state in task records.
-- Do not store pending permissions, pending questions, live runtime routes, in-progress transcripts, tool stream state, or other recoverable live-only values in task records.
-- Rebuild live-only values from the live runtime, event stream, or runtime history.
-- Find task actions in `packages/contracts/src/task-schemas.ts` under `taskActionSchema`.
-- Read the applicable `docs/task-workflow-*.md` file before you change a task state or action.
+Read [docs/external-mcp.md](docs/external-mcp.md) before you change the MCP package, host bridge, workspace scope, or public task tools.
 
-## MCP and Agent Studio contract
+Read [docs/agent-orchestrator-module-map.md](docs/agent-orchestrator-module-map.md) before you change Agent Studio orchestration.
 
-Keep this contract stable. If you change one item, update all affected layers in the same change.
-
-- Server name: `openducktor`.
-- Tool schemas: `ODT_TOOL_SCHEMAS` in `packages/openducktor-mcp/src/lib.ts`.
-- Workflow tools: `odt_read_task`, `odt_read_task_assets`, `odt_read_task_documents`, `odt_set_spec`, `odt_set_plan`, `odt_build_blocked`, `odt_build_resumed`, `odt_build_completed`, `odt_set_pull_request`, `odt_qa_approved`, and `odt_qa_rejected`.
-- Role policy: `AGENT_ROLE_TOOL_POLICY` in `packages/core/src/types/agent-orchestrator.ts`.
-- Role allowlist: all roles can call `odt_read_task`, `odt_read_task_assets`, and `odt_read_task_documents`; `spec` adds `odt_set_spec`; `planner` adds `odt_set_plan`; `build` adds `odt_build_*` and `odt_set_pull_request`; `qa` adds `odt_qa_*`.
-- Workflow tool normalization: `packages/core/src/services/odt-workflow-tools.ts`.
-- Agent Studio root: `packages/frontend/src/pages/agents/agents-page.tsx`.
-- Agent Studio orchestration: `use-agent-studio-*.ts` hooks.
-- Runtime and session orchestration: `packages/frontend/src/state/operations/use-agent-orchestrator-operations.ts`.
-- Do not rename an `odt_*` tool or change a role allowlist in one layer.
-- Update MCP, core, adapters, host, and frontend code in the same change.
+- Keep `ODT_TOOL_SCHEMAS` and `AGENT_ROLE_TOOL_POLICY` consistent.
+- Update MCP, core, adapters, host, and frontend code together when a shared workflow tool or role policy changes.
 
 ## Tests
 
-### Coverage
+Read [docs/testing.md](docs/testing.md) before you add or change tests.
 
-- Add deep tests for changed non-frontend behavior in `packages/host`, `packages/core`, adapters, and MCP.
+- Add deep tests for changed host, core, adapter, and MCP behavior.
 - Add frontend tests for changed frontend behavior.
-- Run the checks that cover each changed area before you finish.
-- NEVER change a production API, constructor, option, or exported type only to make a test easier or faster.
-- Use a narrow test helper, a local fake around an existing boundary, or a refactor that improves the production design.
-
-### Bun module mocks
-
-- NEVER mock a shared re-export barrel such as `@/state`, `@/components`, or another `index.ts` module.
-- Mock the source module that owns the export, such as `@/state/app-state-provider`.
-- Register `mock.module(...)` in scoped setup only when you need a module seam.
-- Prefer dependency injection, a direct function parameter, or `spyOn`.
-- NEVER keep `mock.module(...)` active for the life of a file through `beforeAll` and `afterAll`.
-- Account for Bun interleaving test files in one process.
-- Scope a module mock to the smallest test span and restore it at once.
-- NEVER use `mock.restore()` to clean up `mock.module(...)`.
-- Do not remove mocks from other tests through process-wide cleanup.
-- After `mock.module(...)`, restore the exact module ID by remocking it to the real module or by using an equivalent exact-ID cleanup.
-- Do not leave a module mock active after its test scope.
-- If one file needs the real implementation while another file keeps a module mock, remock the exact module ID to the real implementation or import the real module through an isolated path.
-- Do not use a process-wide restore.
-- NEVER load the real module through the mocked specifier while the mock is active.
-- Capture the real module before the mock, or restore it from a source path that is not mocked.
-- Match the exact import string that the production code uses.
-- A mock for `./bar` does not replace `@/foo/bar`.
-- If production code imports a dependency through a relative path or other non-barrel specifier, mock that exact import string.
-- Do not mock only an upstream alias or barrel.
-
-### Test isolation
-
-- Do not mutate `host`, a shared query client, an exported adapter, or another module-level singleton when a local seam can replace it.
-- If no local seam exists, restore the mutation in `finally` or `afterEach`.
-- Prefer dependency injection or hook parameters over module mocks for code that uses host adapters, TanStack Query hooks, or app-state hooks.
-- If a hook test needs one app-state selector or one host read, mock that exact hook or function instead of a larger provider or store graph.
-- Give each test that uses TanStack Query its own isolated query client.
-- Use `QueryProvider` with `useIsolatedClient`.
-- Do not use the app-global query client or cache state from another test.
-- Provide the smallest required context providers when a test uses an app-state hook such as `useWorkspaceState`.
-- A `renderToStaticMarkup` test needs the same required providers as a client-rendered test when the component uses Query or context state.
-- If a test only checks that one dependency receives the correct input, use a focused hook test with an injected fake instead of a component-level module mock.
-- Prefer a focused hook or module test over a broad page test for orchestration or routing behavior.
-- Avoid broad page tests with React Query, routers, and heavy module mocks because they can leak handles and stop the Bun runner.
-- Return new nested objects and arrays from each fixture.
-- Do not share mutable nested data between tests.
-
-### Async and flaky tests
-
-- Treat a short default polling window as unsafe in CI.
-- For async query work or portal and render scheduling, use an explicit timeout with `waitFor(...)` or the test harness wait helper.
-- Keep each explicit wait timeout below the Bun test timeout.
-- Run flake checks in sequence.
-- Do not run local flake checks in parallel because they can compete for the same Bun test process resources and hide the cause of a leak.
-
-### Browser validation
-
-- Use `agent-browser` against the live app and real OpenDucktor backend for browser end-to-end checks.
-- Use browser mode as the default UI validation path when browser automation can cover the change.
-- Do not start `bun run browser:dev`.
-- Ask the user to start `bun run browser:dev`, then connect to the running app.
+- Keep production APIs independent from test-only needs.
 
 ## Documentation
 
 - Write project prose in ASD-STE100 Simplified Technical English.
-- Keep code, command names, paths, schema fields, and other exact technical terms unchanged.
-- Use sentence case for headings.
-- Use active voice, one idea per sentence, and short common words when they keep the exact meaning.
-- Put each Markdown paragraph and list item on one physical line.
-- State facts, rules, steps, and completion checks.
-- Remove sales language, filler, stock AI phrases, and vague claims.
-- Do not use em dashes, decorative emojis, or bold text as decoration.
-- Keep one source for each rule.
-- Link to branch-specific details instead of copying them into this file.
+- Keep exact code, command, path, schema, and API terms unchanged.
+- Use sentence case, active voice, one idea per sentence, and one physical line per Markdown paragraph or list item.
+- Remove sales language, filler, stock AI phrases, vague claims, decorative bold text, emojis, and em dashes.
+- Keep one source for each rule and link to branch-specific details.
 
 ## Finish
 
-- Run the checks that cover the changed code or documents.
-- Run GitNexus `detect_changes()` before you commit.
-- Use a Conventional Commit.
+Run every full repository check before you complete any change:
+
+```sh
+bun run format:check
+bun run lint
+bun run typecheck
+bun run test
+bun run build
+```
+
+Use a Conventional Commit.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,35 +1,33 @@
-# Documentation Guide
+# Documentation guide
 
-This folder contains the project documentation for OpenDucktor's current architecture, runtime model, release process, and task workflow.
+Use this index to find the document for your task.
 
-## Read This First
+## Start here
 
-- [../README.md](../README.md): public project overview, install guide, and contribution entry point.
-- [architecture-overview.md](architecture-overview.md): high-level map of the shared frontend, Electron/browser shells, TypeScript host, SQLite task-store persistence, and runtime data flows.
-- [cli-tool-discovery.md](cli-tool-discovery.md): host-owned CLI discovery architecture, descriptor source order, distribution-mode boundaries, and the checklist for adding new tools.
-- [effect.md](effect.md): current Effect conventions for host ports, services, adapters, lifecycle, testing, and public boundaries.
-- [tanstack-query-cache-strategy.md](tanstack-query-cache-strategy.md): frontend cache strategy and the boundary between Query-owned reads and host/runtime execution.
-- [runtime-integration-guide.md](runtime-integration-guide.md): how OpenCode and Codex fit into OpenDucktor and what another runtime integration requires.
-- [web-runner.md](web-runner.md): local browser runner architecture, command usage, and package/release expectations for the TypeScript host backend.
-- [adr/](adr/): architecture decision records explaining durable technical choices and rejected alternatives.
+- Read [the project README](../README.md) for the product summary, install steps, and contribution links.
+- Read [the architecture overview](architecture-overview.md) before you change a cross-package data flow or ownership boundary.
+- Read [the Effect guide](effect.md) before you change a host port, service, adapter, lifecycle, or typed error.
+- Read [the runtime integration guide](runtime-integration-guide.md) before you add a runtime or change runtime capabilities, sessions, history, approvals, prompts, or catalogs.
+- Read [the CLI and tool discovery guide](cli-tool-discovery.md) before you add a CLI tool or change how a shell finds one.
+- Read [the TanStack Query cache strategy](tanstack-query-cache-strategy.md) before you add or change a frontend read from the host or backend.
 
-## Workflow Docs
+## Task workflow
 
-- [task-workflow-status-model.md](task-workflow-status-model.md): canonical task statuses, metadata ownership, and issue-type rules.
-- [task-workflow-actions.md](task-workflow-actions.md): canonical workflow actions and UI rendering expectations.
-- [task-workflow-transition-matrix.md](task-workflow-transition-matrix.md): allowed transitions, guards, and invalid examples.
+- [Task status model](task-workflow-status-model.md) defines task statuses, issue types, and document ownership.
+- [Task actions](task-workflow-actions.md) defines action IDs and their effects.
+- [Task transition matrix](task-workflow-transition-matrix.md) defines allowed transitions and guards.
+- [Task description Markdown](task-description-markdown.md) defines task Markdown, image assets, and agent access.
 
-## Runtime And Architecture Docs
+## Runtimes and tools
 
-- [agent-orchestrator-module-map.md](agent-orchestrator-module-map.md): maintainer map for the shared frontend agent orchestration modules.
-- [cli-tool-discovery.md](cli-tool-discovery.md): TypeScript host CLI/tool discovery map for Electron, web, and source/package distributions.
-- [external-mcp.md](external-mcp.md): public MCP package usage, host-bridge startup contract, and the external task tools.
-- [runtime-integration-guide.md](runtime-integration-guide.md): runtime vocabulary, capability model, integration checklist, and verification path.
-- [tanstack-query-cache-strategy.md](tanstack-query-cache-strategy.md): frontend read-cache ownership, invalidation rules, and how Effect-backed host calls should coexist with TanStack Query.
-- [web-runner.md](web-runner.md): how `@openducktor/web` starts the local TypeScript host and serves the shared frontend in browser mode.
+- [Agent orchestrator module map](agent-orchestrator-module-map.md) maps frontend agent orchestration code and ownership.
+- [External MCP](external-mcp.md) defines package use, host bridge startup, workspace scope, and public task tools.
+- [Interactive terminal architecture](interactive-terminal-architecture.md) defines terminal ownership, transport, replay, and cleanup.
+- [Web runner](web-runner.md) defines the local browser runner and its release package.
+- [Architecture decision records](adr/) record accepted and superseded technical decisions.
 
-## Security And Maintenance Docs
+## Security and maintenance
 
-- [mcp-runtime-security.md](mcp-runtime-security.md): current MCP transport and threat assumptions.
-- [dependency-hygiene.md](dependency-hygiene.md): dependency update and audit policy.
-- [release-process.md](release-process.md): Electron desktop, MCP, web package, Homebrew, version sync, and draft publishing steps.
+- [MCP runtime security](mcp-runtime-security.md) defines the allowed MCP transport and threat assumptions.
+- [Dependency hygiene](dependency-hygiene.md) defines dependency checks and update rules.
+- [Release process](release-process.md) defines desktop, web, MCP, and Homebrew releases.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,9 @@ Use this index to find the document for your task.
 - Read [the Effect guide](effect.md) before you change a host port, service, adapter, lifecycle, or typed error.
 - Read [the runtime integration guide](runtime-integration-guide.md) before you add a runtime or change runtime capabilities, sessions, history, approvals, prompts, or catalogs.
 - Read [the CLI and tool discovery guide](cli-tool-discovery.md) before you add a CLI tool or change how a shell finds one.
+- Read [the frontend guidelines](frontend-guidelines.md) before you change frontend state, forms, components, or themes.
 - Read [the TanStack Query cache strategy](tanstack-query-cache-strategy.md) before you add or change a frontend read from the host or backend.
+- Read [the testing guide](testing.md) before you add or change tests.
 
 ## Task workflow
 

--- a/docs/adr/0001-do-not-adopt-acp-without-client-owned-system-prompts.md
+++ b/docs/adr/0001-do-not-adopt-acp-without-client-owned-system-prompts.md
@@ -3,46 +3,44 @@ status: accepted
 date: 2026-05-17
 ---
 
-# Do Not Adopt ACP Without Client-Owned System Prompts
-
-OpenDucktor workflow runtimes must receive the Spec, Planner, Builder, and QA role prompts as privileged runtime instructions, not as ordinary user prompt text. The current ACP standard does not expose a client-owned system or developer prompt field on session creation, loading, forking, or prompt turns, so vanilla ACP agents are not eligible as OpenDucktor workflow runtimes.
+# Do not adopt ACP without client-owned system prompts
 
 ## Context
 
-OpenDucktor role prompts are part of the runtime contract. They define the role mission, allowed ODT workflow tools, task-id locking, lifecycle rules, artifact discipline, read-only expectations, and failure behavior for Spec, Planner, Builder, and QA sessions.
+OpenDucktor sends the Spec, Planner, Builder, and QA role prompts as privileged runtime instructions. These prompts define the role, allowed ODT tools, task ID lock, lifecycle rules, artifacts, read-only rules, and failure behavior.
 
-ACP is attractive because it standardizes client/agent communication and could theoretically let OpenDucktor reach many coding agents through one adapter. However, ACP `session/new` provides working directory and MCP server setup, `session/prompt` sends normal content blocks, and session modes are selected from modes advertised by the agent. ACP extensibility allows custom methods and metadata, but that only helps when an individual agent explicitly implements the extension.
+ACP standardizes client and agent messages, but its standard session and prompt methods do not accept client-owned system or developer instructions. `session/new` accepts the working directory and MCP setup. `session/prompt` sends normal content blocks. The agent owns its session modes. An agent can add a custom ACP method, but other ACP agents do not gain that method.
 
-Prepending the OpenDucktor role prompt as normal prompt text is not equivalent to privileged system prompt injection. A role-scoped MCP server can reject invalid workflow tool calls, but it cannot make a generic agent understand and follow the OpenDucktor role contract.
+A role-scoped MCP server can reject a bad tool call. It cannot make a general agent follow the OpenDucktor role contract. A role prompt sent as user text is not a privileged instruction.
 
 ## Decision
 
-OpenDucktor will not implement vanilla ACP as a workflow runtime while ACP lacks a standard client-owned privileged instruction channel.
+Do not use standard ACP for an OpenDucktor workflow runtime until ACP has a client-owned privileged instruction channel.
 
-ACP may be reconsidered only if one of these becomes true:
+Review this decision again only if one of these conditions becomes true:
 
-- ACP adds a stable standard way for the client to provide privileged session instructions that agents must apply as system or developer prompt material.
-- A specific ACP-backed runtime provides a documented, tested, non-standard instruction channel that OpenDucktor can treat as part of that runtime's adapter contract.
-- OpenDucktor explicitly scopes a future ACP integration to non-workflow experimentation where Spec, Planner, Builder, and QA guarantees are not required.
+- ACP adds a stable standard field for client-owned system or developer instructions.
+- An ACP runtime has a documented and tested instruction channel that its OpenDucktor adapter can require.
+- OpenDucktor limits the ACP integration to work that does not need the Spec, Planner, Builder, or QA contract.
 
-## Considered Options
+## Options we rejected
 
-- Adopt vanilla ACP and prepend role prompts as user text. Rejected because it weakens mandatory role instructions into ordinary prompt content.
-- Use ACP session modes. Rejected as a generic solution because modes are agent-owned; OpenDucktor cannot define their prompt bodies.
-- Define an OpenDucktor ACP extension. Rejected as a general interoperability solution because existing ACP agents will not implement it.
-- Build ACP wrappers around native agents. Rejected as the reason to choose ACP for broad compatibility; this becomes per-agent native integration behind an ACP facade.
-- Enforce only through MCP. Rejected because tool gating does not replace role instruction injection.
+- Prepend the role prompt as user text. User text cannot enforce the role contract.
+- Use ACP session modes. The agent owns the mode and its prompt.
+- Define an OpenDucktor ACP extension. Existing ACP agents would not support it.
+- Wrap each native agent with ACP. This still needs one native integration for each agent.
+- Enforce the role only through MCP. Tool access does not replace role instructions.
 
 ## Consequences
 
-The next OpenDucktor runtime should be evaluated against the native runtime contract first: it must support privileged role prompt injection, ODT workflow tools, read-only role safety, session lifecycle requirements, and history behavior described in the runtime integration guide.
+Evaluate each runtime against the native runtime contract. It must support privileged role prompts, ODT tools, read-only roles, the required session lifecycle, and history.
 
-ACP can still be useful research material for transport, streaming event shapes, and ecosystem direction, but it is not currently a viable runtime-integration target for OpenDucktor's workflow agents.
+ACP can still inform transport and stream design. It is not a workflow runtime target under this decision.
 
-Relevant evidence:
+## References
 
 - [ACP session setup](https://agentclientprotocol.com/protocol/session-setup)
 - [ACP prompt turn](https://agentclientprotocol.com/protocol/prompt-turn)
 - [ACP session modes](https://agentclientprotocol.com/protocol/session-modes)
 - [ACP extensibility](https://agentclientprotocol.com/protocol/extensibility)
-- [OpenDucktor runtime integration guide](../runtime-integration-guide.md)
+- [Runtime integration guide](../runtime-integration-guide.md)

--- a/docs/adr/0002-use-effect-in-the-typescript-host.md
+++ b/docs/adr/0002-use-effect-in-the-typescript-host.md
@@ -3,62 +3,47 @@ status: accepted
 date: 2026-05-17
 ---
 
-# Use Effect in the TypeScript Host
-
-OpenDucktor will use Effect as the internal execution model for `packages/host`, while keeping Promise interop at shell-facing transport boundaries. The host is the first package in a phased Effect adoption because it has the densest concentration of fallible I/O, dependency wiring, long-lived resources, and lifecycle orchestration.
+# Use Effect in the TypeScript host
 
 ## Context
 
-`packages/host` is the transport-neutral TypeScript host used by Electron and the local browser shell. It owns command routing, application use cases, ports, adapters, runtime lifecycle, Beads/Dolt access, git operations, filesystem operations, MCP bridge behavior, dev-server process control, and shutdown coordination.
+`packages/host` is the transport-neutral host for Electron and the browser runner. It owns command routing, use cases, ports, adapters, runtime lifecycle, task storage, Git, file access, MCP bridges, dev servers, and shutdown.
 
-Before adopting Effect, this host boundary was largely Promise-based. That made I/O sequencing familiar, but expected failures, dependency wiring, resource cleanup, background coordination, and transport-boundary error mapping were spread across `async` functions, `try`/`catch`, ad hoc error objects, and manually composed ports.
-
-Effect is a meaningful architectural commitment rather than a local implementation detail: it changes how host ports, application services, adapters, command handlers, and tests express fallibility and execution. The decision is therefore recorded here so future work does not accidentally reintroduce Promise-only orchestration into the host internals, and so later Effect migrations can reuse the same boundary discipline instead of inventing new patterns per package.
+The old Promise-based code spread expected failures, dependency wiring, cleanup, and background work across `async` functions, `try` blocks, error objects, and manual port setup. Effect changes how host ports, services, adapters, command handlers, and tests model that work. This is an architecture choice, not a local code style.
 
 ## Decision
 
-Use Effect as the internal model for fallible and I/O-producing host work.
+Use Effect for host work that performs I/O or can fail.
 
-Concretely:
+- Host ports return `Effect.Effect<Success, Failure, Requirements>` when they perform I/O or can fail.
+- Application services use `Effect.gen` and typed failures.
+- Expected host failures use tagged errors, usually `Data.TaggedError`.
+- Adapters wrap Node, process, file, HTTP, and third-party Promise APIs with `Effect.try`, `Effect.tryPromise`, or resource operators.
+- Use `Context.Tag` and `Layer` when they make dependency setup clear.
+- Keep Promise values at Electron IPC, browser HTTP/SSE, shell bridges, test harnesses, and other external Promise APIs.
+- The command router provides an Effect API and a Promise adapter.
+- Use a retry, polling, schedule, fiber, or fallback only when the product contract calls for it.
 
-- Host ports that perform I/O or can fail return `Effect.Effect<Success, Failure, Requirements>` instead of raw `Promise`.
-- Application services compose host operations with `Effect.gen` and typed failures.
-- Expected host failures are modeled with tagged errors, primarily `Data.TaggedError`.
-- Adapter and infrastructure code wrap external Node, process, filesystem, HTTP, and third-party Promise APIs at the edge with Effect constructors such as `Effect.try`, `Effect.tryPromise`, and resource-aware combinators.
-- Dependency injection uses Effect `Context.Tag` and `Layer` where it makes the host composition root clearer.
-- Promise-returning APIs remain only at external boundaries that must interoperate with Electron IPC, browser HTTP/SSE, existing shell bridges, or test harnesses.
-- The command router exposes an Effect-native surface and a Promise adapter, making Promise interop explicit instead of the host's internal model.
-- Retries, polling, and background work may use Effect scheduling and fibers only when they represent existing product behavior. They must not hide failures or introduce fallback paths.
+This decision applies to `packages/host`. It does not replace public Zod contracts or the TanStack Query cache.
 
-This decision is scoped to `packages/host`, but it is intentionally a first step rather than the final scope of Effect in OpenDucktor. It does not migrate `packages/contracts` from Zod and does not replace TanStack Query or frontend state ownership.
+## Options we rejected
 
-## Considered Options
-
-- Keep the host Promise-based. Rejected because the host has many fallible I/O boundaries and long-lived resources; Promise-only orchestration keeps failure types, cleanup, and dependency wiring implicit.
-- Adopt Effect across the entire monorepo in one step. Rejected because a broad migration would mix packages with very different ownership models and would obscure whether Effect is improving each boundary. Frontend reads are intentionally owned by TanStack Query and shared contracts are Zod-based.
-- Adopt Effect progressively, starting with `packages/host`. Accepted because the host has the clearest immediate fit and can establish reusable patterns for later migrations in runtime adapters, the local web runner, and MCP bridge code.
-- Use Effect only in leaf adapters. Rejected as too shallow: it would wrap external calls but leave application orchestration and port contracts Promise-based, preserving the same ambiguity at the layer where most host decisions are made.
-- Make every public host API return Effect. Rejected because shell transports, Electron IPC, browser HTTP handlers, and existing host clients need Promise-compatible boundaries.
+- Keep a Promise-only host. It leaves expected failures, cleanup, and dependency setup implicit.
+- Migrate the full monorepo at once. Each package has a different owner and boundary.
+- Use Effect only in leaf adapters. The service and port contracts would still hide failures.
+- Return Effect values from every public API. Shell transports and host clients need Promise-compatible APIs.
 
 ## Consequences
 
-The main benefit is that host failures are now part of function signatures instead of convention. Runtime startup failures, invalid command input, path access problems, missing dependencies, process failures, and lifecycle errors can be propagated as typed values until a public boundary turns them into user-visible errors.
+Host function types now show expected failures. A public transport converts those failures to errors for the caller.
 
-Effect also fits the existing hexagonal host architecture. Ports map naturally to Effect service interfaces, adapters remain responsible for external systems, and the composition root can provide concrete dependencies without making application services import infrastructure modules.
+Ports remain independent from adapters. The composition root provides each adapter. Effect scopes and interruption manage runtime registries, dev servers, MCP bridges, task-store lifecycle, and background work.
 
-Resource and lifecycle code becomes easier to reason about. Runtime registries, dev-server shutdown, MCP bridge startup/close, shared Dolt lifecycle, single-flight coordination, and background work can use Effect primitives for sequencing, interruption, and cleanup instead of open-coded Promise state.
+Other packages can adopt these rules when they have the same I/O and lifecycle needs. Make each later migration a separate change.
 
-The host migration establishes OpenDucktor's first Effect conventions. Future packages can adopt those conventions when they have similar pressure: runtime adapters with event streams and session lifecycle, `packages/openducktor-web` with launcher/readiness/SSE orchestration, and `packages/openducktor-mcp` with CLI, discovery, bridge health, and host-call error handling. Those migrations should be separate decisions or implementation slices, not incidental spillover from this ADR.
+Contributors who change `packages/host` must understand the Effect error channel, defects, interruption, `Context`, `Layer`, and the Promise boundary. Pure policy code can stay synchronous.
 
-The tradeoff is a larger conceptual and type-system surface. Contributors working in `packages/host` need to understand Effect failure channels, defects, interruption, `Context`, `Layer`, and the difference between internal Effects and external Promise boundaries.
-
-Another tradeoff is boundary discipline during phased adoption. Effect may coexist with Zod and TanStack Query, but it must not duplicate their ownership by accident. `packages/contracts` remains the public Zod contract source until a separate schema decision says otherwise. Frontend server-read caching remains owned by TanStack Query, even if future query functions or host clients internally run Effect programs.
-
-This also creates sharper review expectations. New host code should not introduce raw Promise orchestration inside application services or ports when an Effect signature is the established boundary. Generic `throw new Error(...)` should not be used for expected host failures. Broad `catchAll`, retry, fallback, or defaulting behavior must be treated suspiciously unless the product behavior explicitly requires it.
-
-Pure domain policy code may stay synchronous and non-Effect when it has no I/O and no meaningful typed failure channel. Keeping pure code simple is part of the decision; Effect is the host execution model, not a mandate to wrap every expression.
-
-Relevant references:
+## References
 
 - [Effect documentation](https://effect.website/docs)
 - [TanStack Query cache strategy](../tanstack-query-cache-strategy.md)

--- a/docs/adr/0003-use-project-native-agent-ui-composition.md
+++ b/docs/adr/0003-use-project-native-agent-ui-composition.md
@@ -29,7 +29,6 @@ A third-party UI library can provide a small component that fits the local desig
 
 - Vercel AI SDK UI as the main UI layer. It manages messages and state, but it does not model the OpenDucktor workflow.
 - An assistant UI component library as the main UI layer. General chat controls do not model local runtime and task rules.
-- Project-native shadcn and Tailwind composition. We chose this option because it uses the current app shell and keeps runtime code behind adapters.
 
 ## Consequences
 

--- a/docs/adr/0003-use-project-native-agent-ui-composition.md
+++ b/docs/adr/0003-use-project-native-agent-ui-composition.md
@@ -3,44 +3,37 @@ status: accepted
 date: 2026-02-18
 ---
 
-# Use Project-Native Agent UI Composition
-
-OpenDucktor's agent surfaces are workflow tools, not generic chat widgets: they combine role-specific launch controls, permission and question handling, task documents, runtime status, tool timelines, and host actions. We will keep the agent UI built from project-native React, shadcn components, Tailwind tokens, and OpenDucktor state/query primitives instead of adopting a third-party assistant UI component system. This keeps workflow semantics in the app while leaving runtime orchestration behind replaceable adapter boundaries.
+# Use project-native Agent UI composition
 
 ## Context
 
-At the start of the project, it was reasonable to ask whether OpenDucktor should use an agent UI library instead of building its own Agent Studio surfaces. Since then, the product surface has become more specific:
+Agent Studio is a workflow UI, not a general chat widget. It shows role launch controls, permission requests, questions, task documents, runtime status, tool calls, and host actions.
 
-- task roles map to OpenDucktor workflow states and `odt_*` tools,
-- sessions are tied to local runtimes, build worktrees, Beads metadata, and host-managed shell actions,
-- permission prompts, structured questions, queued user turns, task documents, todos, git status, and runtime diagnostics all need product-specific rendering and refresh behavior,
-- OpenCode and Codex expose different runtime-native event and transport shapes behind the same `AgentEnginePort`.
-
-Those constraints make a generic chat UI kit a poor owner for the primary interaction model.
+Its sessions also depend on local runtimes, task worktrees, task metadata, shell actions, queued user turns, todos, Git status, and runtime checks. OpenCode and Codex expose different events and transports behind `AgentEnginePort`. A general chat UI library does not own these product rules.
 
 ## Decision
 
-Use project-native composition for Agent Studio:
+Build Agent Studio from project-owned parts:
 
-- React feature components in `packages/frontend`,
-- shadcn primitives from `packages/frontend/src/components/ui`,
-- Tailwind semantic tokens from the shared frontend theme,
-- TanStack Query for stable host/runtime reads,
-- OpenDucktor state and operation hooks for live session orchestration,
-- `@openducktor/adapters-opencode-sdk` and `@openducktor/adapters-codex-app-server` behind `AgentEnginePort`,
+- React feature components in `packages/frontend`.
+- shadcn components from `packages/frontend/src/components/ui`.
+- Tailwind semantic theme tokens.
+- TanStack Query for stable host and runtime reads.
+- OpenDucktor state and operation hooks for live sessions.
+- Runtime adapters behind `AgentEnginePort`.
 - `@openducktor/host-client` for host commands, task transitions, and runtime control.
 
-Third-party UI libraries may still be used for focused primitives when they fit the local design system, but they must not become the owner of OpenDucktor's agent workflow semantics.
+A third-party UI library can provide a small component that fits the local design system. It must not own OpenDucktor workflow rules.
 
-## Considered Options
+## Options we rejected
 
-- Vercel AI SDK UI (`@ai-sdk/react`). Rejected as the primary UI layer because it is a headless message/state layer, not a complete OpenDucktor workflow surface. It may still be useful as a reference for streaming and message-state ideas.
-- Assistant-focused component libraries. Rejected as the primary UI layer because they optimize for generic chat assistants, while OpenDucktor needs local runtime lifecycle, Beads workflow transitions, task documents, and host-command semantics on screen.
-- Project-native shadcn + Tailwind composition. Accepted because it matches the existing app shell, keeps UI ownership close to OpenDucktor's workflow model, and preserves runtime replaceability at the adapter boundary.
+- Vercel AI SDK UI as the main UI layer. It manages messages and state, but it does not model the OpenDucktor workflow.
+- An assistant UI component library as the main UI layer. General chat controls do not model local runtime and task rules.
+- Project-native shadcn and Tailwind composition. We chose this option because it uses the current app shell and keeps runtime code behind adapters.
 
 ## Consequences
 
-- Agent Studio UI changes must stay aligned with OpenDucktor contracts and host/runtime ownership, not library-owned chat abstractions.
-- New controls should use existing shadcn primitives and semantic theme tokens rather than introducing a parallel visual system.
-- Shared agent logic should be extracted into focused local hooks or components only when it removes real duplication across OpenDucktor surfaces.
-- Runtime-specific behavior belongs in runtime descriptors, adapters, and host orchestration, not in generic UI component assumptions.
+- Keep Agent Studio UI changes in step with OpenDucktor contracts and host ownership.
+- Use current shadcn components and theme tokens.
+- Extract a shared hook or component only when two OpenDucktor views have the same rule.
+- Put runtime-specific rules in descriptors, adapters, and host orchestration.

--- a/docs/adr/0004-use-claude-agent-sdk-for-claude-runtime.md
+++ b/docs/adr/0004-use-claude-agent-sdk-for-claude-runtime.md
@@ -3,68 +3,56 @@ status: superseded by ADR-0007
 date: 2026-05-24
 ---
 
-# Use Claude Agent SDK for the Managed Claude Runtime
-
-OpenDucktor will integrate Claude as a managed workflow runtime through the official Claude Agent SDK, not through `claude -p` as the primary adapter path. The SDK is the only documented Claude Code integration surface that directly exposes the runtime capabilities OpenDucktor needs: client-owned system prompt configuration, MCP/tool wiring, permission control, session lifecycle controls, streaming events, and resume/fork behavior.
+# Use Claude Agent SDK for the managed Claude runtime
 
 ## Context
 
-OpenDucktor workflow runtimes must satisfy the native runtime contract before they can run Spec, Planner, Builder, or QA sessions. That contract requires privileged role prompts, ODT workflow tool execution, read-only role safety, session lifecycle support, history behavior, and explicit capability descriptors. The previous ACP decision records the same baseline: role prompts must be privileged runtime instructions, not ordinary user prompt text.
+This decision selected the Claude Agent SDK if OpenDucktor built a managed Claude runtime. [ADR 0007](./0007-implement-claude-as-claude-agent-sdk-runtime.md) later approved that implementation.
 
-Claude Code can be integrated through multiple documented surfaces:
+An OpenDucktor workflow runtime must provide privileged role prompts, ODT tools, read-only role rules, session lifecycle, history, and capability descriptors. Claude Code offered several ways to run it: the Agent SDK, `claude -p`, an interactive terminal or IDE, and background CLI commands.
 
-- the Claude Agent SDK,
-- `claude -p` / headless CLI usage,
-- interactive Claude Code in a terminal or IDE,
-- background CLI sessions managed with commands such as `claude --bg`, `claude agents --json`, `claude logs`, `claude attach`, and `claude stop`.
+Only the Agent SDK exposed the needed controls through one documented TypeScript API. It provided system prompts, MCP setup, permission decisions, stream events, session IDs, resume, and fork.
 
-These surfaces are not equivalent for OpenDucktor. Some expose a typed programmable agent loop; some expose process streams; some require a terminal interaction model. A terminal-based integration is technically possible and introducing a new terminal surface is not a blocker by itself, but terminal capability is a separate question from whether the runtime can satisfy OpenDucktor's managed `AgentEnginePort` contract.
-
-Anthropic's current Claude plan policy also changes the trade-off. Starting June 15, 2026, subscription usage of the Claude Agent SDK, `claude -p`, and similar programmatic surfaces uses a separate Agent SDK monthly credit. Interactive Claude Code in the terminal or IDE continues to use the normal subscription usage limits. API-key usage through Claude Platform remains pay-as-you-go.
+At the time of this decision, Anthropic planned a separate Agent SDK credit model for subscription use. ADR 0007 records the later policy change.
 
 ## Decision
 
-Use the Claude Agent SDK as the primary implementation path for a first-class OpenDucktor Claude runtime.
+Use the Claude Agent SDK for a managed Claude runtime.
 
-The Claude runtime adapter should treat the SDK as the owned integration surface for:
+- Send OpenDucktor role prompts with the SDK `systemPrompt` option.
+- Add ODT tools through SDK MCP support.
+- Enforce read-only roles with `canUseTool`, `disallowedTools`, `permissionMode`, and runtime descriptors.
+- Map SDK stream messages to OpenDucktor transcript and tool events.
+- Map Claude session IDs to OpenDucktor session records.
+- Use SDK resume, fork, and session storage only when they match the OpenDucktor lifecycle contract.
 
-- injecting OpenDucktor role prompts through the SDK `systemPrompt` option,
-- exposing ODT workflow tools through SDK-supported MCP configuration or in-process MCP tooling,
-- enforcing read-only role safety through SDK permission controls such as `canUseTool`, `disallowedTools`, `permissionMode`, and OpenDucktor runtime descriptors,
-- streaming Claude events into OpenDucktor transcript and tool-call events,
-- mapping Claude session identifiers into OpenDucktor session records,
-- using SDK resume/fork/session-store capabilities only where they can be represented faithfully in OpenDucktor's session lifecycle model.
+Do not use `allowedTools` as a tool limit. In this SDK it grants approval. Use deny rules, permission decisions, and runtime blocked-tool declarations to block tools.
 
-Do not use `allowedTools` as a restriction mechanism. The SDK documents `allowedTools` as auto-approval, not as a tool allowlist. Tool blocking must use deny rules, custom permission decisions, and runtime-owned blocked tool declarations.
+Use an OpenDucktor system prompt for managed workflow sessions. The `claude_code` preset targets a human-led CLI or IDE. A future test can assess the preset with appended instructions, but it is not the default.
 
-Prefer an OpenDucktor-authored system prompt for managed workflow sessions. Anthropic's system prompt guidance says the `claude_code` preset is best for CLI or IDE-like coding tools where a human watches and steers the work, while a custom prompt is appropriate for agents with a different surface, identity, or permission model. OpenDucktor's role-based workflow runtime has a different surface and permission model from the stock Claude Code terminal, so the adapter should not assume the Claude Code preset is sufficient. The preset with `append` may still be evaluated experimentally, but it is not the default architectural decision.
+Treat interactive terminal use as a separate product path. It must meet the same lifecycle, history, permission, and event contracts before it can act as the managed runtime.
 
-Treat terminal Claude Code integration as a separate capability path. OpenDucktor may later offer a terminal-backed Claude workflow or launcher that uses interactive Claude Code with ODT MCP configuration and prompt files. That path is technically possible, and it may be valuable for users who want subscription-limit interactive usage, but it should not be conflated with the managed SDK runtime unless it can expose the same structured lifecycle, history, permission, and event semantics.
+## Options we rejected
 
-## Considered Options
-
-- Claude Agent SDK. Accepted because it exposes the most complete documented programmable surface: system prompt configuration, MCP server configuration, custom permission callbacks, deny rules, sessions, resume/fork controls, streaming messages, session storage, model selection, and optional bundled Claude Code binary resolution.
-- `claude -p`. Rejected as the primary path because it is a CLI process interface over programmatic usage. It can technically support system prompt flags, JSON or streaming JSON output, MCP config, permission-prompt tooling, resume, fork, and model selection, but it would make OpenDucktor own process lifecycle, stream parsing, pending-permission routing, and error mapping that the SDK exposes directly.
-- Interactive Claude Code in a terminal. Rejected as the managed-runtime path, not as a capability. It can technically run Claude Code with system prompt files, MCP config, tool flags, and normal subscription interactive usage, but OpenDucktor would need a terminal or PTY-backed runtime model to represent it honestly. It should be considered a separate terminal integration or launch workflow.
-- Claude CLI background sessions. Rejected as the managed-runtime path because the documented CLI management commands provide session start/list/log/attach/stop controls, not the full structured `AgentEnginePort` contract. They remain useful evidence for a future terminal/background workflow.
-- Direct Anthropic Messages API. Rejected as a Claude Code integration because it would require OpenDucktor to build its own coding-agent loop, tool policy, file editing, shell execution, session model, and MCP behavior instead of integrating Claude Code's documented agent runtime.
+- `claude -p` as the main path. OpenDucktor would have to own process control, stream parsing, permission routing, and error mapping.
+- Interactive Claude Code as the managed runtime. A terminal does not provide the full `AgentEnginePort` contract.
+- Claude background CLI sessions. Their start, list, log, attach, and stop commands do not provide the full runtime contract.
+- The Anthropic Messages API. OpenDucktor would have to build the coding-agent loop, tools, session model, and MCP support.
 
 ## Consequences
 
-The Claude runtime should be designed like the existing OpenCode and Codex runtimes: contracts first, descriptor first, then host starter and adapter behavior. It needs its own `runtimeKind`, capability descriptor, native mutating-tool blocklist, workflow tool alias map, runtime binary or SDK package resolution, and explicit auth/billing configuration.
+A Claude adapter needs its own runtime kind, descriptor, mutating-tool blocklist, tool aliases, SDK or binary discovery, and auth setup.
 
-The subscription policy must be visible in product and setup decisions. A managed SDK runtime is programmatic usage and is affected by the June 15, 2026 Agent SDK credit model for subscription users. For shared production automation or predictable billing, Claude Platform API-key usage is the safer default.
+Bun single-executable packages must extract the SDK's native Claude Code binary to a real path and pass it as `pathToClaudeCodeExecutable`.
 
-The SDK's bundled native Claude Code binary is useful for local setup, but packaging must be handled deliberately. The SDK documentation notes that Bun single-executable packaging needs the native binary extracted to a real path and passed as `pathToClaudeCodeExecutable`.
+Keep a capability disabled until the adapter proves that it can map the native feature without losing data or adding a fallback. This rule applies to approvals, questions, history, todos, diff, file status, slash commands, and subagents.
 
-Capability claims must stay conservative until verified against the SDK. In particular, approvals, questions, history fidelity, todos, diff, file status, slash commands, and subagents should only be marked supported when the adapter can expose them through OpenDucktor's existing contracts without flattening or fallback behavior.
-
-Relevant evidence:
+## References
 
 - [Claude Agent SDK TypeScript reference](https://code.claude.com/docs/en/agent-sdk/typescript)
 - [Claude Agent SDK system prompt guidance](https://code.claude.com/docs/en/agent-sdk/modifying-system-prompts)
 - [Claude CLI reference](https://code.claude.com/docs/en/cli-reference)
 - [Claude headless mode documentation](https://code.claude.com/docs/en/headless)
-- [Claude plan policy for Agent SDK usage](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
-- [OpenDucktor runtime integration guide](../runtime-integration-guide.md)
-- [ADR 0001: Do Not Adopt ACP Without Client-Owned System Prompts](./0001-do-not-adopt-acp-without-client-owned-system-prompts.md)
+- [Claude plan policy](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
+- [Runtime integration guide](../runtime-integration-guide.md)
+- [ADR 0001](./0001-do-not-adopt-acp-without-client-owned-system-prompts.md)

--- a/docs/adr/0005-use-codex-app-server-fuzzy-file-search-for-file-references.md
+++ b/docs/adr/0005-use-codex-app-server-fuzzy-file-search-for-file-references.md
@@ -3,48 +3,41 @@ status: accepted
 date: 2026-06-03
 ---
 
-# Use Codex App-Server Fuzzy File Search for File References
-
-OpenDucktor will implement Codex file-reference autocomplete through Codex app-server `fuzzyFileSearch`, not through a new host-owned recursive file search. File search is a runtime-owned prompt-input capability in OpenDucktor, and Codex now exposes a native app-server search surface that can return file and directory matches fast enough for composer autocomplete while preserving runtime-specific prompt translation inside the Codex adapter.
+# Use Codex app-server fuzzy file search for file references
 
 ## Context
 
-The Agent Chat composer already models file references as structured prompt parts, and the runtime integration guide already treats file search as a runtime-owned optional prompt-input surface. OpenCode satisfies that surface through its native `find.files` API. Codex differs from OpenCode because it does not expose the same SDK API shape, but current Codex app-server does expose `fuzzyFileSearch` plus experimental search-session requests and notifications.
+The Agent Chat composer sends file references as structured prompt parts. File search belongs to the selected runtime. OpenCode uses its `find.files` API. Codex app-server provides `fuzzyFileSearch` and search-session messages.
 
-OpenDucktor also has host filesystem APIs used when users open repositories, but that surface is directory-browsing oriented and belongs to repository selection. Reworking it into a recursive, cached, fuzzy composer search would duplicate runtime search behavior, add another indexing owner, and risk diverging from Codex's own file-reference semantics.
+The host also has file APIs for repository selection. Those APIs browse directories. Turning them into recursive fuzzy search would create a second index and could differ from Codex file-reference rules.
 
 ## Decision
 
-Use Codex app-server `fuzzyFileSearch` as the Codex adapter's file search implementation.
+Use Codex app-server `fuzzyFileSearch` in `CodexAppServerAdapter.searchFiles`.
 
-Concretely:
+- Add `fuzzyFileSearch` to the protocol contract, host allowlist, and app-server client.
+- Resolve the active Codex runtime connection and use its working directory as the search root.
+- Map file and directory matches to `AgentFileSearchResult`.
+- Set `promptInput.supportsFileSearch` only when the adapter can search and encode `file_reference` and `folder_reference` prompt parts.
+- Keep the first version as one request and one response so it matches `searchFiles(query)`.
+- Add search sessions only if tests in large repositories show that the one-shot request is too slow.
 
-- add `fuzzyFileSearch` to the Codex app-server protocol contract, host method allowlist, and Codex app-server client,
-- implement `CodexAppServerAdapter.searchFiles` by resolving the active Codex runtime connection and calling `fuzzyFileSearch` with the current working directory as the search root,
-- map Codex file and directory results into core `AgentFileSearchResult` values,
-- enable Codex `promptInput.supportsFileSearch` only when the adapter can both search files and encode structured `file_reference` and `folder_reference` prompt parts,
-- keep the first implementation request/response shaped so it fits the existing composer `searchFiles(query)` contract,
-- treat Codex search-session APIs as a follow-up optimization if measured latency in large repositories is not good enough.
+If Codex search is missing or fails, return an adapter error. Keep the descriptor capability off until the method works. Do not fall back to host file search.
 
-Do not silently fall back to host-owned file search when Codex search is unavailable. A missing or failing Codex search method should produce an actionable adapter/runtime error, or the descriptor should keep file search disabled until the capability is actually implemented.
+## Options we rejected
 
-## Considered Options
-
-- Codex app-server `fuzzyFileSearch`. Accepted because it is Codex-native, uses Codex's own fuzzy file-search implementation, supports file and directory match types, and keeps runtime-specific behavior behind the Codex adapter.
-- Codex app-server search sessions from the first slice. Rejected for the initial implementation because the current OpenDucktor composer contract is request/response based. Search sessions remain the right next step if autocomplete latency needs streaming or incremental updates.
-- New OpenDucktor host-owned fuzzy file search. Rejected as the Codex default because it would duplicate runtime-owned search, require a new indexing and invalidation owner, and conflate repository-opening filesystem browsing with composer file-reference autocomplete.
-- Reuse OpenDucktor's existing repository-open filesystem search. Rejected because that API is not a recursive, ranked, repo-scoped autocomplete surface.
-- Reuse OpenCode `find.files`. Rejected because it is an OpenCode-specific API shape and Codex does not expose it.
+- Codex search sessions in the first version. The current composer expects one response.
+- A new host-owned fuzzy search. It would duplicate runtime search and need its own index rules.
+- The repository-open file browser. It is not recursive, ranked autocomplete.
+- OpenCode `find.files`. Codex does not provide that API.
 
 ## Consequences
 
-Codex file-reference work should be scoped to the existing runtime boundary: contracts first, then host request allowlisting, Codex client support, adapter mapping, runtime descriptor enablement, and focused tests across those seams.
+The change order is contracts, host allowlist, Codex client, adapter mapping, descriptor, and focused tests. The frontend keeps its shared file-search path and descriptor check.
 
-The frontend should keep using the shared composer file-search path and runtime descriptor gating. It should not grow Codex-specific filesystem traversal logic.
+If the one-shot call is too slow, extend the shared contract for Codex search sessions. Start a session when `@` search opens, update it with the query, handle session updates and completion, then stop it when search closes or runtime context changes.
 
-If the one-shot `fuzzyFileSearch` path is too slow in real repositories, the next architectural slice is to extend OpenDucktor's composer/search contract for Codex app-server search sessions: start one session when the user enters an `@` search, update it on query changes, consume `fuzzyFileSearch/sessionUpdated` and `fuzzyFileSearch/sessionCompleted`, and stop it when the autocomplete closes or the runtime context changes.
-
-Relevant references:
+## References
 
 - [Runtime integration guide](../runtime-integration-guide.md)
-- [ADR 0003: Use Project-Native Agent UI Composition](./0003-use-project-native-agent-ui-composition.md)
+- [ADR 0003](./0003-use-project-native-agent-ui-composition.md)

--- a/docs/adr/0006-use-sqlite-task-store-with-workspace-scoped-database-path.md
+++ b/docs/adr/0006-use-sqlite-task-store-with-workspace-scoped-database-path.md
@@ -16,7 +16,8 @@ Use a one-time migration script. It reads Beads through the `bd` CLI and writes 
 - Treat Beads and Dolt as read-only. If the old store cannot be read, stop with a migration error. Do not start, repair, initialize, or restore it.
 - Parse and validate the full Beads snapshot before the SQLite write.
 - Preserve all Beads task data that OpenDucktor owns, including document history.
-- Keep each task ID unchanged. Generate new SQLite task IDs in the same format.
+- Keep each Beads task ID as the SQLite task ID.
+- Generate IDs in the same format only for tasks created after the migration.
 - Write all rows in one SQLite transaction.
 - Insert into an existing `database.sqlite`. The native task store owns database creation and schema setup.
 - Store clean OpenDucktor data. Do not add a catch-all legacy payload table.

--- a/docs/adr/0006-use-sqlite-task-store-with-workspace-scoped-database-path.md
+++ b/docs/adr/0006-use-sqlite-task-store-with-workspace-scoped-database-path.md
@@ -3,28 +3,28 @@ status: accepted
 date: 2026-06-10
 ---
 
-# Use SQLite Task Store With Workspace-Scoped Database Path
+# Use a SQLite task store with a workspace-scoped database path
 
-OpenDucktor will replace the Beads/Dolt-backed Task Store with a SQLite-backed Task Store whose database lives at `<config-root>/task-stores/<workspaceId>/database.sqlite`. The path uses the technical `workspaceId` instead of a repo-derived id so task storage follows OpenDucktor's configured workspace identity, while invalid workspace ids fail fast rather than being silently normalized.
+## Decision
 
-The Beads-to-SQLite migration will be a standalone one-time script that reads Beads through the `bd` CLI and writes SQLite directly. The script deliberately avoids importing Beads adapter internals so the Beads/Dolt production code can be removed cleanly after migration.
+Replace the Beads and Dolt task store with SQLite at `<config-root>/task-stores/<workspaceId>/database.sqlite`. Use the configured `workspaceId`. Reject an invalid ID. Do not derive or normalize it from the repository.
 
-The migration script is read-only toward Beads/Dolt. It will not start, repair, initialize, or restore the legacy store; unreadable legacy storage is an explicit migration precondition failure.
+Use a one-time migration script. It reads Beads through the `bd` CLI and writes SQLite. It does not import the old adapter code.
 
-The migration must be lossless for the Beads task data OpenDucktor owns and models. SQLite will preserve the current OpenDucktor-used Beads task schema, including historical document entries that the current OpenDucktor UI treats as latest-only.
+## Migration rules
 
-SQLite is the clean OpenDucktor task-store model, not a raw Beads archive. We will keep the old Beads database outside the new runtime path for a while instead of polluting SQLite with catch-all legacy payload tables.
+- Treat Beads and Dolt as read-only. If the old store cannot be read, stop with a migration error. Do not start, repair, initialize, or restore it.
+- Parse and validate the full Beads snapshot before the SQLite write.
+- Preserve all Beads task data that OpenDucktor owns, including document history.
+- Keep each task ID unchanged. Generate new SQLite task IDs in the same format.
+- Write all rows in one SQLite transaction.
+- Insert into an existing `database.sqlite`. The native task store owns database creation and schema setup.
+- Store clean OpenDucktor data. Do not add a catch-all legacy payload table.
+- Decode old document data and store plain Markdown with an explicit format field.
+- Preserve timestamp instants as Unix epoch milliseconds.
 
-Migrated tasks keep their existing Beads ids exactly, and the native SQLite Task Store will continue generating new task ids in the same format. This preserves task references across MCP workflows, documents, transcripts, and existing user habits while allowing the storage engine to change.
+## Data model
 
-The one-time migration parses the complete Beads snapshot before writing SQLite data and keeps validation to the minimum needed for a correct insert into the clean SQLite task-store schema. Unexpected or broken Beads data is a migration error, and persistence happens in one SQLite transaction so the new database is never partially migrated.
+Keep task-scoped data on the task row. Store task documents in a separate table because they can be large and can have history. Do not add separate label, agent-session, pull request, or direct merge tables as part of this migration.
 
-The migration script is insert-only. SQLite database creation and schema setup belong to the native SQLite Task Store, so the migration fails fast when the target `database.sqlite` does not already exist.
-
-The first SQLite task-store schema stays intentionally small: task-scoped data remains inline on the task row, while Task Documents move to a dedicated table because they are larger and can have history. We are not introducing separate label, agent-session, Pull Request, or Direct Merge tables during the migration.
-
-Task Documents are stored in SQLite as plain markdown text for now, with an explicit format field reserved for future encodings. The one-time migration decodes Beads' stored document encoding instead of carrying the legacy gzip/base64 representation forward.
-
-Task and document timestamps preserve the same instant from Beads while using SQLite-friendly integer Unix epoch milliseconds instead of retaining source timestamp strings.
-
-After the one-time migration, OpenDucktor runtime code becomes SQLite-only. Beads/Dolt production adapters, lifecycle code, diagnostics, tool discovery, and Electron sidecars are removed instead of kept as a fallback path.
+Keep the old Beads database outside the new runtime path for a limited time. After migration, remove Beads and Dolt adapters, lifecycle code, checks, tool discovery, and Electron sidecars. Runtime code uses SQLite only.

--- a/docs/adr/0007-implement-claude-as-claude-agent-sdk-runtime.md
+++ b/docs/adr/0007-implement-claude-as-claude-agent-sdk-runtime.md
@@ -3,24 +3,29 @@ status: accepted
 date: 2026-06-25
 ---
 
-# Implement Claude as a Claude Agent SDK Runtime
+# Implement Claude as a Claude Agent SDK runtime
 
-OpenDucktor will implement Claude as a first-class Runtime through the official Claude Agent SDK. This supersedes [ADR 0004](./0004-use-claude-agent-sdk-for-claude-runtime.md): the previous decision treated the SDK as the right path if OpenDucktor later built a managed Claude Runtime, while this decision says to build that Runtime. Anthropic has paused the planned June 15, 2026 separate Agent SDK credit model, so subscription-authenticated Claude Agent SDK usage, `claude -p`, Claude Code GitHub Actions, and third-party Agent SDK app usage currently still draw from subscription usage limits; the managed Runtime choice should therefore be based on integration control, where the SDK is the better surface because it gives OpenDucktor structured control over system prompts, MCP servers, permission decisions, streaming messages, settings sources, and session lifecycle.
+## Decision
 
-## Considered Options
+Implement Claude as a runtime with the official Claude Agent SDK. This decision supersedes [ADR 0004](./0004-use-claude-agent-sdk-for-claude-runtime.md), which chose the SDK but did not approve the implementation.
 
-- Claude Agent SDK. Accepted because it is the documented programmable Claude Code surface for TypeScript/Python applications and exposes the controls OpenDucktor needs for a managed Runtime.
-- `claude -p`. Rejected as the primary Runtime path because it has the same current subscription-usage treatment as SDK usage, while making OpenDucktor own process lifecycle, stream parsing, pending-permission routing, and error mapping that the SDK exposes directly.
-- Interactive Claude Code in a terminal or IDE. Rejected as the managed Runtime path because it still uses normal subscription limits but does not expose OpenDucktor's structured Runtime contract. It can remain a separate launcher or terminal integration later.
+Anthropic paused its planned June 15, 2026 Agent SDK credit model. At the date of this decision, subscription-authenticated SDK use, `claude -p`, Claude Code GitHub Actions, and third-party SDK apps use subscription limits. Choose the SDK for its runtime controls, not for a billing assumption. It gives OpenDucktor structured system prompts, MCP servers, permission decisions, stream messages, settings sources, and session lifecycle.
+
+## Options we rejected
+
+- `claude -p` as the main runtime. It has the same subscription treatment, but OpenDucktor would own process control, stream parsing, permission routing, and error mapping.
+- Interactive Claude Code as the managed runtime. It does not expose the structured OpenDucktor runtime contract. A later terminal launcher can remain separate.
 
 ## Consequences
 
-Claude Runtime implementation work should add a `claude` Runtime Descriptor, host starter, Runtime Adapter, permission policy, MCP wiring, settings/auth/billing setup, and focused contract tests across the same runtime seams used by OpenCode and Codex. Product setup must link users to Anthropic's current plan policy instead of hard-coding quota assumptions, because subscription-authenticated SDK billing and usage treatment has already changed direction once. Shared production automation should prefer Claude Platform API-key billing when predictable pay-as-you-go usage is more important than using a user's Claude subscription limits.
+Add a `claude` descriptor, host starter, runtime adapter, permission policy, MCP setup, settings, auth, billing guidance, and focused contract tests. Use the same runtime boundaries as OpenCode and Codex.
 
-Relevant references:
+Link users to Anthropic's current plan policy instead of hard-coding quota rules. For shared automation, prefer Claude Platform API-key billing when fixed pay-as-you-go use matters more than a user's subscription limits.
 
-- [ADR 0004: Use Claude Agent SDK for the Managed Claude Runtime](./0004-use-claude-agent-sdk-for-claude-runtime.md)
+## References
+
+- [ADR 0004](./0004-use-claude-agent-sdk-for-claude-runtime.md)
 - [Claude Agent SDK TypeScript reference](https://docs.anthropic.com/en/docs/claude-code/sdk/sdk-typescript)
 - [Run Claude Code programmatically](https://docs.anthropic.com/en/docs/claude-code/headless)
-- [Claude plan policy for Agent SDK usage](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
-- [OpenDucktor runtime integration guide](../runtime-integration-guide.md)
+- [Claude plan policy](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
+- [Runtime integration guide](../runtime-integration-guide.md)

--- a/docs/agent-orchestrator-module-map.md
+++ b/docs/agent-orchestrator-module-map.md
@@ -1,992 +1,298 @@
-# Agent Orchestrator Module Map
-
-This is the maintainer-facing map for
-`packages/frontend/src/state/operations/agent-orchestrator`.
+# Agent orchestrator module map
 
-The current design is intentionally small: persisted task records identify workflow
-sessions, the host-owned live-session service publishes one ordered initial snapshot
-plus deltas, transcript history is loaded only for the session that needs it, and the
-selected-session UI derives loading state from one selected route.
-
-Workspace records are a UI/app-state concern. Session modules below
-`useAgentOrchestratorOperations` receive the primitive identity they need:
-`workspaceRepoPath` for repo-scoped session state, and `workspaceId` only when
-prompt/runtime startup code needs repository configuration. Do not pass
-`ActiveWorkspace` into transcript-state, session action, or read-model modules.
-
-## Owners
-
-### Agent Session Store
-
-Files:
-
-- `packages/frontend/src/state/agent-sessions-store.ts`
-- `hooks/use-orchestrator-session-state.ts`
-
-Owns:
-
-- the current in-memory `AgentSessionState` collection for the active workspace
-- derived session summaries and the activity snapshot
-- notifying React subscribers when the collection changes
-
-Invariant: `AgentSessionsStore` is the renderer projection of the latest committed
-host snapshot and deltas. It is the only renderer collection used by UI consumers,
-but it is not the authority for runtime activity, pending input, or context usage.
-Hooks should expose the store, not duplicate collection getters.
-Transient event state is held in explicit named refs; do not reintroduce a
-generic mutable-state bridge that hides which concept owns which value.
-`useAgentOrchestratorOperations` owns the session commit callback that writes to
-`AgentSessionsStore` and optionally persists durable workflow records. Do not
-split this into a single-use mutation hook.
-Repo session read-model refreshes merge through one session store commit; the
-store passes the current collection into that commit and remains the only owner
-of the collection.
-Session history loading, session preparation, and start/reuse policies should read
-one current session through the store's selected-session reader; they must not
-inspect or request full collection snapshots.
-UI start flows such as Kanban receive session summaries as render snapshots;
-they must not create mutable session mirrors to make callbacks look stable.
-
-Must not own:
-
-- persisted task session records
-- host live-snapshot authority
-- selected-session history-load policy
-- live runtime routes
-
-### Session Activity State
-
-Files:
-
-- `packages/frontend/src/types/agent-session-activity.ts`
-- `packages/frontend/src/lib/agent-session-activity-state.ts`
-- `packages/frontend/src/lib/agent-session-waiting-input.ts`
-
-Owns:
-
-- the shared `waiting_input`, `starting`, `running`, `idle`, `stopped`, and `error`
-  UI activity vocabulary
-- deriving product-facing session activity from raw status and pending input
-- the precedence rule that pending questions or approvals beat raw starting/running/idle status
-
-Invariant: UI surfaces such as Agent Studio tabs, Kanban activity, active-session
-sidebars, selected-session action state, and transcript surfaces must use this
-owner instead of recomputing raw status plus pending-input checks. Session
-selection receives full `AgentSessionSummary` objects; it must not accept
-persisted task-session records or optional pending-input fields.
-`AgentSessionsStore` activity snapshots publish this derived `activityState`
-directly; shell/activity read models must not receive pending-input booleans and
-rebuild the precedence rule.
-Session summaries publish `activityState` plus pending-input counts only; the
-pending approval/question payloads stay on the live `AgentSessionState`.
-
-Must not own:
-
-- runtime-specific live-state classification
-- event-stream pending-input mutation
-- durable task-session record reconstruction
-
-### Host Live Session Projection
-
-Files:
-
-- `session-read-model/agent-session-live-projection.ts`
-- `session-read-model/agent-session-workflow-records.ts`
-- `session-read-model/source-session-loader.ts`
-- `session-read-model/use-task-session-records.ts`
-- `hooks/use-repo-session-read-model.ts`
-
-Owns:
-
-- projecting runtime metadata onto roots registered by OpenDucktor and descendants observed through their event lineage
-- applying workflow ownership only from durable task session records or an explicit local start registration
-
-Invariant: live runtime state cannot create a root session. A root enters the renderer collection only through an OpenDucktor start registration or a durable task session record. Live state may update that root and add a descendant only when its parent already exists in the collection.
-
-- consuming query-backed durable task session records for the active task set
-- observing the generic host live-event transport before requesting a repository refresh
-- accepting the repository snapshot as the first item for each initial load or reconnect
-- merging durable records with normalized live snapshots in one collection commit
-- applying ordered live upserts, removals, transcript events, and catalog invalidations
-- projecting parent/child pending input from normalized host relationships
-
-Invariant: the shared host-event listener must exist before `agentSessionLiveRefresh`.
-The browser uses one channel-tagged SSE connection for all host event families;
-Electron uses its existing generic host-event IPC envelope. Live-session observers
-filter by repository, ignore replayed deltas while awaiting a refresh snapshot,
-and accept later refresh snapshots as authoritative collection resets. No renderer
-or transport attachment identity is required.
-Each host snapshot is committed once so session rows, activity, pending
-input, context usage, and sidebar counters all derive from the same collection.
-The renderer must not keep observer registries, snapshot/event overlap counters,
-pending-input tombstones, or runtime-specific recovery caches.
-The per-task session-list query is the only frontend cache for persisted session
-records. Do not add a separate bulk session-record cache; startup read-model
-loads, Kanban history summaries, and session upserts must observe the same
-per-task query keys.
-Start/reuse preparation that needs a missing source session must use
-`source-session-loader.ts` to load that exact durable record and read its generic
-host live snapshot. It must not load transcript history or reload the entire repo
-read model to recover one source session.
-
-Must not own:
-
-- model catalog, slash commands, file search, diffs, or other active-session reads
-- runtime startup policy
-- page navigation state
-- history source selection or history loading
-- runtime-specific protocol selection or permission/question polling
-
-### Runtime Readiness
-
-Files:
-
-- `packages/frontend/src/state/queries/checks.ts`
-- `packages/frontend/src/state/operations/workspace/use-checks.ts`
-- `packages/frontend/src/state/operations/workspace/use-repo-runtime-health.ts`
-- `packages/frontend/src/lib/repo-runtime-health.ts`
-- `packages/frontend/src/lib/repo-runtime-readiness.ts`
-- `packages/frontend/src/lib/use-repo-runtime-readiness.ts`
-- `packages/host/src/application/runtimes/runtime-orchestrator-service.ts`
-
-Owns:
-
-- reading runtime health for the active repository through TanStack Query
-- asking the host for `repoRuntimeHealth`
-- interpreting runtime health into runtime-starting, ready, blocked, and error readiness states
-
-`use-repo-runtime-health.ts` owns the frontend runtime-health query and refresh path. `RepoRuntimeHealthContext` is the only frontend context that exposes runtime health. `use-checks.ts` may consume that result for diagnostics toasts and manual diagnostics refresh, but `ChecksStateContext` must not expose runtime health or become a second runtime readiness surface.
-
-Invariant: app lifecycle owns repository-runtime startup through the explicit
-runtime ensure path. Runtime diagnostics must read status-only health and must
-not start missing runtimes. Runtime health is live process state, so app remounts
-may refresh it, but it must not poll.
-
-Invariant: `not_started` is a passive runtime observation only. UI controlled by
-the automatic repository runtime-health path must treat it as a pending startup
-state, not as a terminal selected-session or diagnostics blocker.
-
-Must not own:
-
-- session start/send runtime preparation
-- selected-session history loading
-- transcript rendering state
-- runtime route resolution for a concrete session action
-
-### Session History Loading
-
-Files:
-
-- `history/session-history-loader.ts`
-- `history/use-selected-session-history-load.ts`
-- `support/session-history-chat-messages.ts`
-- `support/session-prompt.ts`
-- `support/subagent-messages.ts`
-
-Owns:
-
-- marking, applying, failing, and resetting session history load state
-- resolving the selected-session history-load target from selected session,
-  history state, and runtime readiness
-- building transient runtime prompt context through the shared prompt helper and
-  passing it to history loads without storing it in session state
-- projecting runtime history into transcript messages without erasing live messages
-- resolving subagent row identity when runtime history and live events expose
-  separate part-scoped and session-scoped correlation keys
-
-Invariant: history loading is session-scoped and policy-driven. The
-selected-session baseline effect or a session action asks to load one concrete
-session route; the history loader marks, applies, fails, or resets that concrete
-load. The caller that claims and completes a load receives the loaded session;
-duplicate callers receive the current session snapshot without starting another
-request. The repo projection never bulk-loads transcripts.
-The loader receives a store-backed `readSessionSnapshot` dependency and must not
-inspect or request full collection snapshots.
-Selected-session history load effects are fire-and-forget UI effects, but they
-must run through the orchestrator async side-effect runner with session identity
-tags. Do not discard history-load promises with raw `void` calls.
-They must request runtime history for any selected session whose history is still
-`not_requested`, even when live stream messages are already visible. A live tail
-does not prove the historical transcript has hydrated after app reload; loaded
-history merges with any current messages through the history merge module.
-History must not discover pending input, change runtime activity, derive context
-usage, drain runtime events, or trigger an implicit runtime resume.
-
-`support/session-history-chat-messages.ts` owns history-message projection only.
-It must not read or write durable session records.
-`support/subagent-messages.ts` owns subagent row formatting, status merge, and
-part/session correlation matching. Event handlers and history merge must call
-that helper instead of growing their own subagent matching rules.
-
-Invariant: transcript storage is owned by the session message helpers. UI chat
-models receive a `SessionMessagesState` handle; raw message arrays may be
-normalized at boundaries but must not leak into transcript rendering.
-
-### Selected Session Context Loading
-
-Files:
-
-- `history/use-selected-session-context-load.ts`
-- `packages/frontend/src/features/agent-chat-composer/context-usage/use-selected-session-context-usage.ts`
-
-Owns:
-
-- requesting generic host context loading when the selected live session has no
-  context usage and the runtime is ready
-- leaving current context usage on the live snapshot fast path
-
-Invariant: context recovery is explicit and session-scoped. The frontend does not
-know whether an adapter performs a native read or a Codex resume with turns. A
-context failure is reported through the operation error path and must not trigger
-history probes, polling, or recovery for every live session.
-
-### Durable Session Records
-
-Files:
-
-- `support/persistence.ts`
-- `support/session-cache-effects.ts`
-- `support/session-invariants.ts`
-
-Owns:
-
-- converting workflow session state to durable task-store session records
-- converting durable task-store session records back to unloaded local session
-  shells
-- writing durable records through the host port and the per-task session-list
-  query cache for one active repository
-- fail-fast workspace/session invariants shared by action and persistence
-  boundaries
-
-Must not own:
-
-- runtime history projection
-- transcript rendering
-- pending permissions or questions
-- system prompt display
-
-Invariant: durable session writes require an active `workspaceRepoPath`.
-Missing repository identity is a broken caller invariant, not an empty workspace
-case; do not silently drop the host write or query update.
-
-### Transcript Event Stream
-
-Files:
-
-- `events/session-transcript-events.ts`
-- `events/session-event-types.ts`
-- `events/session-lifecycle.ts`
-- `events/session-parts.ts`
-- `events/session-tool-parts.ts`
-- `support/session-turn-metadata.ts`
-- `support/session-turn-timing.ts`
-
-Owns:
-
-- applying normalized transcript events to loaded sessions
-- routing every transcript event by its normalized session ref
-- batching and flushing transcript stream events per session
-- routing runtime todo events into the selected-session todos query owner
-- active-turn transcript anchors and duration timing
-
-Invariant: runtime activity, pending approvals/questions, context usage, and
-session removal are live-state envelopes, not transcript events. Their only
-renderer mutation path is `agent-session-live-projection.ts`.
-Invariant: the transcript event target has exactly one owner:
-`SessionTranscriptEventContext.session`.
-`store`, `turn`, and `todos` are capability groups only; they must not duplicate
-session identity, key, external session id, or selected-session runtime-data fields.
-Invariant: transcript content belongs to `session.messages` only. Do not add
-parallel assistant/reasoning draft state to `AgentSessionState` or event context.
-Invariant: active-turn transcript anchors live behind
-`SessionTurnMetadata`. Import turn-metadata APIs from
-`support/session-turn-metadata.ts`. Transcript handlers may record/read/clear that
-owner, but must not pass raw per-session maps or refs through transcript-event
-boundaries.
-Invariant: turn timing lives behind `SessionTurnTiming`. The orchestrator hook
-owns cross-store cleanup by calling the concrete owners directly; do not
-reintroduce an aggregate transient-state module or barrel.
-Invariant: event batching is only a local coalescing/throttling policy for noisy
-runtime stream events. It must not grow into session reconciliation, history
-loading, polling, or runtime readiness logic.
-
-### Assistant Turn Timing
-
-Files:
-
-- `hooks/use-orchestrator-session-state.ts`
-- `support/assistant-turn-duration.ts`
-- `support/session-turn-timing.ts`
-
-Owns:
-
-- user-message anchor timestamps for pending sends and permission/question replies
-- assistant activity start timestamps from runtime status and part events
-- previous assistant completion timestamps used to bound duration calculations
-- duration resolution for assistant transcript metadata
-
-Invariant: timing state lives behind the `SessionTurnTiming` store. Do not expose
-the raw map, reintroduce a React timing hook, add proxy bridges, or duplicate
-timestamp stores in event handlers.
-
-### Runtime Session References
-
-File:
-
-- `support/session-runtime-ref.ts`
-
-Owns two shapes:
-
-- route refs for generic host control and history: `externalSessionId`, `repoPath`,
-  `runtimeKind`, `workingDirectory`
-- context refs for send/reply: route fields plus durable workflow context such as
-  `taskId`, `role`, optional model, and optional purpose
-
-Do not pass prompts, task roles, models, runtime IDs, or native request IDs into
-the generic live observation contract.
-
-### Existing Session Send Preparation
-
-File:
-
-- `handlers/prepare-session-send.ts`
-
-Owns:
-
-- ensuring the configured runtime process exists for an existing idle/stopped
-  session before sending
-- computing transient system prompt context for the next runtime send
-
-It does not attach live observation, read live snapshots, resume runtime sessions,
-or classify pending input. The host live-state service owns observation for the
-runtime lifetime; visible pending input comes from its ordered snapshot/deltas.
-
-### Pending Input Projection and Replies
-
-Files:
-
-- `session-read-model/agent-session-live-projection.ts`
-- `session-read-model/pending-approval-policy.ts`
-- `handlers/pending-input-actions.ts`
-
-Owns:
-
-- projecting normalized pending input from host snapshots and deltas
-- projecting pending input from unmaterialized child sessions onto the
-  materialized parent session when the host supplies a parent relationship
-- applying the generic read-only approval policy
-- sending opaque approval/question identities back through generic host commands
-- keeping runtime-owned pending permissions/questions transient
-
-Do not add overlay maps, persisted pending-input records, or interpret opaque
-request IDs in frontend code. Runtime-specific identifiers and reply routing
-remain private to the host adapter.
-
-### Selected Session View
-
-Files:
-
-- `pages/agents/agents-page-selection.ts`
-- `pages/agents/use-agent-studio-selection-controller.ts`
-- `pages/agents/selected-session/use-agent-studio-selected-session-view.ts`
-- `pages/agents/selected-session/selected-session-context.ts`
-- `components/features/agents/agent-chat/use-agent-chat-surface-model.ts`
-- `transcript/session-transcript-state.ts`
-
-Owns:
-
-- resolving one selected candidate for the visible task
-- deriving the selected route from that candidate
-- deciding whether the transcript can render, should show runtime loading, should
-  show session loading, or failed to load
-
-Invariant: live summaries and persisted records must be combined before selection.
-Do not resolve live and persisted selections in separate branches.
-
-Invariant: `selected-session-view-projection.ts` owns selected-session
-projection. It walks the selected facts once and returns selected activity,
-selected model, and final transcript state. It also owns the helper that derives
-the selected runtime-readiness target for the hook. Runtime readiness-to-display
-helpers stay in the transcript-state module. History loading policy and
-runtime-data query gating live in their owner modules, not in the transcript
-state model. Page route/task switching is orchestration state and must not be
-stored in the transcript state model. Do not mirror runtime readiness on it.
-Readonly transcript history is owned by
-`readonly-transcript/use-runtime-transcript-session-history.ts`. That hook
-chooses exactly one path: matching live session, runtime history read, or empty
-reason, and returns final transcript state for that path. It also owns the query
-enablement boundary because it has the complete facts: open state, target
-identity, repo path, live session, and runtime readiness. Do not recreate a
-separate source resolver or source-shaped state machine.
-Readonly transcript presentation state is derived in
-`readonly-transcript/runtime-transcript-surface-state.ts`; hooks must not inline
-empty/loading/error policy. Displayed-session working state stays with the hook
-that passes the session into the shared chat model.
-Agent chat renderable-thread projection is derived once in
-`agent-chat/agent-chat-thread-state.ts`. That projection owns the renderable
-thread session, active session key, transcript notice copy, and reset-window
-policy; surface hooks and rendering components must not reinterpret transcript
-state directly or pass a separate transcript-pending boolean beside transcript
-state.
-Agent chat types must reference the canonical selected-session transcript state and
-repo-runtime readiness contracts instead of declaring local lookalike shapes.
-Selected-session history loading is owned by
-`history/use-selected-session-history-load.ts` plus
-`AgentSessionState.historyLoadState`. That hook starts a history load when the
-selected session exists, its history has not been requested, and the runtime is
-ready. Callers pass the loaded session plus runtime-readiness state; they must
-not build a separate history-load target or duplicate the `historyLoadState`
-policy. The selected-session view is passive: it returns selected session facts,
-runtime readiness, runtime data, and transcript state, but it must not call
-runtime/session operations. A live tail is not a complete transcript baseline:
-transcript state must not render session messages until the session history state
-is `loaded`, except that an already-renderable transcript remains visible after a
-history-load failure. Transcript state is display-only: it renders runtime
-waiting, session loading, visible, or failed from the current owner facts, but it
-must not drive the data load. Shell, right-panel, and build-tool modules may
-derive edge booleans from `viewTranscriptState`, but central selection must not
-expose a second `isSessionViewLoading` field.
-Selected-session model choice belongs to the selected session summary until the
-full session is loaded, then to `AgentSessionState.selectedModel`. The selected
-view may expose that display fallback only as `selectedSessionModel`; do not wrap
-it in a session-shaped selected-view projection.
-Selected-session view projection receives selected facts once: inactive,
-selected task, selected session, or loaded session. Runtime readiness target,
-transcript state, selected activity, and selected model all derive there. Do not
-split that work into separate source-resolution and projection APIs.
-Outside those boundaries, selected-session existence is the selected session
-identity itself; pass `selectedSessionIdentity` and derive booleans locally only
-when a branch truly needs them. Likewise, pass `selectedSessionModel` instead of
-a mirrored `hasSelectedSessionModel` flag.
-`use-agent-studio-selected-session-view.ts` owns the selected-session view shape.
-Selection controllers may add task/tab context, but must not rename the selected
-session, runtime-data, readiness, role, launch-action, or transcript fields into
-a parallel view model.
-Shell, route, and selection-controller modules must not accept or forward
-runtime readiness, runtime health, runtime definitions, or runtime catalog
-loader props for the selected session. The selected-session view owner reads the
-runtime/check contexts directly when deriving `runtimeReadiness` and
-`sessionRuntimeData`.
-`selected-session-view-projection.ts` owns the selected-session projection:
-loaded session, selected session, selected task, or inactive. The runtime-target
-helper, transcript state, selected activity, and selected model must stay in
-that module instead of rebuilding the same branch ladder in the hook.
-`selected-session-context.ts` exposes transcript state as selected-session state,
-not as runtime state. Runtime context contains runtime definitions, readiness,
-and selected-session runtime data only.
-Build-tool worktree refresh is not a transcript surface. It observes build
-session messages and `historyLoadState` only; do not pass transcript loading
-state through the shell to suppress historical tool completions.
-Repo-session read-model loading is exposed through one read-model state context:
-`sessionReadModelLoadState` plus the explicit owner command
-`reloadSessionReadModel`. Do not split it back into independent loading and
-error fields or caller-owned retry loops; selected-session view projection is
-the only selected session layer that interprets read-model load state into
-transcript state. Expose this surface only through
-`AgentSessionReadModelStateContext`; do not put it back on aggregate agent state
-or operations values.
-`useAgentOrchestratorOperations` returns explicit owned buckets only:
-`sessionStore`, `operations`, and `readModelState`. Do not reintroduce a
-legacy aggregate hook result that spreads operation methods and session snapshots
-beside those buckets.
-Do not reintroduce `useAgentState` or `AgentStateContextValue`; consumers must
-read sessions and operations through the dedicated hooks/contexts.
-Page shell, route, and selection-controller modules must not accept or forward
-`sessionReadModelLoadState`; the selected-session view owner reads it directly
-from the context when deriving transcript state.
-The exposed read-model load state must be current for the active repository and
-the current read-model inputs; while either input is not ready, expose a loading
-state instead of an empty/ready state.
-`useRepoSessionReadModel` owns that public projection and the actual repo read
-lifecycle: start the repo read, commit ready, or commit failed. It must not
-prepare runtime sessions or choose transcript/history load policy.
-It reads runtime health from the canonical checks state to derive runtime
-readiness for persisted sessions. Do not pass runtime health through
-`AgentStudioStateProvider` or `useAgentOrchestratorOperations`.
-The repo read-model load is keyed by the selected repository plus the task id
-set. Task metadata changes and task order changes must not restart the repo
-session read model, because that would temporarily demote selected sessions back
-to loading and cause transcript/status flicker.
-For the task id set it loaded, the repo read model treats durable task-session
-records as the durable existence source and the current host snapshot as the live
-existence source. Missing records remove durable-only non-starting sessions, while
-host-owned live sessions remain until an ordered `session_removed` envelope arrives.
-Only local `starting` sessions may remain without either source while session
-registration catches up.
-The transcript-state module owns the generic runtime-bound transcript helpers:
-runtime-bound empty, runtime-bound loading, loaded session, failed, and visible.
-Selected-session and read-only transcript surfaces return final transcript state
-through those helpers. Do not add parallel selected-session or read-only
-transcript state machines.
-
-Invariant: subagent waiting badges are derived from child session summaries.
-Selected-session state must not maintain parent-owned pending-input projections.
-Workflow context builders receive selected session identity and selected session
-role as separate facts. Do not fabricate partial `AgentSessionState` objects just
-to drive workflow/session-selector state. The selected role comes from the
-selection resolver; loaded session state must not repair or override it.
-
-### Agent Studio Task Tabs
-
-Files:
-
-- `pages/agents/agent-studio-task-tabs-storage.ts`
-- `pages/agents/agent-studio-task-tabs-list.ts`
-- `pages/agents/agents-page-session-tabs.ts`
-
-Owns:
-
-- repo-scoped task-tab persistence in localStorage
-- pure task-tab list operations such as ensure, reorder, fallback, and close
-- workflow/session projection for tab status, workflow rail state, session
-  selector options, and session creation options
-
-Invariant: tab persistence and tab-list operations do not own session status,
-runtime readiness, selected-session identity, or workflow rail state. Keep those
-concerns in `agents-page-session-tabs.ts`, and do not reintroduce localStorage or
-generic tab-array helpers into the workflow/session projection module.
-
-### Selected Session Runtime Data
-
-Files:
-
-- `hooks/use-session-runtime-data.ts`
-- `support/session-runtime-data-refs.ts`
-- `types/selected-session-runtime-data.ts`
-- `state/queries/agent-session-todos.ts`
-- `state/queries/runtime-catalog.ts`
-- `pages/agents/selected-session/use-agent-studio-selected-session-view.ts`
-
-Owns:
-
-- resolving selected-session runtime-data query refs from the session and runtime definitions
-- gating selected-session runtime-data reads on repo runtime readiness without changing the refs
-- reading selected-session model catalog through the runtime-catalog query owner
-- reading selected-session todos through the session-todos query owner
-- owning live todo state through the same todos query cache used for selected-session reads
-- reporting selected-session runtime-data read errors
-- providing view-only runtime data to Agent Studio
-
-Must not own:
-
-- `AgentSessionState` identity, status, transcript messages, or history load state
-- canonical session todos; todos are runtime data, not session state
-- status/activity-derived gates for selected-session runtime-data reads
-- task session records
-- model catalog, slash-command catalog, skills catalog, or file-search query ownership
-- runtime route resolution
-
-Invariant: runtime-data reads and runtime todo events must not rewrite the session
-store. Agent Studio may compose a chat thread session from raw
-`AgentSessionState` plus selected-session runtime data at the presentation
-boundary, but lifecycle decisions must use the raw selected `AgentSessionState`.
-Runtime events update todos through `updateSessionTodosQueryData`; do not
-reintroduce a writer object or pass a second session route through event context.
-Session-todos query keys, unavailable keys, stale windows, and disabled-query
-fail-fast behavior live in `state/queries/agent-session-todos.ts`. Readonly
-transcript history query keys live in `state/queries/agent-session-history.ts`.
-Runtime catalog query keys and catalog reads live in
-`state/queries/runtime-catalog.ts` for model catalogs, slash commands, skills, and
-file search. The selected session runtime-data refs resolver owns read eligibility
-and stable runtime/session refs. The React hook owns only query wiring and view
-composition. Agent Studio passes selected-session runtime data as one object:
-model catalog, todos, loading state, and read error stay together. Do not add
-parallel `runtimeDataError` or `activeSessionRuntimeData` fields that split this
-concept across view models. The orchestration controller must forward that object
-to selected-session consumers such as the chat composer and session actions; it
-must not project model catalog/loading/runtime descriptor fields into separate
-hook arguments.
-
-### Agent Studio Documents
-
-Files:
-
-- `pages/agents/use-agent-studio-documents.ts`
-
-Owns:
-
-- loading and refreshing task documents for the selected task
-- applying optimistic document updates from completed workflow tool messages
-- deduping processed document-tool events for the selected session
-
-Invariant: document event tracking is keyed by selected-session identity, not by
-loaded session availability. The loaded session is only the message source. If the
-selected identity remains the same while loaded session state temporarily catches
-up, processed document events must not reset or replay.
-
-Must not own:
-
-- selected-session transcript loading state
-- session status, runtime readiness, or runtime data
-- workflow/session-selector identity
-
-### Agent Chat Composer
-
-Files:
-
-- `pages/agents/agent-studio-chat-surface-state.ts`
-- `pages/agents/chat-composer/use-agent-studio-chat-composer.ts`
-- `components/features/agents/model-picker/model-picker.tsx`
-- `components/features/agents/model-picker/model-picker-model.ts`
-- `features/agent-chat-composer/context-usage/use-selected-session-context-usage.ts`
-- `features/agent-chat-composer/model-selection/model-selection-preferences.ts`
-- `features/agent-chat-composer/prompt-input/chat-composer-prompt-input-runtime.ts`
-- `features/agent-chat-composer/prompt-input/use-chat-composer-slash-commands.ts`
-- `features/agent-chat-composer/prompt-input/use-chat-composer-skills.ts`
-- `state/queries/use-runtime-model-catalogs.ts`
-- `state/mutations/use-agent-model-favorites.ts`
-
-Owns:
-
-- composing model-selection choices for a new message or new session
-- presenting runtime and model as one exact `runtimeKind`/`providerId`/`modelId` choice with favorites, search, per-runtime loading, and per-runtime retry
-- resolving composer model selections from one explicit model-selection source:
-  selected session or new session
-- resolving selected composer runtime kind from selected-session model, draft
-  selection, role default, and repo default
-- deriving composer draft scope from task, role, and selected-session identity;
-  rendered chat components may receive a string key, but hooks must not parse it
-- deriving Agent Studio chat empty-state/kickoff visibility and composer
-  read-only state
-- keeping selected-session target identity and selected-model fallback available
-  while the full selected session is still loading
-- deriving context usage from the loaded session's live context usage and messages
-- resolving the single prompt-input runtime state from one explicit prompt-input
-  source, repo-runtime readiness, and unavailable runtime context
-- passing runtime-backed composer tools a `RuntimeWorkingDirectoryRef` for both
-  loaded-session and pre-session repo targets
-- loading other available runtime catalogs only while the new-session picker is open
-- keeping foreign runtime rails visible but disabled for an existing session
-
-Must not own:
-
-- selected-session transcript loading state
-- canonical session status, messages, pending input, or history load state
-- runtime route resolution beyond the already-derived working-directory ref
-- duplicate session-named catalog APIs for model catalogs, slash commands, skills,
-  or file search
-
-Invariant: a session summary may identify the selected session and selected model,
-but it must not provide loaded-session status, messages, or context usage.
-Summary-only sessions are waiting prompt-input state, not an alternate session
-catalog path. Slash commands, skills, and file search must consume the shared
-prompt-input runtime state and runtime-catalog query owner instead of recomputing
-session/repo/loading/runtime-error booleans independently or exposing duplicate
-`readSession*Catalog` APIs.
-Pre-session repo tools use the repository root as their working directory, but
-they still pass that through the same runtime working-directory ref shape as
-loaded-session tools.
-
-Fresh task-scoped agent sessions are different: Specification, Planner, Builder,
-and QA all prepare the task's canonical worktree before adapter startup while
-the shared runtime process remains repository-scoped. Existing persisted
-sessions continue using their exact recorded working directory.
-
-Invariant: Agent Studio chat surface state receives selected-session transcript state
-and already-computed start availability. It must not recompute task workflow
-availability or runtime readiness.
-It receives the selected-session key directly; do not wrap task/workflow/session
-facts into a local selected-session object or pass a mirrored
-`hasSelectedSession` boolean.
-The generic chat composer may receive an already-computed waiting-input
-placeholder string, but it must not receive pending approval/question payloads or
-derive pending-input copy from `AgentSessionState`.
-Agent Studio passes selected-session identity and loaded session state as
-separate facts into the composer model. Do not reintroduce a copied
-composer-only session object, store runtime-data loading on a session-shaped
-object, or pass the full loaded session into prompt-input runtime helpers.
-Prompt-input helpers consume only the selected session identity plus the
-repo-runtime readiness state. Session activity is transcript/UI state; it must
-not be reused as a runtime readiness proxy.
-The selected-session view owns selected-session identity. The composer may use a
-loaded session for model, context-usage, and activity facts, but it must not
-replace the selected-session identity with an identity derived from the loaded
-session object. The chat surface receives the selected-session key once and
-passes it to thread layout/windowing and composer autofocus; neither path should
-rederive that key from a loaded session that can temporarily be unavailable while
-session state catches up. Runtime kind and working directory are identity-owned
-facts exposed as `selectedSessionIdentity`. Do not wrap them in a
-session-shaped projection object, recover identity from a loaded session or
-summary snapshot, or expose mirrored top-level selected-session fields.
-Selected-session existence is `selectedSessionIdentity !== null`; do not expose a
-duplicate `hasSession` projection field.
-Selected-session activity is exposed separately as `selectedSessionActivityState`.
-Consumers that own action or build-tool policy can derive local booleans from
-that activity fact.
-Selected interaction role belongs to the selected-session view, not
-selected-session identity; do not mirror it as a selected-session field.
-Workflow/header model builders receive selected-session identity only, not the
-whole selected-session view. The selected-session context owns the selected
-role; workflow context must not mirror it as a second selected-role field. The
-selected-session context owns only the active document, not right-panel
-availability. The right-panel hook derives panel kind, open state, and toggle
-visibility from role plus task/document availability at the usage site.
-Model-selection actions receive a loaded selected-session identity only when a
-user explicitly changes the selected session model; otherwise they update the
-new-session draft selection. Do not add automatic loaded-session model sync
-effects, and do not store a mirrored loaded-session identity. The composer can
-derive that action target from the loaded session it already receives.
-Model-picker actions must validate the exact runtime, provider, and model against the target catalog before updating a draft or session. Existing sessions reject foreign runtime choices before any durable session update.
-Selected-session model fallback is exposed separately as `selectedSessionModel`
-and remains display-only until the user changes the model.
-An explicit session model action requires that selected session to be loaded.
-Missing loaded-session state is a caller invariant error, not a no-op model
-update. Session model actions persist the selected model before touching the
-runtime adapter, because selected model is durable session context. Runtime model
-sync is attempted only for observed sessions; unobserved idle or stopped session
-shells keep the durable choice for the next send/start preparation.
-
-Invariant: build-tools worktree reads are owned by
-`features/agent-studio-build-tools/use-agent-studio-build-tools-worktree-snapshot.ts`.
-Their query identity is the repo, task id, and task version. Do not pass
-transcript loading, active-session identity, or task-loading flags through the
-Agent Studio shell to force worktree refreshes.
-Build-tool Git refreshes are owned by
-`features/agent-studio-build-tools/use-agent-studio-build-worktree-refresh.ts`.
-That hook may ignore history-load snapshots through `AgentSessionState.historyLoadState`,
-but it must not depend on selected-session transcript presentation state.
-
-Invariant: prompt-input capability helpers receive one already-selected runtime
-kind. The Agent Studio composer chooses whether that runtime kind came from a
-session target or a new-session selection; helper modules must not know about
-session-vs-new-session branching.
-Model-selection preference rules live in
-`features/agent-chat-composer/model-selection/model-selection-preferences.ts`.
-The Agent Studio composer hook wires data and queries; it must not reimplement
-selected-session/new-session model fallback or runtime-kind priority rules.
-
-### Session Actions
-
-Files:
-
-- `handlers/start-session.ts`
-- `handlers/session-launch-executor.ts`
-- `handlers/start-session-workflow-launch.ts`
-- `handlers/session-actions.ts`
-- `handlers/send-agent-message.ts`
-- `handlers/stop-session.ts`
-- `handlers/session-model-actions.ts`
-- `handlers/pending-input-actions.ts`
-- `handlers/public-operations.ts`
-
-Owns:
-
-- start, reuse, fork, send, stop, model update, permission reply, and question reply
-- asking the runtime to create a session and accepting metadata-only control results
-- registering a workflow session in the fixed order: create it in the runtime, persist its task record, then attach it to local task state
-- aborting preparation failures before host control succeeds, then keeping host-stored task sessions when later frontend work fails
-- passing route refs to listeners and context refs to runtime actions
-
-Invariant: only the explicit workflow start path may register task ownership. The runtime control result supplies metadata for the session that OpenDucktor just started; runtime events cannot create or attach an unrelated root session.
-
-Invariant: session-action availability answers whether an action is valid for
-the selected task, role, launch action, and current loaded session. It must not
-gate transcript empty-state actions on selection timing or runtime-loading
-timing; selected-session view projection owns that loading-vs-empty distinction.
-Selected-session send policy must resolve runtime capabilities from selected-session
-runtime data or `AgentSessionState.runtimeKind`; it must not use composer model
-selection as a substitute runtime source for an already-selected session.
-Session actions receive `selectedSessionModel` for the catalog-loading send
-guard. Do not pass a mirrored `hasSelectedSessionModel` flag, and keep
-model-selection details with the composer/model-selection owner.
-Send, question, and approval action sub-hooks receive selected-session identity
-for their runtime target. They must not rederive that identity from the loaded
-session object, because the loaded session can temporarily be unavailable while
-the selected target stays valid.
-Session-action derived state owns busy, waiting-input, queued-message, and busy
-send-blocking policy only. Selected-session existence is the selected-session
-identity itself; do not add a mirrored `hasSelectedSession` field to action state.
-Selected Session Runtime Data owns model-catalog loading; do not mirror that
-loading state through action state.
-Pending-question and pending-approval payloads still come from the loaded
-session. The selected-session store owns those payloads; action hooks only track
-local submit state and call the runtime reply operation.
-Once an action reaches the session operation boundary with a concrete session
-identity, that session must be loaded for mutating operations such as send,
-model update, and pending-input reply. Missing loaded session state is an
-invariant error, not a silent no-op.
-Fresh and fork starts that need an immediate post-start message are held in
-`starting` by the start-session flow before creation; releasing that held state
-belongs to the send-message path and must not be exposed through page-level code.
-After the start modal returns a concrete decision, every Agent Studio session
-start is tracked as starting by the start-session flow. Do not add per-call
-tracking flags or start paths that bypass starting activity publication.
-Post-start messages are part of the session-start workflow and are awaited by the
-single `RunSessionStartWorkflow` command. Do not add detached/fire-and-forget
-kickoff sends; a session start must not complete before the kickoff send has
-finished or failed. Post-start send failures are returned on
-`SessionStartWorkflowResult.postStartActionError`; entry surfaces may report that
-result, but the shared workflow runner must not accept UI/reporting callbacks for
-the same error.
-Sessionless sends and message-first selection must use the same start-availability
-policy as explicit starts. Parent Agent Studio action wiring owns that predicate;
-sub-hooks receive the resulting boolean/function and must not accept selected-task
-or task-readiness inputs just to re-check workflow availability.
-The session-start flow may use `selectedTask` for modal context, target branch,
-and human-review prompts, but it consumes parent-owned start predicates instead
-of recomputing task/runtime readiness.
-The session start modal reads available runtime definitions from runtime
-availability context. Do not pass a second runtime-definition list into the
-modal state; start-mode filtering is local modal selection policy, and runtime
-health/readiness interpretation stays in `useRepoRuntimeReadiness`.
-Agent Studio, Kanban, and Autopilot start entry points consume a single
-`RunSessionStartWorkflow` command. Only shell/provider composition wires that
-command from `startAgentSession` and `sendAgentMessage`; page/business modules
-must not receive both low-level operations and reassemble post-start behavior.
-Kickoff visibility composes from the already-computed start decision plus the
-launch action metadata; it must not re-read task workflow readiness.
-Busy-send blocking and queued-follow-up support are derived by the session-action
-state module from the active session plus runtime descriptor. Parent action wiring
-passes that decision through; it must not rebuild the runtime capability message.
-Session-action state derivation is pure: runtime definitions are passed from the
-orchestration boundary, not read from React context inside lower action helpers.
-
-### Readonly Runtime Transcripts
-
-Files:
-
-- `components/features/agents/agent-chat/readonly-transcript/use-runtime-transcript-session-history.ts`
-- `components/features/agents/agent-chat/readonly-transcript/use-runtime-transcript-interactions.ts`
-- `components/features/agents/agent-chat/readonly-transcript/use-session-transcript-surface-model.ts`
-
-Owns:
-
-- loading a readonly transcript from runtime history
-- preferring an already-loaded live session when one exists
-- reading pending permissions/questions from the live session when one exists
-- replying to pending input through an explicit runtime context ref
-
-Must not own:
-
-- creating global sessions or live-state observers
-- runtime route resolution
-- workflow session status
-- parent-observed copies of pending permissions/questions
-
-### Task Session Records
-
-Files:
-
-- `state/queries/agent-sessions.ts`
-- `state/operations/agent-orchestrator/session-read-model/task-session-records.ts`
-- `state/operations/agent-orchestrator/session-read-model/use-task-session-records.ts`
-- `state/operations/agent-orchestrator/hooks/use-repo-session-read-model.ts`
-- `state/operations/agent-orchestrator/session-read-model/agent-session-workflow-records.ts`
-
-Owns:
-
-- reading durable task session records through per-task session-list queries
-- keeping per-task session-list query keys as the only frontend cache for persisted session records
-- applying loaded durable records onto the projected live collection during repo reads
-- presenting task session history to Agent Studio, Kanban, task details, and autopilot
-
-Must not own:
-
-- live runtime status
-- transcript messages
-- runtime route resolution
-
-Invariant: UI decisions must not read session history from `TaskCard.agentSessions`.
-Use task session record queries instead, so task cards remain task summaries and
-session history has one frontend read boundary.
-Repo startup session loading is keyed by task IDs only. Task title, status,
-document, or workflow metadata changes must not reload the repo session read
-model. Task-session query invalidation/refresh owns persisted session-record
-changes for UI history surfaces. Orchestrator internals must not reload the repo
-session read model for explicit start/reuse preparation; they may load exactly
-one source session through `source-session-loader.ts`.
-`useTaskSessionRecords` is the only hook that fans out per-task session-record queries for repo startup. `useRepoSessionReadModel` consumes that result, attaches to the generic host live-state stream, and owns the one collection projection/commit. The host reads root references from the task store when it refreshes live runtime state.
-It must not select a runtime adapter or load transcript history. Task reset pages
-must not call a session refresh command after reset. Reset
-operations invalidate the exact task-session-record query, and the repo read
-model reacts to that owned query data.
-Live projection during repo reads splits by ownership.
-`agent-session-live-projection.ts` applies host snapshots and ordered deltas and knows nothing about tasks or records. It rejects unknown roots and accepts an unknown descendant only when its declared parent is already registered.
-`agent-session-live-projection.ts` never treats runtime state as task ownership. Only the OpenDucktor start transaction or a saved task-store record can attach a session to a task. `agent-session-workflow-records.ts` restores past sessions, fills matching live sessions with their saved fields, and prunes a workflow session only when its task is loaded, its record is gone, it is not starting, and `liveReported` is false.
-`useRepoSessionReadModel` applies loaded records before and after each live projection, then commits once for snapshots, deltas, and task refreshes alike. The first record pass admits only durable OpenDucktor roots; the second restores durable workflow fields after live status is applied.
-Unloaded, failed, or stale record reads skip that step because they cannot prove deletion.
-A successful current-scope record read clears prior task-record failures only; live-stream failures recover through the stream itself.
-`liveReported` commits inside the session state; do not add a presence store beside it.
-
-## Startup Flow
-
-1. The app loads task IDs from the task store.
-2. `use-task-session-records.ts` reads per-task session records through the
-   shared task-session query keys.
-3. The renderer observes the existing generic host-event channel, then requests one live-state refresh for the active repository. The host reads the exact roots from durable task session records.
-4. Each runtime adapter reads only those roots and their verified descendants. `buildAgentSessionLiveCollection` rejects any other root, reapplies workflow session records, and commits the collection once.
-5. Session rows, activity, pending input, current context usage, and sidebar
-   counters all derive from that same committed collection.
-6. Subsequent ordered upserts, removals, transcript events, faults, and catalog
-   invalidations arrive on the same generic host-event connection. On browser
-   reconnect, replayed live deltas are ignored until a fresh snapshot arrives.
-7. Transcript history and missing context are independent selected-session reads.
-   Neither blocks registered-session projection or pending-input updates.
-
-## Regression Anchors
-
-Use these compact tests as the first-line safety net:
-
-| Regression class | Owning test |
-| --- | --- |
-| Active and waiting-input sessions after reload | `session-read-model/agent-session-live-projection.test.ts` and host adapter tests |
-| Initial snapshot and delta ordering | `hooks/use-repo-session-read-model.test.tsx` and `application/agent-sessions/agent-session-live-state-service.test.ts` |
-| Missing live evidence clears live-only state without erasing history | `session-read-model/agent-session-live-projection.test.ts` |
-| Task metadata changes cannot churn the repo session read model | `hooks/use-repo-session-read-model.test.tsx` |
-| Pending input startup snapshots without overlap or resurrection | `session-read-model/agent-session-live-projection.test.ts` and runtime-adapter live-state tests |
-| Child pending input survives reload on a materialized parent | `session-read-model/agent-session-live-projection.test.ts` and host Codex live-adapter tests |
-| Selected-session history remains on demand | `history/use-selected-session-history-load.test.tsx` and `history/session-history-loader.test.ts` |
-| Missing context is selected-session-only and independent of history | `history/use-selected-session-context-load.test.tsx` and runtime-adapter context tests |
-| Browser reconnect refreshes live state without another SSE connection | `local-host-transport.test.ts` |
-| Stale history reads are not reported as success or failure | `history/session-history-loader.test.ts` |
-| Selected-session runtime/history/read-model loading surface | `transcript/session-transcript-state.test.ts`, `components/features/agents/agent-chat/agent-chat-thread-state.test.ts`, `components/features/agents/agent-chat/agent-chat-thread.test.ts`, `pages/agents/selected-session/selected-session-view-projection.test.ts`, `pages/agents/use-agent-studio-selection-controller.test.tsx`, and `pages/agents/use-agent-studio-page-models.test.tsx` |
-| Selected-session runtime-data ref eligibility | `support/session-runtime-data-refs.test.ts` and `hooks/use-session-runtime-data.test.tsx` |
-| Composer summary runtime cannot act as loaded session state | `features/agent-chat-composer/prompt-input/chat-composer-prompt-input-runtime.test.ts` and `pages/agents/chat-composer/use-agent-studio-chat-composer.test.tsx` |
-| Existing idle session send preparation | `handlers/prepare-session-send.test.ts` and `handlers/session-actions-send.test.ts` |
-| Host live snapshot projection onto session state | `session-read-model/agent-session-live-projection.test.ts` |
-| Permission/question replies through normalized runtime refs | `handlers/session-actions-pending-input.test.ts` |
-| Event-driven permission/question lifecycle after startup | `hooks/use-repo-session-read-model.test.tsx` and `session-read-model/agent-session-live-projection.test.ts` |
-| Readonly transcript loading and direct pending-input replies | `components/features/agents/agent-chat/readonly-transcript/use-runtime-transcript-session-history.test.tsx` and `components/features/agents/agent-chat/readonly-transcript/use-runtime-transcript-interactions.test.tsx` |
-| Single selected-session route across live and persisted candidates | `pages/agents/use-agent-studio-selection-controller.test.tsx` |
-
-## Anti-Regressions
-
-- Do not reintroduce repo hydration coordinators, presence stores, reattach stages,
-  or reconciliation stages.
-- Do not make the repo session read model prepare runtime sessions. It may
-  project persisted records plus the generic ordered host snapshot only.
-- Do not make the repo session read model select transcript/history load
-  targets. Session history loading owns that policy.
-- Do not add runtime transcript open/attach operations to the app-state operations
-  context. Readonly transcripts load local history and reply with runtime context refs.
-- Do not load selected transcript history by refetching task session records.
-  The selected session state already owns runtime kind, working directory, role,
-  and selected model for history reads.
-- Do not create separate history-loading paths for repo startup and selected
-  sessions. They must share the same transient prompt-context boundary.
-- Do not add fallback runtime routing. Persisted sessions carry `runtimeKind` and
-  `workingDirectory`; missing data is an actionable error.
-- Do not treat a missing host live snapshot as an idle runtime event. A cold
-  persisted session starts idle from its durable record. A mounted session loses
-  runtime-owned active state while transcript/history stays mounted; running and
-  waiting-input state require runtime evidence from snapshots or events.
-- Keep runtime ids and runtime routes in low-level adapters/registry code. UI and
-  page modules should carry runtime kind plus working directory, not live routes.
-- Keep frontend runtime dispatch direct: `agent-runtime-services.ts` owns adapter
-  selection from the required `runtimeKind` and exposes only the agent engine plus
-  runtime catalog operations. Do not reintroduce optional-runtime dispatch helpers
-  or missing-runtime repair there.
-- Do not store live runtime routes, pending permissions, pending questions, or
-  transcript stream state in task records.
-- Do not pass generic mutable ref bundles between session hooks. Transcript
-  consumers receive only their concrete turn-state owners; other refs stay with
-  the owner that actually needs them.
-- Do not add pass-through reader hooks that only wrap `agentEngine` runtime reads.
-  The public operations boundary adapts `agentEngine` directly.
-- Do not add parent-session pending-input overlays for subagents. Child sessions
-  own pending requests; parent rows only link to child session ids.
-- Do not make operations context carry read-model state or task-session refresh.
-  Read-model load state lives in the read-model context; exact source-session
-  recovery lives in `source-session-loader.ts`.
-- Do not split selected-session identity between a summary branch and a persisted
-  record branch. Build one candidate list and resolve once.
+Use this map before you change `packages/frontend/src/state/operations/agent-orchestrator` or an Agent Studio session flow.
+
+The host owns live session truth. The task store owns durable workflow session records. The renderer holds one projection of those sources. History loads only for the selected session.
+
+Pass primitive identity through these modules. Use `workspaceRepoPath` for repository session state. Pass `workspaceId` only to code that reads repository config or starts a runtime. Do not pass `ActiveWorkspace` into transcript, action, or read-model modules.
+
+## Session store
+
+Files: `packages/frontend/src/state/agent-sessions-store.ts` and `hooks/use-orchestrator-session-state.ts`.
+
+Owns the current `AgentSessionState` collection, derived summaries, activity snapshot, and React notifications.
+
+Rules:
+
+- The store is the renderer projection of the latest host snapshot and ordered changes. It is not the source of runtime activity, pending input, context, or routes.
+- `useAgentOrchestratorOperations` owns the commit that writes the store and, when needed, durable records.
+- A repository refresh commits through this store once. Do not add a second session collection.
+- Read one selected session through the store reader. Do not request a full collection only to prepare or load one session.
+- Pass summaries to render code as snapshots. Do not build a mutable mirror.
+
+## Activity state
+
+Files: `types/agent-session-activity.ts`, `lib/agent-session-activity-state.ts`, and `lib/agent-session-waiting-input.ts`.
+
+Owns `waiting_input`, `starting`, `running`, `idle`, `stopped`, and `error`.
+
+Pending questions or approvals take priority over raw starting, running, or idle status. Tabs, Kanban, sidebars, actions, and transcripts use this shared rule. Summaries contain `activityState` and pending counts. Full pending payloads remain on `AgentSessionState`.
+
+## Host live projection
+
+Files: `session-read-model/agent-session-live-projection.ts`, `session-read-model/agent-session-workflow-records.ts`, `session-read-model/source-session-loader.ts`, `session-read-model/use-task-session-records.ts`, and `hooks/use-repo-session-read-model.ts`.
+
+Owns durable record reads, root admission from durable records or explicit starts, host live attachment, the first snapshot, ordered changes, one collection commit, and parent-child pending-input links.
+
+Rules:
+
+- Attach the host listener before `agentSessionLiveRefresh`.
+- A live snapshot cannot create a root. A root enters through an OpenDucktor start registration or a durable task session record.
+- A live event can add a descendant only when its parent already exists in the collection.
+- On reload, the host reads exact root references from the task store. Runtime adapters read only those roots and their verified descendants.
+- Runtime state cannot prove task ownership. Only an explicit workflow start or durable task record can attach a session to a task.
+- The browser uses one tagged SSE channel for all host events. Electron uses its generic host-event IPC message.
+- Ignore replayed changes while a reconnect waits for its new snapshot.
+- Treat each later snapshot as a full collection reset.
+- Commit a snapshot once so rows, activity, pending input, context, and counters use the same state.
+- The per-task session-list query is the only frontend cache for durable records.
+- Load one missing source record through `source-session-loader.ts`. Do not load its transcript or refresh the full repository model.
+
+This owner does not load catalogs, file status, diff, selected history, or page navigation. It does not select a native runtime protocol.
+
+## Runtime readiness
+
+Files: `state/queries/checks.ts`, `operations/workspace/use-checks.ts`, `operations/workspace/use-repo-runtime-health.ts`, `lib/repo-runtime-health.ts`, `lib/repo-runtime-readiness.ts`, `lib/use-repo-runtime-readiness.ts`, and `packages/host/src/application/runtimes/runtime-orchestrator-service.ts`.
+
+Owns the runtime health query and the mapping to starting, ready, blocked, or error.
+
+`RepoRuntimeHealthContext` is the only frontend runtime health context. Diagnostics can read it but cannot expose a second copy. App lifecycle starts a repository runtime. A diagnostic reads health only. It does not start or poll a runtime.
+
+`not_started` is a passive observation. During automatic startup, treat it as pending startup, not a terminal session error.
+
+## Selected history
+
+Files: `history/session-history-loader.ts`, `history/use-selected-session-history-load.ts`, `support/session-history-chat-messages.ts`, `support/session-prompt.ts`, and `support/subagent-messages.ts`.
+
+Owns one selected session history request, its load state, transient prompt context, message projection, merge with live messages, and subagent correlation.
+
+Rules:
+
+- Mark, apply, fail, or reset one concrete session load.
+- The caller that claims the load makes the request. Another caller reads the current session snapshot.
+- Start the selected history load through the tagged async side-effect runner.
+- Load history when state is `not_requested`, even if a live tail is visible.
+- Merge history with current messages. Do not erase live items.
+- A history read does not resume, discover pending input, change activity, set context, or drain events.
+- `support/subagent-messages.ts` owns subagent formatting and correlation.
+- Transcript data lives in `SessionMessagesState`.
+
+## Selected context
+
+Files: `history/use-selected-session-context-load.ts` and `features/agent-chat-composer/context-usage/use-selected-session-context-usage.ts`.
+
+Load context only when the selected live session has no context usage and the runtime is ready. Keep current context usage on the snapshot path. A failure uses the operation error path. It does not start history, polling, or all-session recovery.
+
+## Durable records
+
+Files: `support/persistence.ts`, `support/session-cache-effects.ts`, and `support/session-invariants.ts`.
+
+Owns conversion between workflow sessions and durable task-store records, writes to the host and per-task query cache, and shared identity checks.
+
+A durable write requires `workspaceRepoPath`. Missing repository identity is an invariant error. Do not skip the write. Durable records do not own transcripts, pending input, history projection, or system prompt display.
+
+## Transcript events
+
+Files: `events/session-transcript-events.ts`, `events/session-event-types.ts`, `events/session-lifecycle.ts`, `events/session-parts.ts`, `events/session-tool-parts.ts`, `support/session-turn-metadata.ts`, and `support/session-turn-timing.ts`.
+
+Owns transcript event routing, per-session batching, todo event forwarding, active-turn anchors, and duration.
+
+Rules:
+
+- Live activity, pending input, context, and removal arrive as live-state messages. Only `agent-session-live-projection.ts` applies them.
+- `SessionTranscriptEventContext.session` is the only event target. Other capability groups do not copy session identity.
+- Transcript text exists only in `session.messages`.
+- `SessionTurnMetadata` owns turn anchors. `SessionTurnTiming` owns timing.
+- Batching can reduce noisy stream updates. It cannot reconcile sessions, load history, poll, or decide runtime readiness.
+
+## Assistant timing
+
+Files: `hooks/use-orchestrator-session-state.ts`, `support/assistant-turn-duration.ts`, and `support/session-turn-timing.ts`.
+
+`SessionTurnTiming` owns user-message anchors, assistant start times, previous completion times, and final duration. Do not expose its raw map or create a second timing store.
+
+## Runtime references
+
+File: `support/session-runtime-ref.ts`.
+
+Use a route reference for host control and history. It contains `externalSessionId`, `repoPath`, `runtimeKind`, and `workingDirectory`.
+
+Use a context reference for send and reply. It adds task ID, role, optional model, and optional purpose. Do not add prompts, runtime IDs, or native request IDs to generic live observation.
+
+## Prepare an existing session
+
+File: `handlers/prepare-session-send.ts`.
+
+Before a send to an idle or stopped session, make sure its configured runtime process exists and build transient system prompt context. This step does not attach observation, read a snapshot, resume a session, or classify pending input.
+
+## Pending input
+
+Files: `session-read-model/agent-session-live-projection.ts`, `session-read-model/pending-approval-policy.ts`, and `handlers/pending-input-actions.ts`.
+
+Owns pending-input projection, child-to-parent attention links, read-only approval policy, and opaque reply handles.
+
+Keep native IDs in the host adapter. Keep pending payloads in live state. Do not persist them or add frontend overlay maps.
+
+## Selected session view
+
+Files: `pages/agents/agents-page-selection.ts`, `pages/agents/use-agent-studio-selection-controller.ts`, `pages/agents/selected-session/use-agent-studio-selected-session-view.ts`, `pages/agents/selected-session/selected-session-context.ts`, `components/features/agents/agent-chat/use-agent-chat-surface-model.ts`, and `transcript/session-transcript-state.ts`.
+
+Owns the selected candidate, its identity, runtime readiness target, selected activity, selected model, and final transcript state.
+
+Rules:
+
+- Combine live summaries and durable records before selection. Resolve one candidate.
+- `selected-session-view-projection.ts` walks the facts once. Do not repeat its branch logic in hooks.
+- The view is passive. History and runtime-data owners make requests.
+- A transcript stays in loading until history is `loaded`. If a visible transcript later fails to reload, keep the visible transcript with the error state.
+- `transcript/session-transcript-state.ts` owns runtime waiting, session loading, visible, and failed states.
+- Use `selectedSessionIdentity !== null` for existence. Do not add `hasSession`.
+- Keep `selectedSessionActivityState`, selected role, and `selectedSessionModel` as separate facts.
+- Runtime kind and working directory belong to `selectedSessionIdentity`.
+- `selected-session-context.ts` owns the active document, not right-panel state.
+- Read-only transcript history chooses a live session, runtime history, or an empty reason.
+- `agent-chat/agent-chat-thread-state.ts` owns the renderable session, active key, notice, and reset window.
+
+The selected view reads runtime, check, and read-model contexts. Do not pass those values through page shells. `AgentSessionReadModelStateContext` exposes one `sessionReadModelLoadState` and `reloadSessionReadModel`.
+
+The repository read model key is repository plus task ID set. Task title, status, order, or document changes do not restart it. Durable records prove durable existence. The host snapshot proves live existence. Only a local `starting` session can exist for a short time without either source.
+
+## Task tabs
+
+Files: `pages/agents/agent-studio-task-tabs-storage.ts`, `pages/agents/agent-studio-task-tabs-list.ts`, and `pages/agents/agents-page-session-tabs.ts`.
+
+Storage owns repository-scoped localStorage. List helpers own ensure, reorder, fallback, and close. `agents-page-session-tabs.ts` owns workflow and session display. Storage and list helpers do not own runtime or session state.
+
+## Selected runtime data
+
+Files: `hooks/use-session-runtime-data.ts`, `support/session-runtime-data-refs.ts`, `types/selected-session-runtime-data.ts`, `state/queries/agent-session-todos.ts`, `state/queries/runtime-catalog.ts`, and `pages/agents/selected-session/use-agent-studio-selected-session-view.ts`.
+
+Owns refs and Query reads for the selected model catalog and todos. It gates reads on runtime readiness and returns one view object with data, loading, and error.
+
+Rules:
+
+- Runtime data and todo events update their Query caches, not the session store.
+- Query modules own keys, stale times, and disabled-query errors.
+- The ref resolver owns read eligibility and stable runtime/session refs.
+- The hook wires queries and builds the view.
+- Lifecycle decisions use raw `AgentSessionState`, not a session object with runtime data attached.
+- This owner does not resolve routes or own session identity, transcript, activity, or history state.
+
+## Task documents
+
+File: `pages/agents/use-agent-studio-documents.ts`.
+
+Owns selected task document reads, refresh, optimistic workflow-tool updates, and processed event IDs.
+
+Key event tracking by selected session identity. A short gap in loaded session state must not reset or replay processed events.
+
+## Composer
+
+Files: `pages/agents/agent-studio-chat-surface-state.ts`, `pages/agents/chat-composer/use-agent-studio-chat-composer.ts`, `components/features/agents/model-picker/*`, `features/agent-chat-composer/context-usage/*`, `features/agent-chat-composer/model-selection/*`, `features/agent-chat-composer/prompt-input/*`, `state/queries/use-runtime-model-catalogs.ts`, and `state/mutations/use-agent-model-favorites.ts`.
+
+Owns model choices, favorites, search, draft scope, empty and kickoff state, context display, prompt-input runtime state, and runtime catalog queries.
+
+Rules:
+
+- A model choice is the exact `runtimeKind`, `providerId`, and `modelId` tuple.
+- Choose either the selected session or the new-session draft.
+- A summary can provide identity and selected model. Only loaded session state can provide status, messages, pending input, or context.
+- Use one prompt-input runtime state for commands, skills, and file search.
+- Pass `RuntimeWorkingDirectoryRef` for both session and repository targets.
+- Repository tools use the repository root. A fresh workflow session uses the canonical task worktree.
+- Pass selected identity and loaded session as separate facts. Do not make a composer session copy.
+- Use the selected key for thread layout and autofocus. Do not derive it again from loaded state.
+- Validate runtime, provider, and model against the target catalog before a model update.
+- Persist an explicit session model choice before native runtime sync. Sync only an observed session.
+- `model-selection-preferences.ts` owns runtime and model fallback order.
+
+Build-tool worktree reads belong to `features/agent-studio-build-tools/use-agent-studio-build-tools-worktree-snapshot.ts`. Their key is repository, task ID, and task version. Git refresh belongs to `use-agent-studio-build-worktree-refresh.ts`. Transcript display state does not control either read.
+
+## Session actions
+
+Files: `handlers/start-session.ts`, `handlers/session-launch-executor.ts`, `handlers/start-session-workflow-launch.ts`, `handlers/session-actions.ts`, `handlers/send-agent-message.ts`, `handlers/stop-session.ts`, `handlers/session-model-actions.ts`, `handlers/pending-input-actions.ts`, and `handlers/public-operations.ts`.
+
+Owns start, reuse, fork, send, stop, model update, pending-input replies, and workflow session registration.
+
+Rules:
+
+- Action availability uses task, role, launch action, and loaded session. Transcript loading belongs to the selected view.
+- An existing session gets runtime capability from its runtime data or `AgentSessionState.runtimeKind`, not the composer draft.
+- A send, model update, or reply requires loaded session state. Missing state is an invariant error.
+- Start code marks every decided start as `starting`.
+- Register a workflow session in this order: create it in the runtime, persist its task record in the host, then attach it to local task state.
+- Stop preparation failures before host control succeeds. If later frontend work fails, keep the task session stored by the host.
+- Only the explicit workflow start path can register task ownership. Runtime events cannot attach an unrelated root session.
+- A fresh or forked start holds `starting` until its first message finishes or fails.
+- `RunSessionStartWorkflow` awaits the first message. It reports a send failure in `postStartActionError`.
+- Agent Studio, Kanban, and Autopilot call the same `RunSessionStartWorkflow` command.
+- Sessionless send uses the same start-availability rule as an explicit start.
+- The start modal reads runtime definitions from runtime availability context.
+- Action state owns busy, waiting, queued, and send-block rules. It does not copy identity or runtime-data loading.
+
+## Read-only transcripts
+
+Files: `components/features/agents/agent-chat/readonly-transcript/use-runtime-transcript-session-history.ts`, `use-runtime-transcript-interactions.ts`, and `use-session-transcript-surface-model.ts`.
+
+Owns read-only history, preference for an existing live session, live pending input, and replies through a runtime context reference. It does not create global sessions, attach observers, resolve routes, or own workflow status.
+
+## Task session records
+
+Files: `state/queries/agent-sessions.ts`, `session-read-model/task-session-records.ts`, `session-read-model/use-task-session-records.ts`, `hooks/use-repo-session-read-model.ts`, and `session-read-model/agent-session-workflow-records.ts`.
+
+Owns per-task durable record queries and task session history for Agent Studio, Kanban, task details, and Autopilot.
+
+Rules:
+
+- Do not read session history from `TaskCard.agentSessions`.
+- Repository startup keys record reads by task ID only.
+- Reset invalidates the exact task record query. It does not call a session refresh command.
+- `useTaskSessionRecords` is the only fan-out hook. `useRepoSessionReadModel` attaches the live stream and commits the collection.
+- Apply durable records before and after each live projection, then commit once. The first pass admits durable roots. The second pass restores durable workflow fields after live status is applied.
+- Reject an unknown live root. Accept an unknown descendant only when its declared parent is already registered.
+- Skip a record update when its read is unloaded, failed, or stale because it cannot prove deletion.
+- Keep `liveReported` on session state. Do not add a presence store.
+
+## Startup sequence
+
+1. Read task IDs from the task store.
+2. Read per-task session records through shared Query keys.
+3. Attach to the generic host-event channel, then request a repository live snapshot. The host reads exact root references from durable task session records.
+4. Each runtime adapter reads only registered roots and verified descendants. Apply durable records before and after the live projection, then commit once.
+5. Derive rows, activity, pending input, current context usage, and counters from that commit.
+6. Apply ordered changes on the same channel. After browser reconnect, wait for a fresh snapshot before replayed changes.
+7. Load history or missing context only for the selected session.
+
+Startup is complete when the task record query and first host snapshot have produced one committed collection. History does not block it.
+
+## Regression tests
+
+| Rule | Main tests |
+|---|---|
+| Reload keeps active and waiting sessions | `session-read-model/agent-session-live-projection.test.ts`, host adapter tests |
+| Snapshot comes before changes | `hooks/use-repo-session-read-model.test.tsx`, `agent-session-live-state-service.test.ts` |
+| Lost live evidence clears only live state | `session-read-model/agent-session-live-projection.test.ts` |
+| Task metadata does not restart the model | `hooks/use-repo-session-read-model.test.tsx` |
+| Pending input survives startup and child projection | Live projection and runtime adapter tests |
+| History stays selected-session only | `history/use-selected-session-history-load.test.tsx`, `history/session-history-loader.test.ts` |
+| Context loads apart from history | `history/use-selected-session-context-load.test.tsx`, adapter context tests |
+| Browser reconnect uses one SSE channel | `local-host-transport.test.ts` |
+| Selected transcript display state | `transcript/session-transcript-state.test.ts`, `agent-chat-thread-state.test.ts`, selected view tests |
+| Existing idle send prepares runtime | `handlers/prepare-session-send.test.ts`, `handlers/session-actions-send.test.ts` |
+| Replies use normalized refs | `handlers/session-actions-pending-input.test.ts` |
+| Read-only history and replies | Read-only transcript hook tests |
+
+## Guardrails
+
+- Keep repository projection limited to durable records and the ordered host snapshot. It does not prepare sessions or select history.
+- Use one selected history path and one transient prompt-context boundary.
+- Use stored `runtimeKind` and `workingDirectory`. Missing route data is an error, not a reason to use the default runtime.
+- A missing live snapshot is not an idle event. Keep history mounted, but clear runtime-owned active state.
+- Keep runtime IDs and routes in adapters and the registry.
+- `packages/frontend/src/state/agent-runtime-services.ts` selects an adapter from required `runtimeKind`. It does not repair a missing runtime.
+- Keep live routes, pending input, and transcript streams out of task records.
+- Give each hook only the concrete state owner it needs. Do not pass a general mutable ref set.
+- Public operations call `agentEngine` reads directly. Do not add pass-through hooks.
+- Child sessions own pending requests. Parent rows only link to child IDs.
+- Operations context does not own read-model state or task-session refresh.
+- Build one selected candidate list. Do not split live and durable selection paths.

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1,191 +1,135 @@
-# End-to-End Architecture and Data Flow
+# Architecture and data flow
 
-## Purpose
+Use this document to find the owner of a rule and trace a user action across packages.
 
-This document is the maintainer-facing map of how OpenDucktor moves data across layers, from the shared React UI through shell bridges, host services, SQLite-backed task persistence, runtime adapters, and MCP clients.
+OpenDucktor supports OpenCode, Codex, and Claude runtimes. OpenCode is the default. `packages/frontend` is the shared UI. Electron and `packages/openducktor-web` provide the shells. `packages/host` serves both shells. Windows and Linux desktop builds remain experimental.
 
-Use it to answer:
+## Layer ownership
 
-- which layer owns a rule
-- where to change code safely
-- what runtime path a user action follows
-
-Current scope:
-
-- Supported runtime kinds today are OpenCode (`opencode`) and Codex (`codex`).
-- OpenCode remains the default runtime.
-- OpenDucktor is macOS-first and early-stage. Windows and Linux Electron builds exist, but they are experimental and not stable yet.
-- `packages/frontend` is the shared UI.
-- `apps/electron` and `packages/openducktor-web` are the shell adapters for Electron and local browser mode.
-- `packages/host` is the TypeScript host for Electron and browser mode.
-
-## Layer Map
-
-| Layer | Primary modules | Owns | Must not own |
+| Layer | Main code | Owns | Does not own |
 |---|---|---|---|
-| UI presentation | `packages/frontend/src/pages`, `packages/frontend/src/components` | Rendering, local interaction state, visual workflow affordances | Workflow authority, status transition rules |
-| Frontend state/orchestration | `packages/frontend/src/state/app-state-provider.tsx`, `packages/frontend/src/state/operations/*` | App-level state slices, async operation orchestration, projection of host-owned live sessions, and selected-session history loading | Persisted schema definitions, task-store mutation semantics, authoritative runtime live state |
-| Shared contracts | `packages/contracts/src/*` | Runtime-validated schemas for tasks, sessions, workflows, host commands, and MCP payloads | Runtime orchestration, host process control |
-| Core services and ports | `packages/core/src/ports/agent-engine.ts`, `packages/core/src/services/*`, `packages/core/src/types/agent-orchestrator.ts` | History/catalog/inspection ports, normalized live-session port, role/tool policy, tool normalization, prompt composition helpers | Shell invocation details, task-store adapter calls |
-| Host client and runtime protocol adapters | `packages/host-client/src/*`, `packages/adapters-opencode-sdk/src/*`, `packages/adapters-codex-app-server/src/*` | Typed host-command client plus runtime-native history/catalog/protocol integration | Business workflow policy ownership, shell transport ownership, shared frontend live-state ownership |
-| TypeScript host | `packages/host/src/*` | Electron/web host command router, Effect-native application services, host-owned live-session projection and runtime adapters, runtime/process/filesystem/git/MCP orchestration | Frontend cache ownership, public contract schema ownership, durable persistence of live runtime state |
-| Shells | `apps/electron/src/*`, `packages/openducktor-web/src/*` | Electron IPC/preload, browser HTTP/SSE bridge, renderer entrypoints, open-url/local-preview behavior | Domain workflow policy, task-store ownership |
-| MCP workflow service | `packages/openducktor-mcp/src/*` | MCP stdio transport, shared schema validation, host-bridge readiness checks, host-backed `odt_*` task/workflow calls | Frontend rendering/state, task-store persistence ownership |
+| UI | `packages/frontend/src/pages`, `packages/frontend/src/components` | Rendered state and local interaction | Workflow rules and status transitions |
+| Frontend state | `packages/frontend/src/state/app-state-provider.tsx`, `packages/frontend/src/state/operations/*` | UI state, operations, host session projection, selected history | Schemas, task mutations, source live runtime state |
+| Contracts | `packages/contracts/src/*` | Zod schemas for tasks, sessions, workflows, host commands, and MCP data | Runtime control and workflow policy |
+| Core | `packages/core/src/ports/agent-engine.ts`, `packages/core/src/services/*`, `packages/core/src/types/agent-orchestrator.ts` | Ports, role policy, tool mapping, prompt helpers | Shell calls and task-store adapter calls |
+| Clients and runtime adapters | `packages/host-client/src/*`, `packages/adapters-opencode-sdk/src/*`, `packages/adapters-codex-app-server/src/*` | Host client and native runtime protocols | Workflow policy and shell transport |
+| Host | `packages/host/src/*` | Command router, Effect services, live session state, runtimes, process, files, Git, task store, and MCP | Frontend cache and public schemas |
+| Shells | `apps/electron/src/*`, `packages/openducktor-web/src/*` | IPC, preload, HTTP/SSE, renderer start, URLs, and previews | Workflow policy and task-store rules |
+| MCP | `packages/openducktor-mcp/src/*` | stdio, schema checks, bridge readiness, and `odt_*` calls | UI state and direct SQLite access |
 
-## Shell Bootstrap Boundary
+## Shell startup
 
-`packages/frontend` owns the shell-neutral React bootstrap through `bootstrapOpenDucktorShell(...)` and the `ShellBridge` contract. It configures the bridge, preloads settings for theme setup, selects browser or hash routing, and renders the shared app. Shell packages stay thin:
+`packages/frontend` exports `bootstrapOpenDucktorShell(...)` and the `ShellBridge` contract. The bootstrap sets the bridge, reads settings for the theme, selects browser or hash routing, and renders the app.
 
-- `apps/electron` provides Electron IPC/preload/event forwarding, context isolation, sandboxed renderer setup, and host lifecycle disposal.
-- `packages/openducktor-web` starts a loopback TypeScript host backend, injects runtime config, serves the frontend, and maps browser HTTP/SSE transport to the same shell bridge shape.
+`apps/electron` supplies IPC, preload events, context isolation, renderer sandboxing, and host cleanup. `packages/openducktor-web` starts a loopback host, injects config, serves the frontend, and maps HTTP/SSE to the same bridge.
 
-## Effect, Zod, and TanStack Query Ownership
+## Shared ownership rules
 
-OpenDucktor uses Effect in `packages/host` for internal execution: typed failures, dependency wiring, fallible I/O orchestration, lifecycle cleanup, and explicit Promise interop at shell-facing boundaries.
+- Zod schemas in `packages/contracts` define public data.
+- Effect defines host execution, typed failures, resources, and Promise conversion.
+- TanStack Query defines frontend cache keys, stale times, in-flight request deduplication, and invalidation.
+- React context and local stores hold UI state. Host runtime adapters hold the source live session state.
 
-Effect does not replace the public schema layer. `packages/contracts` remains the Zod-backed source of truth for runtime, task, workflow, host-bridge, and MCP payload shapes. If a host operation uses Effect internally, it still accepts and returns the same contract-defined payloads at public boundaries.
+Read [ADR 0002](adr/0002-use-effect-in-the-typescript-host.md) and [the TanStack Query cache strategy](tanstack-query-cache-strategy.md) before you change these boundaries.
 
-Effect also does not replace frontend read caching. TanStack Query owns frontend cache keys, stale-time policy, in-flight deduplication, and invalidation for server-owned reads. Effect may run behind a host client or query function, but it must not create a competing frontend cache for the same data.
+## List tasks for the Kanban board
 
-The intended boundary is:
+1. `useTaskQueryReadModel` reads `repoTaskDataQueryOptions`. Manual and event refreshes call `refreshRepoTaskViewsFromQuery`.
+2. `repoTaskDataQueryOptions` calls `host.tasksList(repoPath, doneVisibleDays)` and builds visible rows.
+3. `packages/frontend/src/lib/host-client.ts` delegates to the active shell bridge.
+4. `packages/host-client/src/task-client.ts` maps the call to `tasks_list`.
+5. The shell calls the host command router.
+6. The host resolves the workspace, opens `<config-root>/task-stores/<workspaceId>/database.sqlite`, and reads through `TaskStorePort`.
+7. The host adds `available_actions` and `agent_workflows`.
+8. TanStack Query caches the result. Frontend read models render columns and actions.
 
-- Zod owns public data contracts.
-- Effect owns host-side execution and failure modeling.
-- TanStack Query owns frontend server-read caching.
-- React context and local UI stores own transient UI state and the latest rendered projection of live interactions. Runtime adapters in the host own the authoritative ephemeral live-session state.
+The frontend renders `availableActions`. It does not derive transition rights from status. Host SQLite adapters own database paths, schema setup, records, and cache invalidation.
 
-See [ADR 0002](adr/0002-use-effect-in-the-typescript-host.md) and [TanStack Query Cache Strategy](tanstack-query-cache-strategy.md).
+## Start an agent session
 
-## Runtime Data Flows
+1. Agent Studio calls `startAgentSession` in `use-agent-orchestrator-operations.ts`.
+2. `start-session.ts` applies `fresh`, `reuse`, or `fork` rules.
+3. `session-start-launch-options.ts` resolves the mode for the selected launch action.
+4. A fresh or forked session reads task documents, resolves the runtime, and reads the repository default model.
+5. Every fresh workflow role uses the task-session bootstrap. The first role creates the canonical task worktree and runs copy paths and pre-start hooks. Later roles check and reuse that worktree. The runtime stays repository-scoped, but the session uses the worktree. Only Builder completion moves the task to `in_progress`.
+6. The host starts the selected runtime. Descriptors and `RuntimeInstanceSummary` form the shared contract. OpenCode uses `local_http`; Codex uses stdio app-server; Claude uses a host service.
+7. A managed runtime MCP process gets the host bridge URL and token. It cannot pass `workspaceId`. An external client can pass `workspaceId`. Neither path gets a database path.
+8. The host starts, resumes, or forks through the registered live-session adapter.
+9. Renderer attachment sends one snapshot first, then ordered changes and transcript events on the same channel.
+10. On send, the adapter applies the role policy and writes the native request.
+11. For a workflow session, the host stores the durable session record from the successful runtime control result before it returns the result to the frontend. Live activity, pending input, context, routes, and reply IDs remain in host memory.
 
-### 1. List Tasks For Kanban
+Session rules:
 
-1. Task reads are TanStack Query-owned. `useTaskQueryReadModel` reads `repoTaskDataQueryOptions`; manual and event-driven refresh paths call `refreshRepoTaskViewsFromQuery`.
-2. `repoTaskDataQueryOptions` calls `host.tasksList(repoPath, doneVisibleDays)` and derives visible task rows through frontend read models.
-3. `host` is the frontend host-client proxy (`packages/frontend/src/lib/host-client.ts`), which delegates to the configured shell bridge client.
-4. `packages/host-client/src/task-client.ts` maps `tasksList` to the host command `tasks_list`.
-5. The active shell invokes `packages/host` and its TypeScript host command router.
-6. The host task store resolves the workspace id for the repo, opens `<config-root>/task-stores/<workspaceId>/database.sqlite`, reads task rows and documents through the `TaskStorePort`, and returns task data.
-7. The host task service enriches tasks with backend-derived `available_actions` and `agent_workflows`.
-8. Frontend receives typed payloads, caches server-owned task reads in TanStack Query, derives visible tasks through read models, and renders columns/actions.
+- `spec`, `planner`, and `qa` reject mutating permission requests. If the reply fails, keep the request open and emit a system error.
+- Before host control succeeds, stale workspace protection stops session preparation. After host control succeeds, cleanup can stop the runtime, but it must keep the stored task session and its worktree resources.
+- Register and start the live adapter before the runtime can emit events. Release it when the runtime stops.
+- Read transcript history only for the selected session. A history read does not discover pending input or delay live state.
 
-Key boundary:
+## Change task workflow state
 
-- UI must render actions from backend `availableActions`; it must not infer transition authority from status heuristics.
-- `packages/host/src/adapters/sqlite/*` and `packages/host/src/infrastructure/sqlite/*` own SQLite task-store path resolution, schema setup, task/document/session persistence, and cache invalidation.
+Human and agent actions meet in the host workflow service. SQLite stores the result.
 
-### 2. Start An Agent Session
+For a human action:
 
-1. Agent Studio triggers `startAgentSession` in `use-agent-orchestrator-operations.ts`.
-2. `start-session.ts` enforces explicit start-mode policy:
-   - `fresh`: create a new session
-   - `reuse`: continue an existing session
-   - `fork`: create a new session from an existing source session
-3. The session-start modal resolves the final start mode from the selected launch action in `packages/frontend/src/features/session-start/session-start-launch-options.ts`.
-4. For new or forked sessions it concurrently loads task docs, resolves runtime, and loads repo default model.
-5. Runtime acquisition uses the role-neutral task-session bootstrap for every fresh `spec`, `planner`, `build`, and `qa` session. The first fresh role creates the canonical task worktree and runs configured copy paths and pre-start hooks once; later roles strictly validate and reuse it. The runtime itself remains repository-scoped, the adapter session uses the worktree, and only successful Builder completion advances the task to `in_progress`.
-6. The active host resolves the requested runtime kind, then runs runtime-specific startup. The shared contract is runtime descriptors plus `RuntimeInstanceSummary`; startup mechanics are runtime-specific (`local_http` for OpenCode, stdio/app-server identity for Codex).
-7. The runtime-launched MCP process uses only the host-bridge contract. It is host-scoped and forbids explicit `workspaceId`; public external MCP clients may pass `workspaceId`, but all MCP calls still go through the host bridge and never receive task-store database coordinates.
-8. The host selects the registered runtime-specific live-session adapter, starts, resumes, or forks the session, and updates the normalized host projection.
-9. The renderer consumes that projection through one ordered attachment: its initial snapshot is the first envelope, followed by normalized changes and transcript events on the same channel.
-10. On prompt send, the host adapter applies the effective role-scoped runtime policy and sends the runtime-native request.
-11. For a workflow session, the host stores the durable session record from the successful runtime control result before it returns the result to the frontend. Pending input, activity, context usage, routes, and reply identities remain ephemeral host state.
+1. The user selects an action from `availableActions`.
+2. The frontend calls a host method such as `taskTransition`, `humanApprove`, or `buildCompleted`.
+3. The shell maps the method to a host command.
+4. The host workflow service checks the transition.
+5. The task store writes status, fields, or documents.
+6. The frontend refreshes tasks and renders the new action list.
 
-Critical session invariants:
+For an agent tool:
 
-- Read-only roles (`spec`, `planner`, `qa`) must auto-reject mutating permission prompts; on auto-reply failure, permission remains actionable and a system error is emitted.
-- Before host control succeeds, stale workspace protection aborts session preparation. After host control succeeds, cleanup may stop the runtime but must keep the stored task session and its worktree resources.
-- The runtime-specific live adapter must be registered and observing before its runtime can emit events, and it must be released when that runtime ends.
-- Transcript history is an on-demand read for the selected session. It must not discover pending input, recover context implicitly, or delay live-session hydration.
+1. The session calls an `odt_*` tool on the local `openducktor` MCP server.
+2. `packages/openducktor-mcp` checks input with `ODT_TOOL_SCHEMAS`.
+3. `OdtTaskStore` forwards the call to the host bridge. For an external client, the host maps `workspaceId` to `repoPath`.
+4. The host workflow service checks the action and writes through the task store.
+5. The tool result enters the session stream.
+6. The frontend sees the completed mutation tool and refreshes tasks.
 
-### 3. Workflow Transition
+Managed and external MCP clients use the same bridge. The host alone owns SQLite. Repository sessions get all `ODT_MCP_TOOL_NAMES` and use runtime approval rules. Task workflow sessions keep their role tool limits and cannot call public task tools.
 
-OpenDucktor has two transition paths that converge on the host workflow service as the mutation entry point and the SQLite task store as persistent truth.
+## Generate a pull request
 
-Human-triggered path:
+1. The approval flow starts Builder with `build_pull_request_generation`.
+2. The launch uses `reuse` or `fork` from an existing Builder session.
+3. Builder uses provider Git or GitHub tools to create or update the pull request.
+4. Builder calls `odt_set_pull_request`.
+5. The host resolves `providerId` and pull request number, then stores the canonical metadata.
 
-1. User clicks a workflow action surfaced from `availableActions`.
-2. Frontend operation calls host method (`taskTransition`, `humanApprove`, `buildCompleted`, etc.).
-3. The shell host adapter invokes the relevant host command.
-4. The host workflow service validates transition rules.
-5. The task store updates task status and durable task-store fields/documents.
-6. Frontend refreshes tasks and re-renders with backend-derived action set.
+The page does not parse chat text to create a pull request.
 
-Agent-triggered path:
+## Sources of truth
 
-1. Active OpenCode or Codex session calls `odt_*` tool through local MCP server `openducktor`.
-2. `packages/openducktor-mcp` validates input against shared `ODT_TOOL_SCHEMAS`.
-3. `OdtTaskStore` forwards the workspace-scoped call to the running host bridge; the host resolves `workspaceId` to `repoPath` when the call comes from an external MCP client.
-4. The host workflow service validates workflow rules and persists task documents/status through the task store. The MCP package does not talk to the SQLite database directly.
-5. Tool result is emitted in session stream.
-6. Frontend session-event handler detects completed ODT mutation tools and triggers task refresh.
-
-Key boundary:
-
-- Desktop-managed and standalone MCP clients use the same host-bridge execution path.
-- SQLite task storage remains a host-owned infrastructure concern, not an agent runtime or MCP client concern.
-- Repository Sessions receive the full `ODT_MCP_TOOL_NAMES` catalog from the workspace-bound `openducktor` MCP server, and each Tool Call follows the Runtime's approval policy.
-- Task-bound workflow sessions keep their Workflow Role tool limits, so Public Task MCP Tools remain unavailable to them.
-
-### 4. Generate A Pull Request
-
-1. The approval flow starts a Builder session with launch action `build_pull_request_generation`.
-2. That launch action must start from an existing Builder source session and supports `reuse` or `fork`.
-3. The Builder uses provider-native git or GitHub tools to create or update the PR.
-4. Once the PR exists, the Builder calls `odt_set_pull_request`.
-5. `odt_set_pull_request` persists canonical PR metadata into task metadata by resolving the provider record from `providerId + number`.
-
-Key boundary:
-
-- The page layer no longer parses Builder chat output to create a PR.
-- PR generation is now an explicit launch action in the Builder workflow.
-
-## Source-of-Truth Contracts and Ownership
-
-| Concern | Source of truth | Owner modules |
+| Concern | Source | Owner |
 |---|---|---|
-| Task statuses, issue types, action IDs | `packages/contracts/src/task-schemas.ts` | `@openducktor/contracts`, consumed by adapters/frontend/host |
-| Role and start modes | `packages/contracts/src/agent-workflow-schemas.ts` | `@openducktor/contracts` |
-| Canonical ODT tool names | `packages/contracts/src/odt-tool-names.ts` and `packages/contracts/src/odt-mcp-schemas.ts` | `@openducktor/contracts`, consumed by MCP/core/adapters/host |
-| Role-to-tool allowlist | `AGENT_ROLE_TOOL_POLICY` in `packages/core/src/types/agent-orchestrator.ts` | `@openducktor/core` |
-| ODT/public MCP tool schema validation | `ODT_TOOL_SCHEMAS` exported from `packages/contracts/src/odt-mcp-schemas.ts` and re-exported by `packages/openducktor-mcp/src/lib.ts` | `@openducktor/contracts`, consumed by MCP/host |
-| Transition legality and backend-derived actions/workflows | `packages/host/src/domain/task/*`, `packages/host/src/application/tasks/*` | `@openducktor/host` |
-| Persisted task lifecycle state | SQLite `tasks.status` field | `packages/host/src/adapters/sqlite/*` through host task-store implementations |
-| Workspace task-store database identity | `<config-root>/task-stores/<workspaceId>/database.sqlite` | `packages/host/src/infrastructure/sqlite/*` |
-| Agent-authored docs and session snapshots | SQLite task-document rows and durable task fields | `packages/host/src/adapters/sqlite/*` and host task services |
-| Ephemeral session activity, pending input, context usage, and reply routing | Registered runtime-specific live-session adapter projection | `packages/host/src/application/agent-sessions/*` and `packages/host/src/adapters/agent-sessions/*`; never persisted |
-| Renderer session collection | Latest committed normalized host snapshot and ordered changes | `packages/frontend/src/state/operations/agent-orchestrator/session-read-model/*`; projection only |
-| Transcript history | Explicit runtime history read for one requested session | Runtime history adapters plus selected-session frontend history loader; independent of live hydration |
-| Host execution and expected host failures | Effect programs and tagged host errors under `packages/host/src` | `@openducktor/host`; Promise interop only at explicit transport/package boundaries |
-| Frontend server-read cache | TanStack Query keys/options under frontend query modules | `@openducktor/frontend`; host/runtime Effect code must not duplicate this cache |
+| Task status, issue type, action ID | `packages/contracts/src/task-schemas.ts` | Contracts |
+| Role and start mode | `packages/contracts/src/agent-workflow-schemas.ts` | Contracts |
+| ODT tool names and schemas | `packages/contracts/src/odt-tool-names.ts`, `packages/contracts/src/odt-mcp-schemas.ts` | Contracts |
+| Role tool list | `AGENT_ROLE_TOOL_POLICY` | Core |
+| Workflow rules and derived actions | `packages/host/src/domain/task/*`, `packages/host/src/application/tasks/*` | Host |
+| Task state | SQLite `tasks.status` | Host SQLite adapter |
+| Database identity | `<config-root>/task-stores/<workspaceId>/database.sqlite` | Host SQLite infrastructure |
+| Documents and durable session records | SQLite task and document rows | Host task services |
+| Live session state and reply routing | `packages/host/src/application/agent-sessions/*`, `packages/host/src/adapters/agent-sessions/*` | Host runtime adapter |
+| Renderer session view | `packages/frontend/src/state/operations/agent-orchestrator/session-read-model/*` | Frontend projection |
+| Transcript history | Selected runtime history adapter | Runtime adapter |
+| Host execution errors | Effect and tagged errors in `packages/host/src` | Host |
+| Frontend server-read cache | Query modules under `packages/frontend/src/state/queries` | Frontend |
 
-## Replaceable Boundaries
+## Replaceable boundaries
 
-- TS history/catalog/inspection ports in `packages/core/src/ports/agent-engine.ts`
-- Normalized live-session port in `packages/core/src/ports/agent-engine.ts`
-- Host live-session adapter boundary in `packages/host/src/ports/agent-session-live-adapter-port.ts`
-- Runtime protocol implementations in `packages/adapters-opencode-sdk` and `packages/adapters-codex-app-server`, composed behind host adapters in `packages/host/src/adapters/agent-sessions`
-- Host storage: SQLite-backed `TaskStorePort` adapter under `packages/host/src/adapters/sqlite`
+- Agent engine ports in `packages/core/src/ports/agent-engine.ts`.
+- Live-session port in `packages/host/src/ports/agent-session-live-adapter-port.ts`.
+- Native runtime code in `packages/adapters-opencode-sdk`, `packages/adapters-codex-app-server`, and `packages/host/src/adapters/claude`.
+- SQLite `TaskStorePort` code under `packages/host/src/adapters/sqlite`.
 
-## Cross-Layer Change Checklist
+## Cross-layer change order
 
-1. If data shape changes, update `packages/contracts` first.
-2. If `odt_*` tool shape or names change, update MCP schemas, core tool normalization/policy, adapter behavior, and UI assumptions together.
-3. If public MCP tool shapes (`odt_create_task`, `odt_search_tasks`, `odt_read_task`, `odt_read_task_assets`, `odt_read_task_documents`) change, update package docs and public MCP schemas together.
-4. If workflow transitions/actions change, update the TypeScript host task policies first, then docs and frontend rendering expectations.
-5. Keep shell commands/IPC as transport/mapping layers; place policy in host application/domain layers.
-6. Preserve the host task store as lifecycle source of truth; do not move lifecycle authority into UI-local state.
-7. Keep MCP schemas/descriptions and host task policies aligned; MCP must delegate transition legality to the host task service.
-8. Keep SQLite database paths and task-store ownership in the host; do not reintroduce storage coordinates into MCP startup or runtime-session contracts.
-
-## Related Docs
-
-- `docs/effect.md`
-- `docs/agent-orchestrator-module-map.md`
-- `docs/adr/0006-use-sqlite-task-store-with-workspace-scoped-database-path.md`
-- `docs/tanstack-query-cache-strategy.md`
-- `docs/runtime-integration-guide.md`
-- `docs/task-workflow-status-model.md`
-- `docs/task-workflow-actions.md`
-- `docs/task-workflow-transition-matrix.md`
-- `docs/mcp-runtime-security.md`
+1. Change a shared data shape in `packages/contracts` first.
+2. Change ODT names or workflow schemas in contracts, core policy, adapters, host, MCP, and UI together.
+3. Change public MCP schemas and package docs together.
+4. Change host task policy before workflow docs and UI mapping.
+5. Keep policy in host domain or application code. Shells only map transport.
+6. Keep task lifecycle and database paths in the host.

--- a/docs/cli-tool-discovery.md
+++ b/docs/cli-tool-discovery.md
@@ -1,143 +1,87 @@
-# CLI And Tool Discovery
+# CLI and tool discovery
 
-## Purpose
+OpenDucktor uses local Git, GitHub CLI, Bun, OpenCode, Codex, and Claude Code. The TypeScript host finds these tools for both Electron and web shells.
 
-OpenDucktor depends on local command line tools:
-
-- Git and GitHub CLI for repository and pull request workflows
-- Bun for source-mode MCP startup
-- OpenCode, Codex, and Claude Code for agent runtimes
-
-Discovery for these tools must be host-owned, cross-platform, and shell-neutral.
-Electron and the web runner both use the TypeScript host, so they must get the same discovery behavior.
-Adding a new CLI should mean adding a descriptor and wiring the consumer to `ToolDiscoveryPort`, not adding another shell-specific probe.
-
-## Short Version
-
-Consumers do not search the filesystem themselves. Git, GitHub CLI, and Bun consumers resolve tools through `ToolDiscoveryPort`. Agent runtime startup and health checks use the exact executable path saved in global settings.
-
-Discovery consumers call:
+A consumer asks `ToolDiscoveryPort` for a tool. It does not search files, read `process.env`, run `which`, or inspect an app bundle.
 
 ```ts
-toolDiscovery.resolveToolPath("codex")
+const codexPath = yield* toolDiscovery.resolveToolPath("codex");
+const githubCli = yield* toolDiscovery.resolveTool("githubCli");
 ```
 
-Diagnostics that need to explain where an executable came from call:
+`resolveToolPath` returns the executable path. `resolveTool` also returns the source data that diagnostics can show. Failure uses a typed host error with an install or settings action.
 
-```ts
-toolDiscovery.resolveTool("githubCli")
-```
+## Saved runtime paths
 
-The host resolves that tool by walking its descriptor:
+Global config version 3 stores `enabled` and `executablePath` for OpenCode, Codex, and Claude. A new install discovers each path once, saves valid paths, and enables each runtime it found.
 
-```text
-ToolDiscoveryPort
-  -> tool descriptor registry
-  -> generic explicit paths, ordered descriptor sources, PATH
-  -> SystemCommandPort.resolveCommandPath
-  -> infrastructure/process platform rules
-```
+The version 2 migration keeps the current enabled choice. It discovers paths once and saves an empty path for a missing runtime.
 
-The result is either an executable command path or a typed, actionable host error.
+Startup, version checks, and diagnostics use the saved path. If that path is invalid, they tell the user to fix it in Settings. They do not try an environment variable, bundled path, common path, or `PATH`.
 
-## Persisted Agent Runtime Paths
+Onboarding and Settings call `runtime_executables_check`. The Check again action runs discovery and can replace saved paths. Normal startup does not repeat discovery.
 
-Global config version 3 stores `executablePath` beside `enabled` for OpenCode, Codex, and Claude. A new install runs discovery once, saves each valid path, and enables each runtime that it found. The version 2 migration keeps every existing enabled choice, discovers paths once, and saves an empty path when a runtime cannot be found.
-
-Runtime startup, version checks, and diagnostics validate and use the saved path. They never fall through to an environment override, a bundled path, a conventional location, or PATH when that saved path is invalid. The error tells the user to fix the runtime path in Settings.
-
-The onboarding page and Settings use `runtime_executables_check` for exact-path validation. The explicit **Check again** action runs fresh discovery and lets the user replace saved paths; normal app startup does not repeat discovery.
-
-## Ownership Map
+## Ownership
 
 | Concern | Owner |
-| --- | --- |
-| Public tool ids | `packages/host/src/ports/tool-discovery-port.ts` |
-| User path parsing and home expansion | `packages/path-support/src/user-path.ts` |
-| Tool descriptors and discovery ordering | `packages/host/src/adapters/system/tool-discovery.ts` |
-| PATH, PATHEXT, executable-file checks | `packages/host/src/infrastructure/process/process-command-resolution.ts` |
-| Command resolution and version probing port | `packages/host/src/adapters/system/system-command-runner.ts` |
-| Node host wiring for Electron and web | `packages/host/src/composition/node/node-host-default-ports.ts` |
-| Runtime path initialization and migration | `packages/host/src/application/runtimes/runtime-config-initializer.ts` |
-| Runtime path validation command | `packages/host/src/application/runtimes/runtime-executable-check-service.ts` |
-| Distribution mode input | `packages/host/src/adapters/runtimes/runtime-distribution.ts` |
-| Electron distribution selection | `apps/electron/src/main/electron-runtime-distribution.ts` |
-| Web distribution selection | `packages/openducktor-web/src/web-runtime-distribution.ts` |
+|---|---|
+| Tool IDs | `packages/host/src/ports/tool-discovery-port.ts` |
+| User path syntax and home expansion | `packages/path-support/src/user-path.ts` |
+| Descriptors and search order | `packages/host/src/adapters/system/tool-discovery.ts` |
+| `PATH`, `PATHEXT`, and executable checks | `packages/host/src/infrastructure/process/process-command-resolution.ts` |
+| Command path and version port | `packages/host/src/adapters/system/system-command-runner.ts` |
+| Electron and web host setup | `packages/host/src/composition/node/node-host-default-ports.ts` |
+| Runtime path setup and migration | `packages/host/src/application/runtimes/runtime-config-initializer.ts` |
+| Saved path check | `packages/host/src/application/runtimes/runtime-executable-check-service.ts` |
+| Distribution input | `packages/host/src/adapters/runtimes/runtime-distribution.ts` |
+| Electron distribution | `apps/electron/src/main/electron-runtime-distribution.ts` |
+| Web distribution | `packages/openducktor-web/src/web-runtime-distribution.ts` |
 
-Application services and runtime adapters should depend on `ToolDiscoveryPort`.
-They should not read `process.env`, call `which`, inspect app bundles, or hard-code package resource paths.
-When a package needs to parse a user-supplied path, it should use the pure helpers in `@openducktor/path-support` and supply any environment-specific home-directory or path-joining behavior at its own boundary.
+Use `@openducktor/path-support` to parse a user path. Supply home directory and path joining at the caller boundary.
 
-## Runtime Flow
+## Host startup
 
-At host startup, `createNodeHostDefaultPorts` builds:
+`createNodeHostDefaultPorts` builds these values in order:
 
-1. `processEnv` with platform-aware environment normalization
-2. `systemCommands` from that environment
-3. `toolDiscovery` from `systemCommands`, `processEnv`, shell-provided tool paths, and distribution-owned bundled directories
-4. higher-level adapters and services that consume `toolDiscovery`
+1. `processEnv` with platform environment rules.
+2. `systemCommands` from that environment.
+3. `toolDiscovery` from system commands, environment, shell paths, and distribution paths.
+4. Adapters and services that use `toolDiscovery`.
 
-The same composition path is used by:
+Electron, the published web package, and web workspace mode use this setup.
 
-- Electron main process through `createElectronHostCommandRouter`
-- the local browser backend started by `bunx @openducktor/web`
-- workspace web development mode
+## Search order
 
-This is why CLI discovery belongs in `packages/host`, not in shell code.
+A descriptor lists only sources specific to its tool. The shared search adds explicit paths before those sources and `PATH` after them. The first valid executable wins.
 
-## Discovery Order
+### Environment variable
 
-Each tool descriptor declares only the sources that are specific to that tool.
-The shared discovery pipeline wraps those descriptor sources with generic explicit paths and PATH.
-Discovery stops at the first valid executable source.
-
-### Environment Override
-
-Environment overrides are checked first.
-
-Example:
+The tool's environment variable has first priority. It can contain an absolute path, a home-relative path such as `~/bin/tool`, or a command name that the command runner can resolve.
 
 ```text
 OPENDUCKTOR_BUN_PATH=/opt/homebrew/bin/bun
 ```
 
-An override may be an absolute path, a home-relative path such as `~/bin/tool`, or a command name resolvable by the command runner.
-Quote trimming and `~` expansion come from `@openducktor/path-support`.
+An empty or invalid value returns `HostValidationError`. The search stops because the user set that value.
 
-Invalid overrides fail immediately with `HostValidationError`.
-There is no fallthrough from a broken explicit override to another source, because that would hide the user's configured state.
+### Shell-provided path
 
-### Provided Tool Path
+A shell can pass a path in `providedToolPaths`, keyed by `ToolDiscoveryId`. The host checks it after the environment variable. An invalid provided path fails because the shell claimed that exact path for this run.
 
-Shells may pass a tool path they already know through Node host composition.
-This is a generic `providedToolPaths` map keyed by `ToolDiscoveryId`, not a Bun-specific or shell-specific branch.
+### Descriptor directories
 
-Provided paths are checked after environment overrides and before descriptor conventional locations or PATH.
-If a provided path is invalid, discovery fails immediately because the shell explicitly promised that path for the current run.
+A descriptor can list package-owned or common install directories such as `~/.opencode/bin`.
 
-### Descriptor Search Directories
+| Policy | Result when the directory is missing |
+|---|---|
+| `candidate` | Continue to the next source. |
+| `required` | Return an error. |
 
-Descriptor-owned directories are used for product-owned or conventional install locations.
+Use `required` only when the current distribution promises that path.
 
-Examples:
+### Descriptor files
 
-- package-owned runtime tool directories
-- `~/.opencode/bin`
-
-There are two policies:
-
-| Policy | Behavior |
-| --- | --- |
-| `candidate` | If missing, keep checking later sources. |
-| `required` | If configured and missing, fail before checking later sources. |
-
-Use `required` only when the current distribution promises that directory contains the tool.
-
-### Descriptor Candidate Files
-
-Candidate files are explicit executable paths that are not naturally represented as a directory search.
-
-Codex uses this for macOS app bundle locations such as:
+A descriptor can list exact files that do not fit a directory search. Codex uses this for macOS app files:
 
 ```text
 /Applications/Codex.app/Contents/Resources/codex
@@ -146,110 +90,74 @@ Codex uses this for macOS app bundle locations such as:
 
 ### PATH
 
-PATH is the final generic source for built-in descriptors.
-It uses `SystemCommandPort.resolveCommandPath`, so platform details stay centralized:
+`PATH` is the last built-in source. `SystemCommandPort.resolveCommandPath` applies platform rules:
 
-- POSIX paths require executable regular files
-- POSIX host startup merges the user's login-shell PATH before inherited GUI PATH entries
-- Windows uses PATHEXT for command discovery
-- Windows accepts runnable command extensions such as `.exe`, `.cmd`, and `.bat`
-- directories are not accepted as executable commands
+- POSIX accepts an executable regular file.
+- POSIX startup puts the login shell `PATH` before inherited GUI entries.
+- Windows uses `PATHEXT` and accepts executable types such as `.exe`, `.cmd`, and `.bat`.
+- No platform accepts a directory as a command.
 
-## Current Tool Inventory
+## Tool list
 
-| Tool id | Command | Override variable | Extra descriptor sources | Main consumers |
-| --- | --- | --- | --- | --- |
-| `bun` | `bun` | `OPENDUCKTOR_BUN_PATH` | none | source-mode and web artifact OpenDucktor MCP command |
-| `codex` | `codex` | `OPENDUCKTOR_CODEX_BINARY` | bundled directory when provided, macOS Codex.app candidates | initial setup and explicit rediscovery |
-| `claude` | `claude` | `OPENDUCKTOR_CLAUDE_BINARY` | none; Claude Code is an external prerequisite | initial setup and explicit rediscovery |
-| `git` | `git` | `OPENDUCKTOR_GIT_PATH` | none | Git adapter, diagnostics |
-| `githubCli` | `gh` | `OPENDUCKTOR_GH_PATH` | none | GitHub auth, PR detection and sync |
-| `opencode` | `opencode` | `OPENDUCKTOR_OPENCODE_BINARY` | bundled directory when provided, `~/.opencode/bin` | initial setup and explicit rediscovery |
+| ID | Command | Environment variable | Extra sources | Main use |
+|---|---|---|---|---|
+| `bun` | `bun` | `OPENDUCKTOR_BUN_PATH` | None | Run source or web MCP file |
+| `codex` | `codex` | `OPENDUCKTOR_CODEX_BINARY` | Bundled directory and macOS app files | Setup and rediscovery |
+| `claude` | `claude` | `OPENDUCKTOR_CLAUDE_BINARY` | None | Setup and rediscovery |
+| `git` | `git` | `OPENDUCKTOR_GIT_PATH` | None | Git and diagnostics |
+| `githubCli` | `gh` | `OPENDUCKTOR_GH_PATH` | None | GitHub auth and pull requests |
+| `opencode` | `opencode` | `OPENDUCKTOR_OPENCODE_BINARY` | Bundled directory and `~/.opencode/bin` | Setup and rediscovery |
 
-`OPENDUCKTOR_CLAUDE_BINARY`, `OPENDUCKTOR_CODEX_BINARY`, and
-`OPENDUCKTOR_OPENCODE_BINARY` are existing public names.
-For new general-purpose tools, prefer `OPENDUCKTOR_<TOOL>_PATH` unless there is already a released compatibility name.
+Keep the three released `*_BINARY` names. For a new general tool, use `OPENDUCKTOR_<TOOL>_PATH`.
 
-## Distribution Modes
+## Distribution modes
 
-### Source Mode
+### Source mode
 
-Source mode is used by local development.
+Local development has the workspace root but no package-owned tool directories. Search the environment variable, shell path, descriptor paths, and `PATH`.
 
-The runtime distribution contains the workspace root.
-It does not provide package-owned tool directories.
-Discovery uses environment overrides, shell-provided tool paths, descriptor conventional locations, and PATH.
+### Electron package
 
-### Electron Packaged Mode
+Electron passes an artifact distribution. It resolves the MCP launcher from app resources. The host provides SQLite task storage, so the package has no task-store CLI.
 
-Electron packaged mode passes an artifact runtime distribution.
+All package paths must come from the active app resources. Never use a development worktree path.
 
-The packaged MCP launcher is resolved from Electron resources.
-Released Electron builds do not package task-store CLIs; task storage is provided by the host-owned SQLite adapter.
+### Web package
 
-Packaged Electron must never point discovery at a development worktree.
-Resource paths must come from the packaged app resources for that run.
+`bunx @openducktor/web` passes an artifact distribution. It runs `dist/openducktor-mcp.js` with the Bun executable that started the web package.
 
-### Web Package Mode
+The web package does not use Electron resources and has no bundled runtime CLI directory. It finds runtime CLIs through descriptor rules unless the shell supplies an exact path. A future bundled CLI must use an npm package path.
 
-`bunx @openducktor/web` also uses an artifact runtime distribution.
+## Errors
 
-The MCP launcher is the package-owned `dist/openducktor-mcp.js` script executed by the `bun` tool resolved through `ToolDiscoveryPort`.
-The web launcher provides the active Bun executable to `ToolDiscoveryPort`, so `bunx @openducktor/web` launches its MCP script with the same Bun executable that started the package.
-The web package does not use Electron resources and does not currently provide bundled runtime tool directories.
+| Case | Error | Reason |
+|---|---|---|
+| Explicit value is empty | `HostValidationError` | User config is invalid. |
+| Explicit file is missing or not executable | `HostValidationError` | User config must change. |
+| Required bundled source is missing | `HostDependencyError` | The package is incomplete. |
+| All sources miss the tool | `HostDependencyError` | The host dependency is absent. |
 
-Therefore, runtime CLIs such as Git, OpenCode, Codex, and GitHub CLI are discovered through their descriptor overrides, descriptor conventional locations, and PATH unless the web shell has an exact provided path for that tool.
-If the web package ever bundles a CLI, its resolver must provide package-owned paths from the npm package layout, not desktop app paths.
-
-## Error Model
-
-Discovery returns typed host failures.
-
-| Scenario | Error type | Why |
-| --- | --- | --- |
-| Explicit override is empty | `HostValidationError` | The user configured an invalid value. |
-| Explicit override points to a missing or non-executable file | `HostValidationError` | The configured value is wrong and should be fixed. |
-| Bundled source is configured but missing | `HostDependencyError` | The distribution promised to bundle a tool that is absent. |
-| No source finds the tool | `HostDependencyError` | The host dependency is unavailable. |
-
-Missing-tool errors include every checked source and the descriptor install hint.
-
-Example:
+A missing-tool error lists every checked source and the install hint.
 
 ```text
 bun not found. Checked OPENDUCKTOR_BUN_PATH, PATH. Install bun and ensure it is available on PATH, or set OPENDUCKTOR_BUN_PATH.
 ```
 
-## Adding A New CLI
+## Add a CLI
 
-Use this checklist when a new host-owned CLI is needed.
+### 1. Check ownership
 
-### 1. Confirm It Belongs In Tool Discovery
+Use `ToolDiscoveryPort` for a known dependency of a host service, runtime, diagnostic, GitHub flow, MCP launcher, or other host workflow. Keep user-defined commands in process-launch adapters.
 
-Use `ToolDiscoveryPort` when the CLI is a known OpenDucktor dependency used by host services, runtime startup, diagnostics, storage, GitHub integration, MCP launch, or another host-owned workflow.
+The step is complete when the CLI has one named OpenDucktor consumer and the host owns its install check.
 
-Do not add arbitrary user commands to the registry.
-For user-configured commands such as dev server scripts, keep using the process-launch adapters and their command-line parsing rules.
+### 2. Add the ID
 
-### 2. Add The Tool Id
+Add a stable `ToolDiscoveryId` to `packages/host/src/ports/tool-discovery-port.ts`. Name the tool, not its path or shell.
 
-Add a new `ToolDiscoveryId` entry in:
+### 3. Add the descriptor
 
-```text
-packages/host/src/ports/tool-discovery-port.ts
-```
-
-Use a stable semantic id such as `githubCli`, not a shell-specific or package-specific path name.
-
-### 3. Add The Descriptor
-
-Add a descriptor in:
-
-```text
-packages/host/src/adapters/system/tool-discovery.ts
-```
-
-Prefer the shared `commandTool` helper for standard tools:
+Add the descriptor to `packages/host/src/adapters/system/tool-discovery.ts`.
 
 ```ts
 const EXAMPLE_TOOL_DESCRIPTOR = commandTool({
@@ -259,8 +167,7 @@ const EXAMPLE_TOOL_DESCRIPTOR = commandTool({
 });
 ```
 
-If the tool has product-owned or conventional locations, add descriptor sources.
-The shared discovery pipeline checks environment overrides and provided paths before those sources, then PATH after those sources.
+Add product-owned paths only when needed:
 
 ```ts
 const EXAMPLE_TOOL_DESCRIPTOR = commandTool({
@@ -278,84 +185,46 @@ const EXAMPLE_TOOL_DESCRIPTOR = commandTool({
 });
 ```
 
-Then register it in `TOOL_DISCOVERY_DESCRIPTORS`.
+Register it in `TOOL_DISCOVERY_DESCRIPTORS`.
 
-### 4. Wire Consumers Through The Port
+### 4. Use the port
 
-Consumers should receive `ToolDiscoveryPort` from composition or an application dependency bundle.
-
-Do this:
+Inject `ToolDiscoveryPort` through composition or the service dependency set.
 
 ```ts
 const binary = yield* toolDiscovery.resolveToolPath("example");
 ```
 
-Do not do this:
+Do not read the variable in the consumer. A workflow can cache one resolved command for its own run. Do not add a second global cache.
 
-```ts
-const binary = process.env.OPENDUCKTOR_EXAMPLE_PATH ?? "example";
-```
+### 5. Add diagnostics
 
-The consumer may cache a resolved command for one workflow if that avoids repeated probes, but cache ownership should stay local to that workflow.
-Do not add a second global discovery cache.
+Show the tool in runtime health, system diagnostics, or another relevant check when its absence blocks a user path. Diagnostics call `ToolDiscoveryPort` and do not copy descriptor rules.
 
-### 5. Decide Whether Diagnostics Should Show It
+### 6. Add package paths
 
-If the missing tool blocks a user-visible setup or runtime path, add it to the relevant diagnostics service:
+If a shell owns a bundled tool:
 
-- runtime health for agent runtime CLIs
-- system diagnostics for repository/GitHub tools
-- task-store diagnostics for the SQLite database path and readiness
+1. Put the file in that package build.
+2. Expose its directory through the package distribution resolver.
+3. Add a descriptor `searchDirectories` source for the tool ID.
+4. Test source and package modes.
 
-Diagnostics should call `ToolDiscoveryPort`.
-They should not duplicate descriptor logic.
+Electron paths come from app resources. Web paths come from the npm package. If the shell already knows an exact executable path, pass it through `providedToolPaths`.
 
-### 6. Handle Distribution Ownership
+### 7. Test the tool
 
-If a shell package owns a bundled copy of the CLI:
+At minimum, test a valid environment path, an invalid environment path, a missing-tool error, Windows executable types, source and package modes, and source-layer error propagation.
 
-1. package that binary or script in the shell/package build
-2. expose its directory through the shell's runtime distribution resolver
-3. add a descriptor `searchDirectories` source keyed by the tool id
-4. test source mode and packaged mode separately
+The main test file is `packages/host/src/adapters/system/tool-discovery.test.ts`. Consumer tests check behavior, not the descriptor algorithm.
 
-For Electron, package paths must come from Electron resources.
-For `@openducktor/web`, package paths must come from the npm package layout.
-Never reuse a path from another shell, another worktree, or a removed development directory.
+## Review rules
 
-If a shell already knows the exact executable path for a tool it is using to run OpenDucktor, pass that path through the host composition `providedToolPaths` input.
-Do not add a one-off discovery branch for that shell or tool.
-
-### 7. Add Tests
-
-At minimum, add or update tests for:
-
-- environment override success
-- invalid override failure
-- missing tool diagnostics listing the override variable
-- Windows command discovery when the tool may be a `.cmd`, `.bat`, or `.exe`
-- packaged/source distribution behavior when bundled directories are involved
-- the consuming service failing at the source layer with the discovery error
-
-The central test file is:
-
-```text
-packages/host/src/adapters/system/tool-discovery.test.ts
-```
-
-Consumer tests should assert behavior, not reimplement the descriptor search order.
-
-## Design Rules
-
-- Keep CLI discovery in `packages/host`.
-- Use descriptors as the source of search order, install hints, and override names.
-- Leave low-level platform resolution in `infrastructure/process` and `SystemCommandPort`.
-- Avoid Codex-specific, OpenCode-specific, or shell-specific discovery branches.
-- Reject invalid explicit overrides instead of falling back to PATH.
-- Keep packaged mode independent from source worktrees.
-- Keep the web package independent from Electron resources.
-- Reuse descriptor search logic from diagnostics, runtime starters, and task workflows.
-- Treat missing required bundled tools as distribution errors, not PATH lookup misses.
-- Keep errors actionable and specific to the failed source.
-
-The goal is deliberately boring: one port, one descriptor registry, one platform command resolver, many consumers.
+- Keep discovery in `packages/host`.
+- Keep search order, install hints, and variable names in descriptors.
+- Keep platform checks in `infrastructure/process` and `SystemCommandPort`.
+- Stop on an invalid explicit path.
+- Keep package mode independent from worktrees.
+- Keep web paths independent from Electron.
+- Share descriptor logic across diagnostics, runtimes, and workflows.
+- Treat a missing required bundled tool as a package error.

--- a/docs/dependency-hygiene.md
+++ b/docs/dependency-hygiene.md
@@ -1,107 +1,48 @@
-# Dependency Hygiene Policy
+# Dependency hygiene
 
-This repository uses recurring checks and automated update PRs to keep dependencies lean and up to date.
+Dependabot proposes version updates and security fixes. Knip finds unused dependencies and exports. Both checks run because neither replaces the other.
 
-## Automated Update PRs (Dependabot)
+## Pull request gate
 
-- Config: `.github/dependabot.yml`
-- Coverage:
-  - Bun workspace updates from repository root
-  - GitHub Actions updates
-- Cadence: weekly
-- Grouping: patch/minor updates are grouped to reduce PR noise
+Run the full gate with:
 
-Dependabot and `knip` solve different problems:
+```sh
+bun run deps:check
+```
 
-- Dependabot proposes version upgrades and security fixes.
-- `knip` detects unused dependencies/exports that update bots do not remove.
+The gate runs on pull requests and pushes to `main`. It includes:
 
-## 1) Blocking Dependency Hygiene Gate
+- `bun run deps:audit`, which applies the high-severity and Hono policies to one audit response
+- `bun run deps:unused:deps`
+- `bun run deps:unused:exports`
 
-- Command: `bun run deps:check`
-- Includes:
-  - `bun run deps:audit`, which applies the high-severity and Hono policies to one audit response
-  - `bun run deps:unused:deps`
-  - `bun run deps:unused:exports`
+The workflow is `.github/workflows/dependency-hygiene.yml`.
 
-This check runs on pull requests and `main` pushes and must pass.
+## Unused code checks
 
-Implementation notes:
+`bun run deps:unused:deps` runs Knip for dependencies in all `@openducktor/*` workspaces.
 
-- Workflow: `.github/workflows/dependency-hygiene.yml`
+`bun run deps:unused:exports` runs Knip for exports in those workspaces. Use `bun run deps:unused:exports:report` only when a workflow must publish a report despite findings. Do not use the report command as a blocking gate.
 
-## 2) Unused Dependency Detection (Blocking Component)
+- Add a short reason beside each intentional Knip exclusion.
+- Do not export production code only for a test. Test it through public behavior or keep the helper in test code.
+- Remove `export` when a symbol is used only in its own file.
 
-- Command: `bun run deps:unused:deps`
-- Backed by: `knip`
-- Scope: all workspaces matching `@openducktor/*`
-- Check type: `dependencies`
-- Implementation: `bunx knip --workspace='@openducktor/*' --include dependencies`
+## Security checks
 
-This check is included in `deps:check`.
+`bun run deps:audit` fails when one `bun audit --json` response reports a high or critical advisory. It also fails if GHSA-`xh87-mx6m-69f3` or GHSA-`v8w9-8mx6-g223` returns. `hono` must resolve to `>=4.12.7`.
 
-## 3) Unused Export Detection (Blocking Component)
+The audit request fails with a transport error after 30 seconds instead of waiting for Bun's default idle timeout.
 
-- Command: `bun run deps:unused:exports`
-- Backed by: `knip`
-- Scope: all workspaces matching `@openducktor/*`
-- Check type: `exports`
-- Implementation: `bunx knip --workspace='@openducktor/*' --include exports`
+## Update reports
 
-This check is included in `deps:check`.
+Dependabot reads `.github/dependabot.yml`. It checks the Bun workspace and GitHub Actions each week. It groups patch and minor updates.
 
-Implementation notes:
+`bun run deps:outdated` lists packages that can be updated. `.github/workflows/dependency-hygiene-report.yml` publishes this list and the unused-export report each week.
 
-- Report-only command: `bun run deps:unused:exports:report`
-- Report-only implementation: `bunx knip --workspace='@openducktor/*' --include exports --no-exit-code`
-- Use the report-only command only for artifact generation where the workflow needs to publish findings even when unused exports exist. Do not use it for blocking local or CI gates.
-- Intentional public entry points or generated files should be excluded in Knip configuration with a short rationale next to the exclusion.
-- Do not export production symbols only for tests. Cover private helpers through public behavior, or move reusable test setup into test files.
-- When Knip reports an export that is only used inside its own source file, remove the `export` keyword unless another module should import it.
+## Update rules
 
-## 4) Outdated Dependency Review
-
-- Command: `bun run deps:outdated`
-- Backed by: `bun outdated`
-- Output: package versions that can be upgraded
-
-Implementation notes:
-
-- Dedicated report workflow: `.github/workflows/dependency-hygiene-report.yml`
-
-## 5) High/Critical Vulnerability Gate
-
-- Command: `bun run deps:audit:high`
-- Backed by: `bun audit --json`
-- Scope: blocks any dependency that resolves to a high or critical advisory
-
-Implementation notes:
-
-- Included through the single-request `deps:audit` command in `deps:check`, which runs in `.github/workflows/dependency-hygiene.yml`.
-- The audit request fails after 30 seconds with a transport error instead of waiting for Bun's default idle timeout.
-
-## 6) Targeted Vulnerability Gate (Hono)
-
-- Command: `bun run deps:audit:hono`
-- Backed by: `bun audit --json`
-- Scope: blocks GHSA-`xh87-mx6m-69f3` and GHSA-`v8w9-8mx6-g223` reintroduction (`hono` must resolve to `>=4.12.7`)
-
-Implementation notes:
-
-- Included through the single-request `deps:audit` command in `deps:check`, which runs in `.github/workflows/dependency-hygiene.yml`.
-
-## Cadence
-
-- Weekly (automated): Dependabot creates update PRs, and report CI publishes `bun run deps:unused:exports:report` plus `bun run deps:outdated` outputs.
-- Per PR and on `main` pushes (automated): dependency hygiene CI runs `bun run deps:check` to catch dependency drift, unused exports, and vulnerability regressions without blocking lint/typecheck/test/build.
-- Monthly (manual): open a dependency refresh PR for safe patch/minor updates.
-- Urgent security advisories: process outside cadence and patch immediately.
-
-## Upgrade Handling Guidelines
-
-- Prefer patch and minor upgrades in routine refreshes.
-- Treat major upgrades separately with focused testing and release notes review.
-- After upgrades, run:
-  - `bun run typecheck`
-  - `bun run test`
-  - `bun run build`
+- Put routine patch and minor updates in a dependency refresh pull request.
+- Put each major update in a separate pull request. Read its release notes and run focused tests.
+- Process an urgent security advisory at once.
+- After an update, run `bun run typecheck`, `bun run test`, and `bun run build`.

--- a/docs/effect.md
+++ b/docs/effect.md
@@ -69,6 +69,7 @@ export type SettingsConfigError = HostOperationError | HostPathAccessError | Hos
 export type SettingsConfigPort = {
   readConfig(): Effect.Effect<GlobalConfig | null, SettingsConfigError>;
   canonicalizePath(path: string): Effect.Effect<string, HostOperationError>;
+  pathExists(path: string): Effect.Effect<boolean, HostPathAccessError>;
   join(...paths: Array<string>): string;
 };
 
@@ -126,7 +127,7 @@ return yield* new HostOperationError({
 });
 ```
 
-Use `Effect.catchTag` when the product handles one known error. Use `Effect.catchAll` only when the product handles every error in the channel. A JavaScript `try` block inside `Effect.gen` does not catch an Effect failure.
+Use `Effect.catchTag` when the product handles one known error. Use `Effect.catchAll` only when the product handles every error in the channel. Use `Effect.result` when the caller needs the failure as a `Result`. A JavaScript `try` block inside `Effect.gen` does not catch an Effect failure.
 
 | Category | Example | Treatment |
 |---|---|---|
@@ -170,6 +171,8 @@ Use `Effect.sync` for synchronous work that must run inside the Effect runtime. 
 Use `Effect.gen` for ordered application steps:
 
 ```ts
+import { HostPathNotFoundError } from "../effect/host-errors";
+
 const loadWorkspace = (repoPath: string) =>
   Effect.gen(function* () {
     const settings = yield* SettingsConfigPortTag;

--- a/docs/effect.md
+++ b/docs/effect.md
@@ -127,7 +127,7 @@ return yield* new HostOperationError({
 });
 ```
 
-Use `Effect.catchTag` when the product handles one known error. Use `Effect.catchAll` only when the product handles every error in the channel. Use `Effect.result` when the caller needs the failure as a `Result`. A JavaScript `try` block inside `Effect.gen` does not catch an Effect failure.
+Use `Effect.catchTag` when the product handles one known error. Use `Effect.catchAll` only when the product handles every error in the channel. Use `Effect.either` when the caller needs success or failure as a value. Use `Effect.exit` when the caller also needs defect or interruption data. A JavaScript `try` block inside `Effect.gen` does not catch an Effect failure.
 
 | Category | Example | Treatment |
 |---|---|---|

--- a/docs/effect.md
+++ b/docs/effect.md
@@ -1,117 +1,59 @@
-# Effect Adoption Guide
+# Effect guide
 
-This guide describes how OpenDucktor uses Effect in TypeScript packages.
+Read this guide before you change a host port, service, adapter, lifecycle, or typed error.
 
-The short version:
+Use Effect for application work that performs I/O, can fail, owns a resource, starts background work, or needs controlled time and concurrency. Keep pure data and policy code in plain TypeScript.
 
-- Use Effect for fallible or I/O-producing application work.
-- Keep pure domain policy synchronous when it has no useful failure channel.
-- Model expected failures as typed errors.
-- Use `Context.Tag` and `Layer` for dependency injection.
-- Wrap Promise and throwing APIs at the adapter boundary.
-- Convert Effects to Promises only at explicit external boundaries.
-- Do not use Effect recovery operators to hide broken contracts.
-
-The current reference implementation is `packages/host`. Future migrations in `packages/openducktor-web`,
-`packages/openducktor-mcp`, and other eligible TypeScript packages should reuse these conventions instead of inventing
-package-local Effect styles.
-
-## Why Effect
-
-Effect is OpenDucktor's TypeScript execution model for code that has one or more of these properties:
-
-- it performs I/O
-- it can fail with an expected application or infrastructure error
-- it coordinates dependencies
-- it owns a resource lifecycle
-- it starts background work
-- it needs deterministic retry, polling, scheduling, or interruption behavior
-
-Effect makes those concerns explicit in the type:
+The main type is:
 
 ```ts
 Effect.Effect<Success, Failure, Requirements>
 ```
 
-Read this as:
+- `Success` is the result.
+- `Failure` is an expected typed failure.
+- `Requirements` lists services supplied through `Context` and `Layer`.
 
-- `Success`: the value produced when the operation succeeds
-- `Failure`: expected failures returned through the Effect error channel
-- `Requirements`: services that must be provided through `Context` and `Layer`
+A JavaScript defect is not an expected failure. Keep expected failures in the Effect error channel until a public boundary converts them.
 
-JavaScript defects can still happen. They are not the same thing as expected failures. Expected failures should be typed
-and propagated until a public boundary maps them to a user-visible or transport-visible error.
+`packages/host` is the current reference. Use the same rules in another package only when its I/O and lifecycle need them.
 
-## Where Effect Belongs
+## Where Effect fits
 
-Use Effect inside eligible TypeScript packages when the code is application, adapter, infrastructure, lifecycle, or
-transport orchestration code.
+Use Effect for:
 
-Good candidates:
+- Host commands and use cases.
+- MCP bridge discovery and calls.
+- Web startup, readiness, HTTP, and SSE.
+- Runtime process lifecycle.
+- File, Git, SQLite, and CLI adapters.
+- Bounded loops, schedules, retries, polling, and shutdown.
 
-- host command handling and use cases
-- MCP bridge discovery and host calls
-- web runner startup, readiness, HTTP, and SSE orchestration
-- runtime process lifecycle
-- filesystem, git, SQLite task store, and external CLI adapters
-- long-running loops, polling, retries, and shutdown logic
+Keep these in plain TypeScript:
 
-Do not force Effect into code that is clearer as plain TypeScript:
+- Pure transforms and predicates.
+- Schema constants and lookup data.
+- React local state.
+- DTOs that only serialize data.
+- Packages that only export types or constants.
 
-- pure data transforms
-- pure domain predicates
-- schema constants
-- enum or lookup definitions
-- React local UI state
-- serialization-only DTO definitions
-
-Pure code may call pure code directly. It does not become better because it returns `Effect.succeed(value)`.
+Do not wrap a pure value in `Effect.succeed` only for style.
 
 ## Boundaries
 
-Effect should be internal to the package unless the package intentionally exposes an Effect-native API.
+Keep Effect inside its package unless the package exports an Effect API by design.
 
-Promise interop is allowed at explicit boundaries:
+Convert to Promise at an Electron IPC handler, HTTP or SSE handler, CLI entry point, shell bridge, test boundary, or third-party Promise API.
 
-- Electron IPC handlers
-- browser HTTP and SSE handlers
-- CLI entrypoints
-- shell bridge adapters
-- third-party package APIs that require Promises
-- test harness boundaries
+Wrap an external Promise once in its adapter. Application services compose Effects, not `async` functions.
 
-Inside an Effect-native package, avoid `async` orchestration as the main implementation style. If an external API returns
-a Promise, wrap it once at the adapter boundary with `Effect.tryPromise`. Application services should compose Effects,
-not Promises.
+Before a package migration, check that the package owns expected failures, I/O, replaceable dependencies, resources, or concurrency. Start with one complete path. Do not convert a full package only to change syntax.
 
-## Package Eligibility
+## Services and layers
 
-Before migrating another package, check that Effect will improve the package's boundary rather than only changing syntax.
+Use a service for a replaceable port, adapter dependency, runtime, config source, process service, or resource owner.
 
-Effect is a good fit when the package owns fallible I/O, dependency wiring, long-lived resources, or concurrent runtime
-behavior.
-
-Effect is not automatically a good fit for:
-
-- public contract packages where Zod schemas are the source of truth
-- frontend read caching owned by TanStack Query
-- small packages that only re-export types or constants
-- pure domain packages with no meaningful failure or resource model
-
-When in doubt, migrate a narrow vertical path first and document the boundary. Do not migrate an entire package just to
-make every function return an Effect.
-
-## Dependency Injection
-
-Use Effect services for replaceable dependencies. A service is usually:
-
-- a port in a hexagonal boundary
-- an adapter dependency
-- a runtime or process service
-- a configuration or environment provider
-- a lifecycle collaborator that tests need to replace
-
-Define service tags with `Context.Tag`:
+Define the tag with `Context.Tag`:
 
 ```ts
 import type { GlobalConfig } from "@openducktor/contracts";
@@ -136,7 +78,7 @@ export class SettingsConfigPortTag extends Context.Tag("@openducktor/host/Settin
 >() {}
 ```
 
-Provide implementations with `Layer` at the composition root:
+Provide the implementation at the composition root:
 
 ```ts
 import { Layer } from "effect";
@@ -147,27 +89,21 @@ export const SettingsConfigPortLive = Layer.succeed(
 );
 ```
 
-Use a layer when an implementation is part of application wiring. Passing dependencies manually is still acceptable for
-small local factory functions, but application-level dependency graphs should be visible in one composition root.
+A small local factory can pass a dependency as an argument. Use layers when the app dependency graph needs one visible setup point.
 
-Current host reference:
+Rules:
 
-- `packages/host/src/ports/*`
-- `packages/host/src/composition/node/node-host-default-ports.ts`
+- Services depend on ports, not adapters.
+- Adapters implement ports and can import Node or third-party APIs.
+- Composition roots import and provide adapters.
+- Tests provide local fakes or test layers.
+- A required capability belongs in the port. Do not probe for an optional method at runtime.
 
-### Dependency Injection Rules
+References: `packages/host/src/ports/*` and `packages/host/src/composition/node/node-host-default-ports.ts`.
 
-- Application services depend on ports, not adapters.
-- Adapters implement ports and may import Node APIs or third-party APIs.
-- Composition roots import adapters and provide them through layers.
-- Tests replace services through local fake implementations or test layers.
-- Do not add runtime probes for optional methods. If a capability is required, make it part of the port.
+## Error model
 
-## Error Model
-
-Expected failures belong in the Effect error channel.
-
-Use `Data.TaggedError` for stable error types:
+Use `Data.TaggedError` for a stable expected error:
 
 ```ts
 import { Data } from "effect";
@@ -180,7 +116,7 @@ export class HostOperationError extends Data.TaggedError("HostOperationError")<{
 }> {}
 ```
 
-Inside `Effect.gen`, return failed effects explicitly:
+Return it from `Effect.gen`:
 
 ```ts
 return yield* new HostOperationError({
@@ -190,35 +126,23 @@ return yield* new HostOperationError({
 });
 ```
 
-Use `Effect.catchTag` when you intentionally recover from a specific expected failure. Avoid broad `catchAll` unless the
-product behavior truly handles every possible typed failure.
+Use `Effect.catchTag` when the product handles one known error. Use `Effect.catchAll` only when the product handles every error in the channel. A JavaScript `try` block inside `Effect.gen` does not catch an Effect failure.
 
-Do not use `try`/`catch` inside `Effect.gen` to catch Effect failures. Effect failures are not thrown JavaScript
-exceptions. Use `Effect.catchTag`, `Effect.catchAll`, or `Effect.result`.
+| Category | Example | Treatment |
+|---|---|---|
+| Rejection | User denied permission | Typed failure or an explicit success result |
+| Domain failure | Invalid task transition | Typed failure |
+| Infrastructure failure | File error or process exit | Typed failure at the adapter |
+| Defect | Broken invariant | Fail, or convert at the public boundary |
+| Interruption | Shutdown or canceled fiber | Run Effect cleanup |
 
-### Failure, Defect, and Interruption
+Do not hide a failed dependency with a fallback. Return an error from the layer that owns the failure.
 
-Use this taxonomy during design and review:
+References: `packages/host/src/effect/host-errors.ts` and `packages/host/src/domain/task/task-policy-error.ts`.
 
-| Category | Examples | Treatment |
-| --- | --- | --- |
-| Expected rejection | user denied permission, user cancelled | typed failure or explicit success value |
-| Domain failure | invalid task transition, missing required input | typed failure |
-| Infrastructure failure | filesystem error, process exit, git failure | typed failure at adapter boundary |
-| Defect | invariant violation, impossible state, programmer mistake | let it fail loudly or convert at a public boundary |
-| Interruption | shutdown, timeout, cancelled fiber | cleanup through Effect lifecycle primitives |
+## Wrap external APIs
 
-OpenDucktor does not add fallback behavior to mask broken contracts. If a dependency fails, propagate an actionable
-typed error from the layer where the failure originates.
-
-Current host reference:
-
-- `packages/host/src/effect/host-errors.ts`
-- `packages/host/src/domain/task/task-policy-error.ts`
-
-## Wrapping External APIs
-
-Use `Effect.tryPromise` for Promise-returning APIs:
+Use `Effect.tryPromise` for a Promise API:
 
 ```ts
 const ensureDirectory = (path: string) =>
@@ -229,7 +153,7 @@ const ensureDirectory = (path: string) =>
   }).pipe(Effect.asVoid);
 ```
 
-Use `Effect.try` for synchronous APIs that can throw, including parsers:
+Use `Effect.try` for a synchronous API that can throw:
 
 ```ts
 const parsePayload = (text: string) =>
@@ -239,14 +163,11 @@ const parsePayload = (text: string) =>
   });
 ```
 
-Use `Effect.sync` for synchronous code that does not throw but should run inside the Effect runtime, such as reserving
-mutable process-local state before forking background work.
+Use `Effect.sync` for synchronous work that must run inside the Effect runtime. One example is reserving process-local state before a fork.
 
-Do not wrap every pure expression. Prefer plain TypeScript until the code has a real Effect concern.
+## Compose steps
 
-## Composition Style
-
-Use `Effect.gen` for sequential application logic:
+Use `Effect.gen` for ordered application steps:
 
 ```ts
 const loadWorkspace = (repoPath: string) =>
@@ -267,7 +188,7 @@ const loadWorkspace = (repoPath: string) =>
   });
 ```
 
-Use `.pipe(...)` for transformations and short adapter pipelines:
+Use `.pipe(...)` for short transforms:
 
 ```ts
 Effect.tryPromise({
@@ -279,89 +200,57 @@ Effect.tryPromise({
 );
 ```
 
-Avoid deeply nested operators:
+Put the main Effect first. Do not wrap it in deeply nested operators.
 
 ```ts
-// Avoid
-Effect.asVoid(
-  Effect.tryPromise({
-    try: () => mkdir(path, { recursive: true }),
-    catch: (cause) => toHostOperationError(cause, "dir.ensure", { path }),
-  }),
-);
-
-// Prefer
 Effect.tryPromise({
   try: () => mkdir(path, { recursive: true }),
   catch: (cause) => toHostOperationError(cause, "dir.ensure", { path }),
 }).pipe(Effect.asVoid);
 ```
 
-Use named helpers when the same Effect pattern repeats enough to hide intent. Do not add a helper just to avoid one
-clear `Effect.tryPromise(...).pipe(...)` expression.
+Add a named helper when a repeated pattern hides what the code does. Keep one clear use inline.
 
-## Resource and Lifecycle Management
+## Resources and concurrency
 
-Use Effect runtime primitives for resources and background work:
+- Use `Effect.acquireUseRelease` or a scoped layer for acquire and release.
+- Use `Effect.addFinalizer` for cleanup tied to a scope.
+- Use `Effect.fork` for a background fiber.
+- Join or interrupt each owned fiber during shutdown.
+- Use `Deferred` for one-time coordination and single-flight work.
+- Use `Ref` for mutable Effect state.
+- Use `Schedule` with `Effect.retry` or `Effect.repeat` for a product retry or polling rule.
 
-- `Effect.acquireUseRelease` or scoped layers for resources with acquire/release lifecycles
-- `Effect.addFinalizer` for cleanup attached to a scope
-- `Effect.fork` for background fibers
-- `Fiber.join` or `Fiber.interrupt` for controlled shutdown
-- `Deferred` for one-time coordination and single-flight startup
-- `Ref` for mutable Effect state
-- `Schedule` with `Effect.retry` or `Effect.repeat` for explicit retry and polling behavior
+For single-flight startup, reserve the in-flight slot synchronously before the first yield. Then fork the work and complete a `Deferred` with the full `Exit`. Every caller then gets the same success or failure.
 
-Single-flight startup is a common OpenDucktor pattern. Reserve the in-flight operation synchronously, then fork the work,
-then complete a `Deferred` with the full `Exit` so all callers observe the same success or failure.
+`Deferred.make` and `Effect.fork` can yield. If code sets shared state after either call, two callers can both start the resource.
 
-This matters because `Deferred.make` and `Effect.fork` can yield. If shared process state is set only after a yield, two
-callers can both believe they own startup.
+References: `packages/host/src/adapters/mcp/mcp-host-bridge-server.ts` and `packages/host/src/adapters/runtimes/runtime-registry.ts`.
 
-Current host references:
+## Time and streams
 
-- `packages/host/src/adapters/mcp/mcp-host-bridge-server.ts`
-- `packages/host/src/adapters/runtimes/runtime-registry.ts`
-
-## Scheduling and Time
-
-Use Effect scheduling primitives for retries, polling, and loops only when they are explicit product behavior.
-
-Prefer readable duration strings:
+Use schedules only when retry, polling, or a loop is part of the product rule.
 
 ```ts
 Effect.sleep("500 millis");
 Schedule.fixed("5 seconds");
 ```
 
-Do not add retries to make failures disappear. Retrying must be part of the feature contract, such as waiting for a
-runtime that has just been launched.
+Use the Effect clock in a program so tests can control time.
 
-When code needs the current time inside an Effect program, prefer Effect's clock service over `Date.now()` so tests can
-control time deterministically.
+Use an Effect stream for SSE, process output, runtime events, watch mode, or subscription state. Bound stream reads in tests. Scope and finalize stream resources. Define backpressure. Convert native events at the transport boundary.
 
-## Streams
+Never collect an infinite stream without `Stream.take`, `takeUntil`, or another bound.
 
-Use Effect streams when a package owns a real stream: SSE, process output, runtime events, watch mode, or subscription
-state.
+## Tests
 
-Rules:
-
-- bound stream consumption in tests
-- do not collect infinite streams without `Stream.take`, `takeUntil`, or an equivalent bound
-- ensure stream resources are scoped and finalized
-- keep backpressure behavior explicit
-- convert to host or transport events only at the boundary
-
-## Testing
-
-Tests should run the Effect at the test boundary:
+Run the Effect at the test boundary:
 
 ```ts
 await Effect.runPromise(program);
 ```
 
-For service-dependent programs, provide a test layer or a local fake service:
+Provide a test layer for services:
 
 ```ts
 const TestSettingsConfig = Layer.succeed(SettingsConfigPortTag, fakeSettingsConfig);
@@ -369,79 +258,47 @@ const TestSettingsConfig = Layer.succeed(SettingsConfigPortTag, fakeSettingsConf
 await Effect.runPromise(program.pipe(Effect.provide(TestSettingsConfig)));
 ```
 
-When using Effect test helpers with a test clock:
+- Use `TestClock.adjust(...)` for controlled time.
+- Use a live clock only when wall time is the subject of the test.
+- Use scoped tests for resources with finalizers.
+- Interrupt forked fibers during cleanup.
+- Use a started latch and a gate for a concurrency test.
+- Inside an Effect test program, `yield*` a child Effect. Do not call `Effect.runPromise` again.
 
-- advance time with `TestClock.adjust(...)`
-- use live tests only when real wall-clock behavior is required
-- use scoped tests for resources that require finalization
-- interrupt forked fibers in cleanup paths
-- use a started latch plus a gate when asserting concurrency
+## Public boundaries
 
-Do not call `Effect.runPromise(...)` inside an already-running Effect test program. Stay inside the runtime and `yield*`
-the child Effect.
+Convert an Effect result at the edge that owns the caller contract. An IPC handler returns a Promise. An HTTP handler returns a status and body. An SSE handler writes frames. A CLI prints an error and exits with a code.
 
-## Public Boundaries
+Do not make an internal service throw only because its outer boundary needs a rejected Promise.
 
-Public boundaries must translate Effect results into the shape expected by the caller.
+## Migrate a package
 
-Examples:
+1. Name each external boundary such as CLI, HTTP, IPC, SDK, file, process, or transport.
+2. Define typed expected failures.
+3. Convert I/O ports and services to `Effect.Effect`.
+4. Add service tags for replaceable dependencies.
+5. Provide live layers at one composition root.
+6. Wrap Promise and throwing APIs in adapters.
+7. Move cleanup, schedules, and background work to Effect operators.
+8. Keep pure policy synchronous.
+9. Convert to Promise only at a public boundary.
+10. Test failures, replacement, cleanup, and relevant concurrency.
 
-- an Electron IPC handler returns a Promise and maps typed host errors to IPC errors
-- an HTTP route returns a response body and status code
-- an SSE endpoint maps stream events to transport frames
-- a CLI entrypoint logs an actionable error and exits with the right code
+The migration is complete when one full path uses Effect from its public adapter boundary through the service and back. Do not leave Promise orchestration in the middle.
 
-Keep this translation at the edge. Do not force internal services to throw because a boundary eventually needs a thrown
-or rejected Promise error.
+## Review checklist
 
-## Migration Recipe
+- I/O and expected failures use `Effect.Effect`.
+- Expected failures have tagged types.
+- Adapters wrap Promise APIs once.
+- Public Promise boundaries are clear.
+- Services depend on ports.
+- Layers make app dependency setup visible.
+- Recovery and retries match a product rule.
+- Cleanup runs on success, failure, and interruption.
+- Every background fiber has an owner.
+- Single-flight state changes before the first yield.
+- Pure code stays synchronous.
+- Tests control time, streams, fibers, and scopes.
 
-Use this sequence when migrating another eligible package:
-
-1. Identify the real external boundaries: CLI, HTTP, IPC, SDK, filesystem, process, or transport.
-2. Define typed errors for expected package failures.
-3. Convert ports and application services that perform I/O or can fail to return `Effect.Effect`.
-4. Add `Context.Tag` services for replaceable dependencies.
-5. Provide live implementations through a package composition root.
-6. Wrap Promise and throwing APIs at adapters with `Effect.tryPromise` or `Effect.try`.
-7. Move resource cleanup, polling, retries, and background work to Effect runtime primitives.
-8. Keep pure policy code synchronous.
-9. Convert to Promise only at public boundaries.
-10. Add tests for typed failures, dependency replacement, lifecycle cleanup, and concurrency when relevant.
-
-Do this vertically. A small path that is Effect-native end to end is better than a wide migration that leaves Promise
-orchestration in the middle.
-
-## Review Checklist
-
-Use this checklist for Effect code reviews:
-
-- Does fallible or I/O-producing application code return `Effect.Effect`?
-- Are expected failures typed with tagged errors?
-- Are Promise APIs wrapped at adapter boundaries?
-- Are public Promise boundaries explicit?
-- Does application code depend on ports/services instead of adapters?
-- Are services provided through `Context.Tag` and `Layer` where dependency wiring matters?
-- Are `catchAll`, retries, and default values real product behavior rather than fallback masking?
-- Does resource cleanup run on success, failure, and interruption?
-- Are background fibers joined, interrupted, or owned by a scope?
-- Are concurrent single-flight paths race-free before the first yield?
-- Is pure code kept simple and synchronous?
-- Are tests deterministic around time, streams, fibers, and scoped resources?
-
-## Current Reference Patterns
-
-The first OpenDucktor package migrated to Effect is `packages/host`. Use it as the reference for the next migrations, but
-preserve package boundaries:
-
-- port tags and Effect signatures: `packages/host/src/ports/*`
-- shared host errors: `packages/host/src/effect/host-errors.ts`
-- adapter Promise wrapping: `packages/host/src/adapters/attachments/local-attachment-adapter.ts`
-- dependency composition: `packages/host/src/composition/node/node-host-default-ports.ts`
-- command/router boundary: `packages/host/src/interface/router/*`
-- lifecycle shutdown: `packages/host/src/composition/host-lifecycle.ts`
-- single-flight runtime coordination: `packages/host/src/adapters/runtimes/runtime-registry.ts`
-- MCP bridge lifecycle: `packages/host/src/adapters/mcp/mcp-host-bridge-server.ts`
-
-The host is a reference, not a template to copy blindly. If a future package has a smaller dependency graph, use fewer
-layers. If a future package owns streams or request-scoped resources, use the Effect primitives that match that shape.
+Current examples are in `packages/host/src/ports/*`, `packages/host/src/effect/host-errors.ts`, `packages/host/src/adapters/attachments/local-attachment-adapter.ts`, `packages/host/src/composition/node/node-host-default-ports.ts`, `packages/host/src/interface/router/*`, `packages/host/src/composition/host-lifecycle.ts`, `packages/host/src/adapters/runtimes/runtime-registry.ts`, and `packages/host/src/adapters/mcp/mcp-host-bridge-server.ts`.

--- a/docs/external-mcp.md
+++ b/docs/external-mcp.md
@@ -211,7 +211,7 @@ The tool has no MCP `outputSchema` or `structuredContent`. It does not return st
 
 Unknown fields fail. `workspaceId` is optional only when the process has a default workspace.
 
-A requested key always appears. A missing spec or plan returns empty Markdown and `updatedAt: null`. A missing QA report also returns `verdict: "not_reviewed"`.
+A requested spec or plan key always appears. A missing spec or plan returns empty Markdown and `updatedAt: null`. The response omits `latestQaReport` when no QA report exists.
 
 The host stores and returns plain Markdown. If it cannot decode the latest stored body, that document gets an optional `error` with a host message. The read does not migrate old metadata.
 
@@ -226,11 +226,6 @@ The host stores and returns plain Markdown. If it cannot decode the latest store
     "implementationPlan": {
       "markdown": "## Plan",
       "updatedAt": "<ISO 8601 timestamp>"
-    },
-    "latestQaReport": {
-      "markdown": "",
-      "updatedAt": null,
-      "verdict": "not_reviewed"
     }
   }
 }

--- a/docs/external-mcp.md
+++ b/docs/external-mcp.md
@@ -1,106 +1,81 @@
-# External MCP Usage
+# External MCP
 
-## Purpose
+`@openducktor/mcp` exposes the `openducktor` MCP server outside the desktop app. It validates MCP calls and sends them to the OpenDucktor host. It never reads SQLite directly.
 
-This document describes the public OpenDucktor MCP package that can be used outside the desktop app.
+The host owns task-store readiness, task rules, and document writes. Desktop-managed and external MCP clients use the same host bridge.
 
-Both desktop-managed and standalone MCP paths route task operations through the OpenDucktor host. The TypeScript MCP package does not talk to the SQLite task store directly.
+## Configure a client
 
-- Desktop-managed launches receive `ODT_HOST_URL` from the desktop host automatically.
-- Standalone external use auto-discovers the current host bridge from the local discovery file.
-- `ODT_HOST_URL` and `--host-url` remain available as explicit overrides.
-- Startup fails if the host bridge is unhealthy or does not expose the required ODT tool surface.
-
-The MCP package is transport and validation only. The host remains the owner of SQLite task-store readiness, workflow transitions, and document persistence.
-
-Package name:
-
-- `@openducktor/mcp`
-
-MCP server name:
-
-- `openducktor`
-
-## Basic Configuration
-
-Example MCP config with a startup default workspace:
+Set a default workspace when one client will use one workspace:
 
 ```json
 {
   "mcpServers": {
     "openducktor": {
       "command": "bunx",
-      "args": [
-        "@openducktor/mcp",
-        "--workspace-id", "my-workspace"
-      ]
+      "args": ["@openducktor/mcp", "--workspace-id", "my-workspace"]
     }
   }
 }
 ```
 
-Example MCP config without a startup default workspace:
+Omit `--workspace-id` when each tool call will supply `workspaceId`:
 
 ```json
 {
   "mcpServers": {
     "openducktor": {
       "command": "bunx",
-      "args": [
-        "@openducktor/mcp"
-      ]
+      "args": ["@openducktor/mcp"]
     }
   }
 }
 ```
 
-Optional arguments:
+Arguments:
 
-- `--workspace-id <workspace-id>` optional default workspace for later workspace-scoped calls
-- `--host-url <url>`
-- `--host-token <token>` matching token for `--host-url`
+- `--workspace-id <workspace-id>` sets the default workspace.
+- `--host-url <url>` replaces host discovery.
+- `--host-token <token>` supplies the token for `--host-url`.
 
-Equivalent environment variables:
+Environment variables:
 
-- `ODT_WORKSPACE_ID` optional default workspace
-- `ODT_HOST_URL` optional override
-- `ODT_HOST_TOKEN` matching token for `ODT_HOST_URL`
-- `OPENDUCKTOR_CHANNEL=dev` selects development host discovery; leave it unset for production
-- `OPENDUCKTOR_DEV_INSTANCE` selects the exact development instance printed by its dev server
+- `ODT_WORKSPACE_ID` sets the default workspace.
+- `ODT_HOST_URL` replaces host discovery.
+- `ODT_HOST_TOKEN` supplies the token for `ODT_HOST_URL`.
+- `OPENDUCKTOR_CHANNEL=dev` selects development discovery. Leave it unset for production.
+- `OPENDUCKTOR_DEV_INSTANCE` selects the development instance printed by its server.
+- `OPENDUCKTOR_CONFIG_DIR` replaces the default `~/.openducktor` config root.
 
-Automatic discovery:
+## Host discovery
 
-- With `OPENDUCKTOR_CHANNEL` unset, the MCP reads the production host bridge from `runtime/mcp-bridge.json`.
-- With `OPENDUCKTOR_CHANNEL=dev`, the MCP requires `OPENDUCKTOR_DEV_INSTANCE` and reads the development host bridge from `runtime/dev-instances/<instanceId>/mcp-bridge.json`.
-- The MCP rejects empty or unknown channel values during automatic discovery. It does not try the other channel's file.
-- The default config directory is `~/.openducktor`.
-- Set `OPENDUCKTOR_CONFIG_DIR` to change the config root for the selected discovery file.
+Production discovery reads `runtime/mcp-bridge.json`. Development discovery requires both `OPENDUCKTOR_CHANNEL=dev` and `OPENDUCKTOR_DEV_INSTANCE`, then reads `runtime/dev-instances/<instanceId>/mcp-bridge.json`.
 
-To connect an external MCP client to `bun run electron:dev` or `bun run browser:dev`:
+An empty or unknown channel fails. The MCP process does not try another channel. OpenDucktor-managed runtime sessions get `ODT_HOST_URL` and `ODT_HOST_TOKEN` and do not use discovery files.
+
+Connect a client to a development server with:
 
 ```sh
 OPENDUCKTOR_CHANNEL=dev OPENDUCKTOR_DEV_INSTANCE=<instance-id> bunx @openducktor/mcp@latest
 ```
 
-Startup contract:
+## Startup
 
-1. Resolve an optional startup default workspace from `--workspace-id` or `ODT_WORKSPACE_ID`.
-2. Use `ODT_HOST_URL` or `--host-url` first when provided, with the matching token from `ODT_HOST_TOKEN` or `--host-token`.
-3. Otherwise read the local discovery file for the current host bridge URL and token.
-4. Validate the discovered host bridge before serving tools.
-5. Call authenticated `odt_mcp_ready` through the loopback host API.
-6. When a default workspace is configured, call `odt_get_workspaces` alongside readiness and require both calls to succeed.
-7. Refuse startup if any required ODT tool name is missing.
-8. Keep `/health` available as an unauthenticated diagnostic endpoint; MCP startup does not call it.
-9. Do not implicitly choose a workspace. Workspace-scoped tool calls must resolve a workspace from tool input `workspaceId` first, then the startup default.
+1. Read the default workspace from `--workspace-id` or `ODT_WORKSPACE_ID`.
+2. Use an explicit host URL and token when present. Otherwise, read the selected discovery file.
+3. Check the host bridge.
+4. Call authenticated `odt_mcp_ready`.
+5. When a default workspace exists, call `odt_get_workspaces` at the same time and require both calls to succeed.
+6. Check that every required ODT tool is present.
+7. Start MCP stdio only after all checks pass.
 
-Desktop-managed and standalone MCP clients intentionally use this same host-bridge path. The difference is only how the MCP learns the host URL: desktop mode injects it, while standalone mode usually discovers it. Workspace resolution is request-scoped for workspace-bound tools: tool-input `workspaceId` wins over any startup default, and missing both sources is an error.
+`/health` is an unauthenticated diagnostic route. MCP startup does not use it.
 
-OpenDucktor-managed OpenCode and Codex sessions receive explicit `ODT_HOST_URL` and `ODT_HOST_TOKEN` values. They do not depend on discovery files or `OPENDUCKTOR_CHANNEL`.
+The process does not choose an active or first workspace. A tool uses its `workspaceId` first, then the startup default. If neither exists, the call fails.
 
-## Public Tools
+## Tool access
 
-Public external tools:
+Public tools:
 
 - `odt_get_workspaces`
 - `odt_create_task`
@@ -109,7 +84,7 @@ Public external tools:
 - `odt_read_task_assets`
 - `odt_read_task_documents`
 
-Internal workflow tools remain on the same MCP server:
+Workflow tools on the same server:
 
 - `odt_set_spec`
 - `odt_set_plan`
@@ -120,13 +95,11 @@ Internal workflow tools remain on the same MCP server:
 - `odt_qa_approved`
 - `odt_qa_rejected`
 
-Current OpenDucktor Spec/Planner/Builder/QA agents must not receive `odt_create_task`, `odt_search_tasks`, or `odt_get_workspaces` in their tool selection.
+Task-bound Spec, Planner, Builder, and QA sessions do not get `odt_get_workspaces`, `odt_create_task`, or `odt_search_tasks`.
 
-## Workspace Discovery And Scoping
+## List workspaces
 
-Use `odt_get_workspaces` when you start the MCP without a default workspace and need to discover the canonical `workspaceId` values known to the host.
-
-`odt_get_workspaces` takes no input and returns the existing shared workspace record shape:
+Call `odt_get_workspaces` when the process has no default workspace or when the client needs canonical workspace IDs. The tool takes no input.
 
 ```json
 {
@@ -145,23 +118,16 @@ Use `odt_get_workspaces` when you start the MCP without a default workspace and 
 }
 ```
 
-Workspace resolution for workspace-scoped tools is deterministic:
+## Task summary
 
-1. top-level tool input `workspaceId`
-2. startup default workspace resolved once at process startup from `--workspace-id` or `ODT_WORKSPACE_ID`
-
-If no workspace can be resolved, the MCP rejects the call with an actionable error instead of selecting an active or first workspace.
-
-## Shared Response Model
-
-`odt_create_task`, `odt_search_tasks`, and `odt_read_task` reuse the same lightweight public task summary shape:
+`odt_create_task`, `odt_search_tasks`, and `odt_read_task` use this task summary:
 
 ```json
 {
   "task": {
     "id": "repo-123",
     "title": "Implement MCP docs",
-    "description": "Document the external MCP surface.",
+    "description": "Document the external MCP tools.",
     "status": "ai_review",
     "priority": 2,
     "issueType": "task",
@@ -179,193 +145,75 @@ If no workspace can be resolved, the MCP rejects the call with an actionable err
 }
 ```
 
-This is a discovery-only summary. Call `odt_read_task` first. Read referenced description images with one `odt_read_task_assets` batch, and call `odt_read_task_documents` only for the document bodies you actually need.
+`qaVerdict` is `approved`, `rejected`, or `not_reviewed`. Public summaries omit `parentId`, `availableActions`, and `agentWorkflows`.
 
-`qaVerdict` is `"approved"`, `"rejected"`, or `"not_reviewed"`. `not_reviewed` means the task has no persisted QA report yet.
+Call `odt_read_task` first. It tells the client which documents exist and which images the description refers to. Read only the bodies and images needed for the task.
 
-Public MCP task snapshots intentionally do not expose:
+## Create a task
 
-- `parentId`
-- `availableActions`
-- `agentWorkflows`
+`odt_create_task` requires `title`, `issueType`, and `priority`.
 
-## `odt_create_task`
+- `issueType` is `task`, `feature`, or `bug`. MCP rejects `epic`.
+- `priority` is an integer from 0 through 4.
+- `description`, `labels`, and `aiReviewEnabled` are optional.
+- `workspaceId` is optional only when the process has a default workspace.
 
-Creates a new public task.
+The result is `{ task }`.
 
-Allowed inputs:
+## Read a task
 
-- `workspaceId` optional per-call workspace override
-- `title` is required
-- `issueType` is required: `task | feature | bug`
-- `priority` is required: `0 | 1 | 2 | 3 | 4`
-- `description` optional
-- `labels` optional
-- `aiReviewEnabled` optional
+`odt_read_task` requires `taskId`. It also requires `workspaceId` when the process has no default workspace. The result is `{ task }` with the shared summary shape.
 
-Constraints:
+## Search tasks
 
-- `epic` is rejected at the MCP schema layer.
-- Input fields mirror the current desktop create form only.
-- When the MCP started without `--workspace-id` or `ODT_WORKSPACE_ID`, `workspaceId` is required at call time.
-
-Output:
-
-- `{ task }`
-
-## `odt_read_task`
-
-Reads one persisted task summary.
-
-Input:
-
-- `workspaceId` optional per-call workspace override
-- `taskId` required
-
-When the MCP started without `--workspace-id` or `ODT_WORKSPACE_ID`, `workspaceId` is required at call time.
-
-Output:
-
-```json
-{
-  "task": {
-    "id": "repo-123",
-    "title": "Implement MCP docs",
-    "description": "Document the external MCP surface.",
-    "status": "ai_review",
-    "priority": 2,
-    "issueType": "task",
-    "aiReviewEnabled": true,
-    "labels": ["docs", "mcp"],
-    "createdAt": "<ISO 8601 timestamp>",
-    "updatedAt": "<ISO 8601 timestamp>",
-    "qaVerdict": "approved",
-    "documents": {
-      "hasSpec": true,
-      "hasPlan": true,
-      "hasQaReport": true
-    }
-  }
-}
-```
-
-Call `odt_read_task` first to discover task state, `qaVerdict`, and document availability. If the description contains `odt-asset:<assetId>` image targets needed for the work, collect the IDs and call `odt_read_task_assets` once. Use `odt_read_task_documents` only when you need the actual persisted markdown bodies.
-
-## `odt_search_tasks`
-
-Searches active tasks only.
+`odt_search_tasks` returns active tasks. It does not return `closed` tasks.
 
 Optional filters:
 
 - `workspaceId`
-- `priority`
-- `issueType`
-- `status`
-- `title`
-- `tags`
-- `limit`
+- `priority`, exact match
+- `issueType`, exact match
+- `status`, exact active status
+- `title`, case-insensitive substring
+- `tags`, all tags must match
+- `limit`, default 50 and maximum 100
 
-Search semantics:
-
-- `priority`: exact match
-- `issueType`: exact match. Active epics may appear in search results.
-- `status`: exact active-status match only
-- `title`: case-insensitive substring match
-- `tags`: AND semantics, task must contain all provided tags
-- `limit`: default `50`, max `100`
-
-Excluded statuses:
-
-- `closed`
-
-When the MCP started without `--workspace-id` or `ODT_WORKSPACE_ID`, `workspaceId` is required at call time.
-
-Output:
+Active epics can appear in results. `workspaceId` is optional only when the process has a default workspace.
 
 ```json
 {
-  "results": [
-    {
-      "task": {
-        "id": "repo-123",
-        "title": "Implement MCP docs",
-        "description": "Document the external MCP surface.",
-        "status": "ai_review",
-        "priority": 2,
-        "issueType": "task",
-        "aiReviewEnabled": true,
-        "labels": ["docs", "mcp"],
-        "createdAt": "<ISO 8601 timestamp>",
-        "updatedAt": "<ISO 8601 timestamp>",
-        "qaVerdict": "approved",
-        "documents": {
-          "hasSpec": true,
-          "hasPlan": true,
-          "hasQaReport": true
-        }
-      }
-    }
-  ],
+  "results": [{ "task": { "id": "repo-123", "title": "Implement MCP docs" } }],
   "limit": 50,
   "totalCount": 1,
   "hasMore": false
 }
 ```
 
-## `odt_read_task_assets`
+Each result has the full shared task summary.
 
-Reads task-description images as native MCP image content.
+## Read task images
 
-Input:
+`odt_read_task_assets` reads description images as MCP image blocks. It requires `taskId` and 1 through 50 unique asset UUIDs. It also requires `workspaceId` when the process has no default workspace.
 
-- `workspaceId` optional per-call workspace override
-- `taskId` required
-- `assetIds` required array of 1 to 50 distinct asset UUIDs
+Send one call when the raw images total at most 20 MiB. Split a larger set. The host checks every asset and the total size before it reads any file. It also checks workspace, task, `description` scope, media type, stored size, and request order. One bad ID fails the full call.
 
-The caller should collect all description images needed for the current work and request them in one call when their raw total is at most 20 MiB. Split only larger sets. The host resolves aliases or titles to the canonical task ID, checks each registry row and the aggregate byte limit before reading files, checks each asset against the exact workspace, task, and `description` scope, and keeps request order. The whole call fails if any ID is missing, belongs to another task or workspace, exceeds a byte limit, or cannot pass the stored media and byte-size checks.
+For each ID, the MCP response contains a short text block and an `image` block with base64 data and a checked MIME type. Supported types are PNG, JPEG, WebP, and GIF.
 
-The MCP response contains, for each requested ID:
+The tool has no MCP `outputSchema` or `structuredContent`. It does not return storage paths, runtime URLs, or registry rows.
 
-1. a short text block that identifies the asset, media type, and byte size
-2. an `image` block with base64 data and its verified MIME type
+## Read task documents
 
-The tool has no MCP `outputSchema` and returns no `structuredContent`. This is deliberate: clients receive the image blocks directly instead of preferring a private bridge JSON object. Storage paths, runtime URLs, and registry records never leave the host.
+`odt_read_task_documents` requires `taskId` and at least one `true` flag:
 
-Supported media types:
+- `includeSpec`
+- `includePlan`
+- `includeQaReport`
 
-- `image/png`
-- `image/jpeg`
-- `image/webp`
-- `image/gif`
+Unknown fields fail. `workspaceId` is optional only when the process has a default workspace.
 
-When the MCP started without `--workspace-id` or `ODT_WORKSPACE_ID`, `workspaceId` is required at call time.
+A requested key always appears. A missing spec or plan returns empty Markdown and `updatedAt: null`. A missing QA report also returns `verdict: "not_reviewed"`.
 
-## `odt_read_task_documents`
-
-Reads only the requested persisted document bodies.
-
-Input:
-
-- `workspaceId` optional per-call workspace override
-- `taskId` required
-- `includeSpec` optional boolean
-- `includePlan` optional boolean
-- `includeQaReport` optional boolean
-
-Constraints:
-
-- Unknown input fields are rejected.
-- At least one include flag must be `true`.
-- When the MCP started without `--workspace-id` or `ODT_WORKSPACE_ID`, `workspaceId` is required at call time.
-- Requested document keys are returned consistently even when no persisted body exists yet.
-- Missing spec and plan return `{ "markdown": "", "updatedAt": null }`.
-- Missing latest QA report returns `{ "markdown": "", "updatedAt": null, "verdict": "not_reviewed" }`.
-- Workflow documents are stored as plain markdown in the host-owned task store.
-- Successful MCP reads return plain markdown.
-- When the latest stored document cannot be decoded, the returned document includes an optional `error` field with an actionable host-supplied message.
-- There is no automatic migration of older markdown-only metadata.
-
-Output:
+The host stores and returns plain Markdown. If it cannot decode the latest stored body, that document gets an optional `error` with a host message. The read does not migrate old metadata.
 
 ```json
 {
@@ -375,23 +223,22 @@ Output:
       "updatedAt": "<ISO 8601 timestamp>",
       "error": "Failed to decode openducktor.documents.spec[0]: invalid base64 payload"
     },
-    "implementationPlan": { "markdown": "## Plan", "updatedAt": "<ISO 8601 timestamp>" },
+    "implementationPlan": {
+      "markdown": "## Plan",
+      "updatedAt": "<ISO 8601 timestamp>"
+    },
     "latestQaReport": {
       "markdown": "",
-      "updatedAt": "<ISO 8601 timestamp>",
-      "verdict": "approved",
-      "error": "Failed to decode openducktor.documents.qaReports[0]: invalid gzip payload"
+      "updatedAt": null,
+      "verdict": "not_reviewed"
     }
   }
 }
 ```
 
-`error` is optional. It is omitted for healthy documents and for documents that do not exist yet.
+## Ownership
 
-## Architecture Notes
-
-- `packages/openducktor-mcp` owns MCP transport, request validation, response validation, and packaging.
-- The OpenDucktor host owns SQLite task-store readiness, task reads and writes, workflow transitions, recovery, and canonical document writes.
-- The host bridge surface mirrors the MCP tool names so desktop-managed and standalone MCP clients use the same execution path.
-- The host bridge uses a validated base64 DTO for task assets; the MCP adapter alone turns it into native image content blocks.
-- The task store stays modeled as host-owned storage infrastructure. It is not part of the MCP runtime contract beyond the host-owned bridge being healthy.
+- `packages/openducktor-mcp` owns MCP transport, request and response checks, image-block conversion, and packaging.
+- The host owns SQLite readiness, task reads and writes, workflow rules, recovery, and document writes.
+- The bridge mirrors MCP tool names so all MCP clients use one execution path.
+- The host bridge sends task images as a checked base64 DTO. Only the MCP adapter converts it to image blocks.

--- a/docs/frontend-guidelines.md
+++ b/docs/frontend-guidelines.md
@@ -1,0 +1,53 @@
+# Frontend guidelines
+
+Read this guide before you change frontend state, forms, components, or themes.
+
+Read [the TanStack Query cache strategy](tanstack-query-cache-strategy.md) before you add or change a frontend read from the host or backend.
+
+## State and files
+
+- Wire state contexts in `packages/frontend/src/state/app-state-provider.tsx`.
+- Put domain operations in focused hooks under `packages/frontend/src/state/{lifecycle,operations,tasks}`.
+- Put shared types in `packages/frontend/src/types`.
+- Put feature constants in `constants.ts`.
+- Use operation-specific flags such as `isLoadingTasks` and `isLoadingChecks`.
+- Do not use a generic busy flag or a magic string.
+
+## Forms and control flow
+
+- Disable the full form during an async submission.
+- Show loading in the submit button.
+- Keep pending, error, or success feedback visible.
+- Replace nested ternaries with named booleans, helper functions, lookup maps, or explicit `if` and `else` statements.
+
+## Components and themes
+
+The app uses shadcn semantic tokens with Tailwind CSS v4. Tokens are in `packages/frontend/src/styles.css`.
+
+- Use a component from `packages/frontend/src/components/ui` when one exists.
+- Use semantic tokens for structural UI.
+- Apply semantic tokens with `className` at the use site.
+- Keep base shadcn components free of feature-specific hardcoded colors.
+- Make each new UI element work in light and dark themes.
+- Do not use hardcoded gray colors or gradient backgrounds for structural UI.
+
+| Purpose | Use |
+|---|---|
+| Page background | `bg-background` |
+| Card or surface | `bg-card` |
+| Main text | `text-foreground` |
+| Secondary text | `text-muted-foreground` |
+| Layout border | `border-border` |
+| Input border | `border-input` |
+| Subtle surface | `bg-muted` |
+| Interactive accent | `bg-primary`, `text-primary-foreground` |
+| Destructive action | `bg-destructive`, `text-destructive` |
+| Sidebar | `bg-sidebar`, `text-sidebar-foreground`, `border-sidebar-border` |
+
+## Hardcoded color exceptions
+
+- Use `bg-emerald-*` for success, `bg-sky-*` for information, `bg-amber-*` for a warning, and `bg-rose-*` for an error.
+- Use the accent colors in `kanban-theme.ts` for Kanban lane themes.
+- Use hardcoded colors for small badges and tags that have semantic meaning.
+- Prefer a light background such as `bg-sky-50` and dark text such as `text-sky-700`.
+- Add dark-theme classes for each hardcoded color.

--- a/docs/frontend-guidelines.md
+++ b/docs/frontend-guidelines.md
@@ -41,7 +41,7 @@ The app uses shadcn semantic tokens with Tailwind CSS v4. Tokens are in `package
 | Input border | `border-input` |
 | Subtle surface | `bg-muted` |
 | Interactive accent | `bg-primary`, `text-primary-foreground` |
-| Destructive action | `bg-destructive`, `text-destructive` |
+| Destructive action | `bg-destructive`, `text-destructive-foreground` |
 | Sidebar | `bg-sidebar`, `text-sidebar-foreground`, `border-sidebar-border` |
 
 ## Hardcoded color exceptions

--- a/docs/interactive-terminal-architecture.md
+++ b/docs/interactive-terminal-architecture.md
@@ -1,63 +1,65 @@
 # Interactive terminal architecture
 
-Interactive terminals are transient resources owned by the host process. The host owns each PTY, its process tree, and its in-memory session state. The renderer owns the xterm instances and transient terminal presentation state.
+The host owns each PTY, process tree, and in-memory terminal session. The renderer owns xterm and tab display state.
 
-Terminal sessions, tab state, and transcripts are not stored in settings or in the SQLite task store. After a renderer reload, the UI rediscovers and reattaches to terminals that still belong to the same running host. Stopping the app or host terminates and forgets them.
+The app does not store terminal sessions, tabs, or transcripts in settings or SQLite. After a renderer reload, the UI finds terminals that still belong to the same host and attaches again. Host shutdown stops and forgets them.
 
-## Components and boundaries
+## Ownership and transport
 
-- `packages/contracts` defines terminal commands, summaries, typed failures, and the versioned binary protocol. Each frame contains a four-byte big-endian length for the JSON header, the JSON header itself, and an optional binary payload.
-- `packages/host` owns terminal IDs, launch policy, admission limits, the in-memory session registry, output replay, byte sequencing, flow control, title tracking, and cleanup. Runtime-specific PTY implementations use the `TerminalPtyPort` interface.
-- Electron uses `node-pty` and carries terminal frames over a dedicated preload IPC bridge.
-- The browser runner uses `Bun.spawn({ terminal })` and carries frames over one authenticated, origin-checked, multiplexed WebSocket with the `openducktor-terminal.v1` subprotocol.
-- `packages/frontend/src/features/terminals` contains the reusable terminal panel, collection hook, tab presentation state, transport controller, xterm renderer, and input policies. Agent Studio uses a thin adapter that resolves the selected task worktree and supplies its task context to this module. The transport controller shares one connection across the mounted terminal emulators.
+- `packages/contracts` defines commands, summaries, typed failures, and the binary protocol. A frame has a four-byte big-endian JSON header length, the JSON header, and an optional binary body.
+- `packages/host` owns IDs, launch rules, limits, in-memory sessions, output replay, byte order, flow control, titles, and cleanup. PTY adapters implement `TerminalPtyPort`.
+- Electron uses `node-pty` over a dedicated preload IPC bridge.
+- The web runner uses `Bun.spawn({ terminal })` over one authenticated WebSocket. It checks origin and requires the `openducktor-terminal.v1` subprotocol.
+- `packages/frontend/src/features/terminals` owns the shared panel, collection hook, tabs, transport controller, xterm renderer, and input rules. Agent Studio only supplies the task worktree and task context.
 
-Create, list, close, and path-preparation requests use the normal host command interface. Interactive input, resize, attach, detach, ACK, output, lifecycle, and title messages use the terminal frame transport. Electron and the browser runner compose their PTY adapters explicitly; neither transport falls back to another adapter.
+Create, list, close, and path setup use host commands. Input, resize, attach, detach, ACK, output, lifecycle, and title use terminal frames. Electron and web each provide one PTY adapter. Neither falls back to the other.
 
-## Launch and terminal context
+## Start a terminal
 
-`workingDir` is required when creating a terminal. The host canonicalizes the path, verifies that it is an accessible directory, and records it as `initialWorkingDir`. This field is the launch directory, not the shell's current directory after later `cd` commands.
+`workingDir` is required. The host makes it canonical, checks that it is an accessible directory, and saves it as `initialWorkingDir`. Later `cd` commands do not change that field.
 
-The host chooses the shell, arguments, and sanitized child-process environment. The renderer cannot provide an executable, arguments, or environment variables. On Unix-like systems, terminals use the user's login shell with `TERM=xterm-256color` and `COLORTERM=truecolor`.
+The host selects the shell, arguments, and clean child environment. The renderer cannot choose an executable, arguments, or environment variables. On Unix, use the login shell with `TERM=xterm-256color` and `COLORTERM=truecolor`.
 
-A terminal can be unassociated or include a task context containing `repoPath` and `taskId`. The context is used for listing, limits, and cleanup. It does not restrict filesystem access inside the shell.
+A terminal can have no task or have `repoPath` and `taskId`. The host uses this context for lists, limits, and cleanup. It does not restrict file access inside the shell.
 
-The initial terminal title is the canonical launch directory. The host then observes bounded OSC 0 and OSC 2 title sequences without changing the PTY output. It sanitizes the latest title, stores it in the in-memory summary, and sends it in attachment snapshots and live title events. The renderer uses this host-provided title instead of deriving a second title from terminal output.
+The first title is the canonical start directory. The host then reads bounded OSC 0 and OSC 2 title codes without changing PTY output. It cleans and stores the latest title, then sends it in snapshots and title events.
 
-## Attachment, replay, and flow control
+## Attach and replay
 
-Attaching adds the renderer as an output consumer before sending a snapshot. The snapshot contains the current lifecycle, title, earliest retained sequence, and snapshot end sequence. The host then sends the retained output followed by live output. Output bytes use monotonically increasing sequence ranges, and exit is emitted after the final output sequence has been published.
+The host adds an output consumer before it sends the attachment snapshot. The snapshot has lifecycle, title, first retained byte sequence, and snapshot end sequence. The host then sends retained output followed by live output. Exit comes after the final output sequence.
 
-The renderer records the last sequence consumed by xterm. An ACK is sent only after xterm's write callback completes. On reattachment, the renderer provides that sequence so the host sends only the required retained output. If the requested range has already been discarded, the host sends a `replay_gap` event and the renderer resets the emulator before continuing.
+The renderer records the last sequence written to xterm. It sends ACK only after the xterm write callback finishes. On another attach, it sends that sequence so the host sends only missing output.
 
-During initial attachment, the terminal remains hidden until xterm has consumed output through the snapshot boundary. This rebuilds the current screen without exposing replay as a visible animation.
+If the host already dropped the requested range, it sends `replay_gap`. The renderer resets xterm before it applies later output. During first attach, keep xterm hidden until it reaches the snapshot boundary.
 
-Replay and unacknowledged output are byte-bounded. The `node-pty` adapter pauses and resumes output when consumers fall behind. An adapter that cannot pause output, such as the Bun PTY adapter, emits an overflow event and terminates the terminal instead of buffering without a limit.
+Replay and unacknowledged output have byte limits. `node-pty` can pause and resume. An adapter that cannot pause, such as Bun PTY, sends overflow and stops the terminal.
 
-The frontend reconnects the frame transport automatically and reattaches mounted terminals. A transport disconnect only removes the affected attachments; it does not terminate or recreate the PTY. If the host instance changes while the renderer still holds terminal tabs, those tabs are marked as lost. A stale attach receives `terminal_forgotten`. Lost terminals are never recreated automatically.
+The frontend reconnects the frame transport and attaches mounted terminals again. A transport loss removes attachments, not the PTY. If the host instance changes, old tabs become lost. A stale attach gets `terminal_forgotten`. Do not recreate a lost terminal.
 
-## Lifecycle and cleanup
+## Close and clean up
 
-Closing a terminal without confirmation first checks whether its PTY has child processes. If no child process is running, the terminal closes without prompting. If a child process is running, the host returns `confirmation_required`; a confirmed close terminates the process tree and removes the session. The UI hides a tab while close is pending and restores it if confirmation is required or the close fails.
+Before an unconfirmed close, the host checks for child processes. With no child, it closes at once. With a child, it returns `confirmation_required`. A confirmed close stops the process tree and removes the session.
 
-Task close, delete, reset, and merged-worktree cleanup acquire a terminal cleanup lease and terminate the associated terminals before stopping dev servers or removing worktrees, branches, and task records. A terminal cleanup failure stops the remaining cleanup. The lease also prevents a new terminal from being admitted for that task while cleanup is in progress.
+The UI hides a tab while close is pending. It restores the tab when confirmation is needed or close fails.
 
-Host shutdown stops terminal admission, terminates all PTYs and their process trees, and then continues normal host teardown. Exited sessions may remain in host memory for bounded replay and inspection, but they are removed after the retention limit or when the retained-session limit is reached.
+Task close, delete, reset, and merged-worktree cleanup take a terminal cleanup lease. They stop task terminals before dev servers, worktrees, branches, or task records. A terminal failure stops later cleanup. The lease blocks a new task terminal during cleanup.
 
-No PTY handle, PID, route, terminal ID, live interaction state, or transcript is persisted. Adding terminal persistence would require a separate decision covering privacy, retention, recovery, and access control.
+Host shutdown stops admission, stops all PTYs and process trees, then continues host cleanup. An exited session can stay in memory for bounded replay until time or count limits remove it.
 
-## Keyboard, clipboard, and image input
+Do not persist a PTY handle, PID, route, terminal ID, live state, or transcript. Terminal persistence needs a separate decision about privacy, retention, recovery, and access.
 
-The frontend reads the platform from the host and applies platform-specific terminal shortcuts. Normal terminal input is UTF-8 encoded and sent in ordered chunks within the protocol input limit.
+## Keyboard, clipboard, and images
 
-Clipboard image paste sends the terminal's native paste control input so compatible TUIs can read the image from the operating-system clipboard. Image drag and drop follows a different path: the renderer stages each image as a local attachment, asks the host to format shell-safe paths for the terminal's shell, and pastes those paths into xterm. Image bytes are not sent through the terminal protocol.
+The frontend gets the platform from the host and applies terminal shortcuts. It sends normal input as ordered UTF-8 chunks within the input limit.
 
-Drag and drop accepts at most eight images, 20 MiB per image, and 40 MiB in total. Interaction failures are reported without replacing the terminal screen. Renderer initialization or WebGL failure is blocking for that emulator and is shown in the terminal body.
+Image paste sends the terminal's native paste control so a compatible TUI can read the OS clipboard. Image drag and drop stages each image, asks the host for shell-safe paths, and pastes those paths into xterm. It does not send image bytes through the terminal protocol.
 
-## Limits and transport security
+Drag and drop accepts at most eight images, 20 MiB each, and 40 MiB total. An interaction error does not replace the terminal screen. xterm or WebGL startup failure blocks that emulator and appears in its body.
 
-The host limits live terminals per task and per host, input size, grid dimensions, replay bytes, unacknowledged output, and retained exited sessions. The transports also limit frame size and outbound queues. Every operation uses an opaque terminal ID.
+## Limits and security
 
-Browser WebSocket upgrades require the established HttpOnly app session, an allowed frontend origin, and the exact terminal protocol subprotocol. Invalid directions, malformed frames, and unsupported protocol versions fail explicitly.
+The host limits terminals per task and host, input bytes, grid size, replay bytes, unacknowledged output, and retained exited sessions. The transports limit frame size and output queues. Each operation uses an opaque terminal ID.
 
-Electron keeps `node-pty` as a production dependency, excludes its build scripts from the package, and unpacks its native files from ASAR through Electron Builder configuration. The terminal feature does not use a dependency-specific packaging script.
+A browser WebSocket upgrade needs the HttpOnly app session, an allowed frontend origin, and the exact protocol name. Invalid direction, frame, or protocol version fails.
+
+Electron keeps `node-pty` as a production dependency. The package excludes its build scripts and unpacks native files from ASAR through Electron Builder. No dependency-specific package script handles terminals.

--- a/docs/interactive-terminal-architecture.md
+++ b/docs/interactive-terminal-architecture.md
@@ -10,7 +10,7 @@ The app does not store terminal sessions, tabs, or transcripts in settings or SQ
 - `packages/host` owns IDs, launch rules, limits, in-memory sessions, output replay, byte order, flow control, titles, and cleanup. PTY adapters implement `TerminalPtyPort`.
 - Electron uses `node-pty` over a dedicated preload IPC bridge.
 - The web runner uses `Bun.spawn({ terminal })` over one authenticated WebSocket. It checks origin and requires the `openducktor-terminal.v1` subprotocol.
-- `packages/frontend/src/features/terminals` owns the shared panel, collection hook, tabs, transport controller, xterm renderer, and input rules. Agent Studio only supplies the task worktree and task context.
+- `packages/frontend/src/features/terminals` owns the shared panel, collection hook, tabs, transport controller, xterm renderer, and input rules. Its transport controller shares one connection across the mounted terminal emulators. Agent Studio only supplies the task worktree and task context.
 
 Create, list, close, and path setup use host commands. Input, resize, attach, detach, ACK, output, lifecycle, and title use terminal frames. Electron and web each provide one PTY adapter. Neither falls back to the other.
 
@@ -26,7 +26,7 @@ The first title is the canonical start directory. The host then reads bounded OS
 
 ## Attach and replay
 
-The host adds an output consumer before it sends the attachment snapshot. The snapshot has lifecycle, title, first retained byte sequence, and snapshot end sequence. The host then sends retained output followed by live output. Exit comes after the final output sequence.
+The host adds an output consumer before it sends the attachment snapshot. The snapshot has lifecycle, title, first retained byte sequence, and snapshot end sequence. The host then sends retained output followed by live output. Output byte sequences increase monotonically. Exit comes after the final output sequence.
 
 The renderer records the last sequence written to xterm. It sends ACK only after the xterm write callback finishes. On another attach, it sends that sequence so the host sends only missing output.
 

--- a/docs/mcp-runtime-security.md
+++ b/docs/mcp-runtime-security.md
@@ -1,31 +1,29 @@
-# MCP Runtime Security Assumptions
+# MCP runtime security
 
-This document defines allowed runtime transports and threat assumptions for `@openducktor/mcp`.
+This document defines the allowed transport and threat model for `@openducktor/mcp` version 1.
 
-## Allowed Transports (V1)
+## Allowed transport
 
-- Allowed: MCP `stdio` transport only.
-- Not allowed: network transports (`streamable-http`, SSE, WebSocket, Lambda adapters, reverse-proxied HTTP endpoints).
+Use MCP `stdio` only. `packages/openducktor-mcp/src/index.ts` uses `StdioServerTransport`.
 
-Current implementation uses `StdioServerTransport` in
-`packages/openducktor-mcp/src/index.ts`.
+Do not expose `streamable-http`, SSE, WebSocket, Lambda, or a reverse-proxied HTTP endpoint.
 
-## Threat Assumptions (V1)
+## Threat model
 
-- The MCP server is launched as a local child process by a trusted OpenDucktor runtime.
-- Transport channel is process-local stdio, not internet-reachable.
-- Request metadata from external network boundaries (for example `x-forwarded-for`) is not part of auth decisions in V1.
+- A trusted local OpenDucktor runtime starts the MCP server as a child process.
+- The transport is process-local stdio and cannot accept an Internet connection.
+- External network headers such as `x-forwarded-for` do not take part in version 1 access decisions.
 
-## Supply-Chain Guardrails
+## Supply chain
 
-- `hono` is pinned via root `package.json` override to `^4.12.2` or later.
-- CI runs the Hono policy through the single-request `bun run deps:audit` step in `bun run deps:check`. The policy fails on GHSA-`xh87-mx6m-69f3` or GHSA-`v8w9-8mx6-g223` regression.
+- The root `package.json` override must resolve `hono` to `>=4.12.7`.
+- CI applies the Hono policy through the single-request `bun run deps:audit` step in `bun run deps:check`. It rejects GHSA-`xh87-mx6m-69f3` or GHSA-`v8w9-8mx6-g223`.
 
-## Change Control for Future Transport Expansion
+## Add a network transport
 
-Before enabling any network-facing transport:
+Before you add a network transport:
 
-1. Complete a security design review for authn/authz and proxy trust boundaries.
-2. Reassess dependency advisories for transport framework code paths.
-3. Add integration tests that verify spoofed client-IP headers cannot bypass authentication.
-4. Update this document and `docs/dependency-hygiene.md` in the same change.
+1. Review authentication, authorization, and proxy trust.
+2. Review advisories for every transport dependency and code path.
+3. Add integration tests that prove spoofed client IP headers cannot bypass authentication.
+4. Update this file and [dependency hygiene](dependency-hygiene.md) in the same change.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,10 +1,8 @@
-# Desktop, Web, and MCP Release Process
+# Desktop, web, and MCP release process
 
-OpenDucktor releases are owned by GitHub Actions. Maintainers do not need to run local release commands or create tags by hand.
+GitHub Actions creates OpenDucktor releases. A maintainer starts `Prepare Release`. The workflows create the commit, tag, draft, packages, and desktop files.
 
-## Workflow Layout
-
-The release flow is split into these workflows:
+## Workflows
 
 - `.github/workflows/release-prep.yml`
 - `.github/workflows/release-desktop-electron.yml`
@@ -12,105 +10,58 @@ The release flow is split into these workflows:
 - `.github/workflows/publish-web.yml`
 - `.github/workflows/publish-homebrew-tap.yml`
 
-## Prepare Release
+## Prepare a release
 
-`Prepare Release` is the only workflow a maintainer starts manually.
+Start `Prepare Release` with `workflow_dispatch`. Set `version` and `release_channel`. Use `stable` for a normal semver version such as `0.4.0`. Use `beta` for a prerelease such as `0.4.0-beta.1`.
 
-- Trigger: `workflow_dispatch`
-- Input: `version` like `0.1.0`
-- Input: `release_channel`, either `stable` or `beta`
+The workflow:
 
-It does all release preparation work:
+1. Checks the version and channel.
+2. Updates package manifests and `bun.lock`.
+3. Creates and pushes the release commit and tag.
+4. Creates a draft GitHub release with generated notes. A beta is a GitHub prerelease.
+5. Starts the Electron, MCP, and web workflows after the draft exists.
+6. Sends the npm tag `latest` for stable or `beta` for beta.
 
-- validates the requested version
-- validates that stable releases use normal semver and beta releases use prerelease semver, for example `0.4.0-beta.1`
-- updates repo version manifests
-- refreshes `bun.lock`
-- creates the release bump commit on the default branch
-- creates the release tag
-- creates the draft GitHub release with generated notes after the commit and tag are pushed, marking beta releases as GitHub prereleases
-- dispatches the Electron desktop, MCP, and web publish workflows explicitly after the draft exists
-- passes the npm dist-tag to the web and MCP publish workflows:
-  - `stable` publishes npm packages with `latest`
-  - `beta` publishes npm packages with `beta`
+For a beta, npm packages keep the full prerelease version. The Electron repository manifest uses the numeric base version. The packaged app and updater use the full prerelease version so the updater can compare beta builds.
 
-For beta releases, npm-facing packages keep the full prerelease version, for example `0.4.0-beta.1`. The Electron repo package manifest keeps the numeric base version, for example `0.4.0`, while the packaged desktop app and updater metadata are built with the full prerelease version so in-app beta updates can compare `0.4.0-beta.1` to later beta releases.
+## Build the desktop app
 
-## Release Desktop Electron
+`Release Desktop Electron` gets the tag from `Prepare Release`. A maintainer can rerun it with the same tag.
 
-`Release Desktop Electron` is dispatched by `Prepare Release` with the release tag and can also be rerun manually with the same tag if needed.
+The workflow checks the tag version and draft release. It lints, typechecks, and tests the Electron workspace. It builds Linux x64, macOS arm64, macOS x64, and Windows x64 files.
 
-It:
+It signs and notarizes macOS files, packages the MCP sidecar, creates updater metadata, and uploads all files to the draft. It merges the two macOS manifests into `latest-mac.yml` or `beta-mac.yml`.
 
-- validates that the checked-out repo state matches the tag version
-- verifies that the draft GitHub release already exists
-- lints, typechecks, and tests the Electron workspace
-- builds Electron assets for:
-  - Linux x64
-  - macOS Apple Silicon
-  - macOS Intel
-  - Windows x64
-- signs and notarizes macOS Electron assets
-- packages the MCP sidecar under app resources
-- generates Electron updater metadata for GitHub Releases
-- merges the macOS per-architecture updater manifests into one canonical channel manifest, for example `latest-mac.yml` for stable releases or `beta-mac.yml` for beta releases
-- uploads Electron release assets to the draft GitHub release
+Windows and Linux files are experimental. Do not call them stable release channels.
 
-Windows and Linux Electron assets are experimental. They are included to gather feedback and platform evidence, but they are not yet considered stable release channels.
+## Publish MCP
 
-## Publish MCP Package
+`Publish MCP Package` checks that `packages/openducktor-mcp/package.json` matches the tag. It checks the npm tag, verifies the package, and publishes `@openducktor/mcp` to npmjs.
 
-`Publish MCP Package` is dispatched by `Prepare Release` with the release tag and can also be rerun manually with the same tag if needed.
+## Publish web
 
-It:
+`@openducktor/web` starts a loopback TypeScript host, waits for it, serves the built frontend, and stops the host through the protected `/shutdown` route.
 
-- validates that `packages/openducktor-mcp/package.json` matches the tag version
-- validates that prerelease tags are published to npm `beta` and stable tags are published to npm `latest`
-- verifies the MCP package
-- publishes `@openducktor/mcp` to npmjs with the requested dist-tag
+`Publish Web Package` builds the standalone package, runs `scripts/prepare-web-publish-packages.ts`, runs `npm publish --dry-run`, checks the npm tag, and publishes the package.
 
-## Publish Web Package
+`bun run browser:dev` uses the same launcher in workspace mode with Vite. A published install contains the frontend and host. It does not need published internal workspace packages.
 
-`@openducktor/web` is the npm-facing local browser runner. It is intentionally separate from the desktop bundle: the package starts a loopback-only TypeScript host backend, waits for readiness, serves the built web frontend, and shuts the host down with a control-token-protected `/shutdown` request.
+## Publish Homebrew
 
-`Publish Web Package` is dispatched by `Prepare Release` with the release tag and can also be rerun manually with the same tag if needed.
+`Publish Homebrew Tap` starts after a GitHub release becomes public. A maintainer can rerun it with the same tag.
 
-It:
+The workflow rejects a draft or prerelease. It downloads the signed arm64 and x64 DMG files, calculates SHA-256 values, writes `Casks/openducktor.rb`, then commits and pushes the cask to the tap.
 
-- builds the self-contained `@openducktor/web` package, including the static web frontend and TypeScript host backend
-- verifies package contents with `scripts/prepare-web-publish-packages.ts`
-- runs `npm publish --dry-run` for `@openducktor/web`
-- validates that prerelease tags are published to npm `beta` and stable tags are published to npm `latest`
-- publishes `@openducktor/web` with the requested dist-tag
+This workflow starts after the draft becomes public so Homebrew never points to a private or untested release.
 
-Development mode (`bun run browser:dev`) uses the same launcher in workspace mode and serves the repo-local frontend with Vite. Published installs serve the built frontend and TypeScript host backend from the `@openducktor/web` package and do not require publishing internal workspace packages.
+## Release notes
 
-## Publish Homebrew Tap
+`.github/release.yml` defines categories. `Prepare Release` creates notes with `--generate-notes`. Review and edit the draft before publication.
 
-`Publish Homebrew Tap` runs when a GitHub release is published and can also be rerun manually with the same tag if needed.
+## GitHub secrets
 
-It:
-
-- verifies that the GitHub release exists and is no longer a draft
-- rejects prereleases so the tap only tracks stable published desktop releases
-- downloads the signed macOS arm64 and Intel DMG assets from that release
-- computes SHA-256 checksums for both assets
-- renders `Casks/openducktor.rb` from Electron metadata plus the published asset names and checksums
-- commits and pushes the cask update to the configured Homebrew tap repository
-
-The tap workflow is intentionally separate from desktop artifact workflows because the release draft remains private to maintainers until smoke testing is complete. Homebrew should only point at the final published GitHub release.
-
-## Release Notes
-
-Desktop release notes use **GitHub-generated release notes**.
-
-- `.github/release.yml` defines the category mapping
-- the draft GitHub release is created with `--generate-notes`
-- maintainers can review and edit the draft notes before publishing
-
-## Required GitHub Secrets
-
-### Desktop Release Secrets
+### Desktop
 
 - `APPLE_CERTIFICATE`
 - `APPLE_CERTIFICATE_PASSWORD`
@@ -118,105 +69,74 @@ Desktop release notes use **GitHub-generated release notes**.
 - `APPLE_PASSWORD`
 - `APPLE_TEAM_ID`
 
-Notes:
+`APPLE_CERTIFICATE` is a base64 Developer ID Application `.p12`. The desktop workflow stops if an Apple secret is missing. macOS releases are signed but do not use a separate unsigned path.
 
-- `APPLE_CERTIFICATE` must be a base64-encoded Developer ID Application `.p12` signing certificate.
-- macOS desktop releases are signed-only; the workflow fails fast if any Apple release secret is missing.
+### MCP and web
 
-### MCP Publish Secrets
+MCP and web use npm Trusted Publisher with GitHub Actions OIDC. They do not need an npm secret.
 
-- None. MCP publishing uses npm Trusted Publisher via GitHub Actions OIDC.
+### Homebrew
 
-### Homebrew Tap Secret
+`HOMEBREW_TAP_TOKEN` must be able to push to the tap repository. The default target is `${owner}/homebrew-openducktor` on `main`. `HOMEBREW_TAP_REPOSITORY` and `HOMEBREW_TAP_BRANCH` can replace these defaults.
 
-- `HOMEBREW_TAP_TOKEN`
+### Release automation
 
-Notes:
+`RELEASE_AUTOMATION_TOKEN` pushes the release commit and tag. The workflow rejects the default GitHub Actions token. The desktop workflow also uses this token to read the draft and upload files.
 
-- The token must be able to push to the Homebrew tap repository.
-- By default the workflow targets `${owner}/homebrew-openducktor` on branch `main`.
-- You can override those defaults with repository variables:
-  - `HOMEBREW_TAP_REPOSITORY`
-  - `HOMEBREW_TAP_BRANCH`
+## Version sources
 
-### Release Automation Secret
+`scripts/release-version.ts` updates the root `package.json`, workspace package manifests, `apps/electron/package.json`, and `bun.lock`.
 
-- `RELEASE_AUTOMATION_TOKEN`
+Stable releases use one version. Beta releases use:
 
-`Prepare Release` requires this token and refuses to push with the default GitHub Actions token. `Release Desktop Electron` uses the same token to read the draft GitHub release and upload desktop assets to it. That keeps release automation aligned with normal repository protection and review expectations.
+| Source | Example |
+|---|---|
+| Root, internal packages, MCP, and web | `0.4.0-beta.1` |
+| Electron repository manifest | `0.4.0` |
+| Packaged app and updater metadata | `0.4.0-beta.1` with a numeric OS short version |
+| Git tag | `v0.4.0-beta.1` |
 
-## How Versioning Works
+## Release steps
 
-The repo uses `scripts/release-version.ts` to keep version sources aligned.
+1. Open GitHub Actions and run `Prepare Release`.
+2. Enter the version and select `stable` or `beta`.
+3. Wait for `Prepare Release` to create the commit, tag, draft, and downstream runs.
+4. Wait for desktop, MCP, and web workflows to finish.
+5. Open the draft. Check notes and every expected desktop file. Mark Windows and Linux as experimental.
+6. Publish the draft.
+7. For a stable release, wait for the Homebrew workflow to update `Casks/openducktor.rb`.
 
-The version sync touches:
-
-- root `package.json`
-- workspace package manifests discovered from the root `workspaces` configuration
-- `apps/electron/package.json`
-- `bun.lock`
-
-Stable releases use the same version everywhere. Beta releases split the version domains deliberately:
-
-- root, internal packages, `@openducktor/mcp`, and `@openducktor/web`: full prerelease version, for example `0.4.0-beta.1`
-- Electron repo package manifest: numeric desktop bundle version, for example `0.4.0`
-- packaged Electron app and updater metadata: full prerelease version, for example `0.4.0-beta.1`, with the OS bundle short version kept numeric
-
-The GitHub release tag remains the full release tag, for example `v0.4.0-beta.1`.
-
-## Recommended Release Sequence
-
-1. Open GitHub Actions.
-2. Run `Prepare Release`.
-3. Enter the target version, for example `0.1.0`.
-4. Select `stable` or `beta` for `release_channel`. Use a prerelease version such as `0.4.0-beta.1` for beta.
-5. Wait for `Prepare Release` to finish creating the version bump commit, release tag, draft GitHub release, and explicit downstream workflow dispatch.
-6. Wait for `Release Desktop Electron` to finish uploading Electron assets.
-7. Wait for `Publish MCP Package` to finish publishing `@openducktor/mcp`.
-8. Wait for `Publish Web Package` to finish publishing `@openducktor/web`.
-9. Open the draft GitHub release and review the desktop assets and notes. Treat Windows and Linux assets as experimental and collect feedback before calling them stable.
-10. Publish the draft release when the assets and notes look correct.
-11. For stable releases, wait for `Publish Homebrew Tap` to finish updating `Casks/openducktor.rb` in the tap repository. Beta releases are prereleases and are intentionally rejected by the Homebrew tap workflow.
-
-After a beta publish, verify that npm kept `latest` on the last stable version:
+After a beta, check that `latest` still points to the last stable package:
 
 ```sh
 npm dist-tag ls @openducktor/web
 npm dist-tag ls @openducktor/mcp
 ```
 
-The beta version should appear under `beta`; `latest` should still point to the latest stable version.
+The new version must appear under `beta`.
 
-## Homebrew Tap Setup
+## First Homebrew setup
 
-Before the first Homebrew release, create the tap repository and grant the workflow push access.
+Create `homebrew-openducktor` with `Casks/openducktor.rb` on `main`. Give the workflow token push access.
 
-Recommended defaults:
-
-- repository: `homebrew-openducktor`
-- path: `Casks/openducktor.rb`
-- default branch: `main`
-
-Once the tap exists and the workflow is configured, users can install OpenDucktor with:
+Users install the cask with:
 
 ```sh
 brew install --cask Maxsky5/openducktor/openducktor
 ```
 
-Homebrew requires explicit trust for non-official taps. The fully-qualified install trusts only the OpenDucktor cask. If the tap is already installed and users want the short cask name, they can run `brew trust --cask Maxsky5/openducktor/openducktor` once before `brew install --cask openducktor`.
+The full cask name grants trust only to this cask. A user who already installed the tap can run `brew trust --cask Maxsky5/openducktor/openducktor` once, then use `brew install --cask openducktor`.
 
-## Asset Policy
+## Desktop file policy
 
-OpenDucktor is currently macOS-first. The Electron workflow publishes macOS, Windows, and Linux artifacts, but Windows and Linux builds are experimental and should be labeled and treated accordingly until platform support is proven stable.
+OpenDucktor supports macOS first. Stable builds use the `latest` updater channel. A beta uses its first prerelease name, so `0.4.0-beta.1` uses `beta`.
 
-The packaged desktop updater uses GitHub Releases. Stable builds use the `latest` updater channel. Beta builds derive their updater channel from the first prerelease identifier, so `0.4.0-beta.1` uses `beta`.
+Each desktop release needs:
 
-For in-app updates to work, every desktop GitHub Release must include:
+- Installers for each shipped platform. These include macOS DMG and ZIP, Windows NSIS and ZIP, and Linux AppImage and DEB.
+- Electron Builder metadata. Stable releases need `latest.yml`, `latest-mac.yml`, and `latest-linux.yml`. Beta releases need the same files with the `beta` prefix.
+- Each `*.blockmap` that Electron Builder creates.
 
-- installable artifacts for each shipped platform, including macOS DMG/ZIP, Windows NSIS/ZIP, and Linux AppImage/DEB
-- updater metadata files generated by Electron Builder for the release channel: `latest.yml`, `latest-mac.yml`, and `latest-linux.yml` for stable releases, or `beta.yml`, `beta-mac.yml`, and `beta-linux.yml` for beta releases
-- generated blockmaps such as `*.blockmap` where Electron Builder produces them
+The workflow stops if required metadata is missing. The publish job merges arm64 and x64 macOS metadata before upload.
 
-The release workflow stages updater metadata next to installable artifacts and fails if a staged release is missing required channel metadata. macOS arm64 and x64 builds initially produce separate manifests; the publish job merges those into the canonical channel manifest before uploading assets to the draft release.
-
-Homebrew distribution also stays GitHub Releases based. The cask generator fails if the desktop asset naming stops being architecture-derivable, so maintainers update the generator at the same time the bundle naming changes instead of silently publishing a broken cask.
+The Homebrew cask uses GitHub Release files. If desktop file names change, update the cask generator in the same change. The generator stops when it cannot derive the architecture from a file name.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -29,7 +29,7 @@ For a beta, npm packages keep the full prerelease version. The Electron reposito
 
 `Release Desktop Electron` gets the tag from `Prepare Release`. A maintainer can rerun it with the same tag.
 
-The workflow checks the tag version and draft release. It lints, typechecks, and tests the Electron workspace. It builds Linux x64, macOS arm64, macOS x64, and Windows x64 files.
+The workflow checks that the checked-out repository version matches the selected tag and draft release. It lints, typechecks, and tests the Electron workspace. It builds Linux x64, macOS arm64, macOS x64, and Windows x64 files.
 
 It signs and notarizes macOS files, packages the MCP sidecar, creates updater metadata, and uploads all files to the draft. It merges the two macOS manifests into `latest-mac.yml` or `beta-mac.yml`.
 

--- a/docs/runtime-integration-guide.md
+++ b/docs/runtime-integration-guide.md
@@ -1,215 +1,182 @@
-# Runtime Integration Guide
+# Runtime integration guide
 
-This guide describes OpenDucktor's runtime abstraction, integration boundaries, capability contract, and shared runtime behavior.
+Read this guide before you add a runtime or change runtime capabilities, sessions, history, approvals, prompts, or catalogs.
 
-OpenDucktor currently supports:
-
-| Runtime | Route | Reference value |
+| Runtime | Route | Native form |
 |---|---|---|
-| OpenCode (`opencode`) | `local_http` | External HTTP runtime |
-| Codex (`codex`) | `stdio` | Host-managed app server |
-| Claude (`claude`) | `host_service` | Host-managed SDK service |
+| OpenCode, `opencode` | `local_http` | External HTTP runtime |
+| Codex, `codex` | `stdio` | Host-managed app server |
+| Claude, `claude` | `host_service` | Host-managed SDK service |
 
-Each runtime has a different native protocol. The adapter preserves that protocol internally and exposes shared OpenDucktor contracts externally.
+Each adapter keeps its native protocol inside the adapter and exposes OpenDucktor contracts outside it.
 
-## Architecture
-
-### Runtime concepts
+## Runtime model
 
 | Concept | Meaning | Lifetime |
 |---|---|---|
-| `RuntimeDescriptor` | Static identity, policy, and capabilities for one runtime kind | Application |
-| `RuntimeInstanceSummary` | One running repository-scoped runtime | Runtime process |
-| `RuntimeRoute` | Transient address of a running runtime | Runtime process |
-| Runtime connection | Request-scoped native client input built from a resolved route | Operation |
-| `AgentSessionRecord` | Durable coordinates used to reopen a session | Durable |
-| Live-session adapter | Host-owned normalized state for running sessions | Runtime process |
+| `RuntimeDescriptor` | Static identity, policy, and capabilities for one runtime kind | App |
+| `RuntimeInstanceSummary` | One running repository runtime | Runtime process |
+| `RuntimeRoute` | Address of a running runtime | Runtime process |
+| Runtime connection | Native client input built from a resolved route | One operation |
+| `AgentSessionRecord` | Durable data used to reopen a session | Durable |
+| Live-session adapter | Normalized state for running sessions | Runtime process |
 
-The main data flow is:
+`RuntimeDescriptor` contains `kind`, `label`, `description`, `readOnlyRoleBlockedTools`, `workflowToolAliasesByCanonical`, and `capabilities`. Shared code reads the descriptor instead of testing the runtime kind.
 
-```text
-AgentSessionRecord
-        │
-        ▼
-runtime registry ── resolves ──► RuntimeRoute
-        │
-        ▼
-runtime adapter ── translates ──► native SDK or protocol
-        │
-        ▼
-live-session adapter ── projects ──► normalized snapshot and events
-```
+`RuntimeInstanceSummary` contains the runtime kind and ID, repository, optional task, role, working directory, route, start time, and descriptor. Keep it at registry and adapter boundaries.
 
-`RuntimeDescriptor` contains `kind`, `label`, `description`, `readOnlyRoleBlockedTools`, `workflowToolAliasesByCanonical`, and `capabilities`. Shared code uses this descriptor instead of branching on the runtime kind.
+`RuntimeRoute` can be `local_http`, `stdio`, or `host_service`. A `local_http` route must use the loopback host `localhost`, `127.0.0.1`, or `::1`. Never persist a route. `RuntimeTransport` carries request-scoped `local_http` and `stdio` connections. A host service can resolve inside its host adapter without a new public transport type.
 
-`RuntimeInstanceSummary` contains live runtime metadata: runtime kind and ID, repository, nullable task, role, working directory, route, start time, and descriptor. It belongs at runtime-registry and adapter boundaries.
+`AgentSessionRecord` stores only the external session ID, role, start time, runtime kind, working directory, and selected model. It does not store an endpoint, route, transport, pending request, event buffer, or native reply ID.
 
-`RuntimeRoute` supports `local_http`, `stdio`, and `host_service`. A route describes a live process or service and must never be persisted.
+The live-session adapter owns the normalized snapshot, transcript, current context use, pending approvals and questions, child links, and native reply IDs. Keep this state out of SQLite and renderer caches.
 
-The shared `RuntimeTransport` contract supports request-scoped `local_http` and `stdio` connections. A `host_service` runtime may resolve its service directly inside the host adapter without adding a public transport shape.
+Every session operation uses the stored runtime kind and working directory. If that runtime is unavailable, fail the operation. Do not use the repository default runtime as a fallback.
 
-`AgentSessionRecord` persists only the external session ID, role, start time, runtime kind, working directory, and selected model. It must not contain a route, endpoint, transport, pending request, event buffer, or runtime-native reply handle.
+## Ownership
 
-The live-session adapter owns the normalized session snapshot, transcript state, current context usage, pending approvals and questions, parent-child links, and private native reply routes. This state is ephemeral and does not belong in SQLite, persisted task data, or a renderer cache.
-
-Every session operation uses the runtime kind and working directory stored with the session. If that runtime is unavailable, the operation fails. It must never fall back to the repository's current default runtime.
-
-## Integration surfaces
-
-| Surface | Owns | Must not own |
+| Owner | Owns | Does not own |
 |---|---|---|
-| Shared contracts | Runtime descriptors, routes, session identity, prompt parts, events, snapshots, and history items | Native SDK types or runtime-specific parsing |
-| Runtime-native adapter | Client construction, native configuration, requests, events, history, catalogs, permissions, questions, errors, and cleanup | Shared orchestration or renderer state |
-| Live-session adapter | Ordered controls and events, live snapshots, context, pending input, and child sessions | A second native protocol implementation |
-| Host composition | Runtime startup, route registration, service wiring, command handlers, and lifecycle guards | Reconstructed or guessed routes |
-| Frontend | Capability-driven UI, normalized transcript display, stable queries, and operation errors | Native messages, tools, or pending-input payloads |
+| Shared contracts | Descriptors, routes, session identity, prompt parts, events, snapshots, and history items | SDK types and native parsing |
+| Native adapter | Client setup, native config, requests, events, history, catalogs, input, errors, and cleanup | Shared orchestration and renderer state |
+| Live-session adapter | Ordered controls and events, live snapshots, context, pending input, and child sessions | A second native protocol |
+| Host | Startup, route registration, service wiring, commands, and lifecycle guards | Guessed routes |
+| Frontend | Capability-based UI, normalized transcript, queries, and operation errors | Native payloads |
 
-Shared contracts belong in `packages/contracts`. Add a shared field only when it represents an OpenDucktor concept. Keep SDK options and native protocol details inside the owning runtime adapter.
+Put shared data in `packages/contracts` only when it is an OpenDucktor concept. Keep SDK options and protocol details in the native adapter.
 
-The host must create and subscribe the live-session adapter before the runtime can publish session events. Otherwise startup state can be lost before the host has an owner for it.
+Create and subscribe the live-session adapter before the runtime can send events. Use TanStack Query for stable frontend reads such as history and catalogs. Keep live transcript state in the live-session store.
 
-The frontend uses TanStack Query for stable host reads such as catalogs and history. Streaming transcript state remains in the live-session store.
-
-Before mapping native behavior, inspect the runtime's official SDK types, documentation, protocol, or source. Confirm how it represents startup, configuration, authentication, models, session lifecycle, activity, history, tools, permissions, questions, context usage, catalogs, and optional features. If the public contract does not expose enough data for a feature, leave that capability disabled.
+Before you map a feature, inspect official SDK types, protocol docs, or runtime source. Check startup, config, auth, models, sessions, activity, history, tools, approvals, questions, context, catalogs, and optional features. Keep a capability off when the public runtime contract lacks the needed data.
 
 ## Capability contract
 
-`RuntimeDescriptor.capabilities` tells shared code what a runtime can do. Every enabled field must have a working adapter path and matching UI behavior.
+Each enabled `RuntimeDescriptor.capabilities` field needs a working adapter path and matching UI.
 
 ### Provisioning and workflow
 
 | Field | Meaning |
 |---|---|
-| `provisioningMode` | Whether OpenDucktor manages the runtime (`host_managed`) or connects to an external runtime (`external`) |
-| `workflow.supportsOdtWorkflowTools` | Whether the runtime can execute canonical OpenDucktor workflow tools |
-| `workflow.supportedScopes` | Supported session scopes: `workspace`, `task`, and `build` |
+| `provisioningMode` | `host_managed` or `external` |
+| `workflow.supportsOdtWorkflowTools` | Can run canonical ODT tools |
+| `workflow.supportedScopes` | Can run `workspace`, `task`, or `build` sessions |
 
 ### Session lifecycle
 
 | Field | Meaning |
 |---|---|
-| `sessionLifecycle.supportedStartModes` | Supported start modes: `fresh`, `reuse`, and `fork` |
-| `sessionLifecycle.supportsSessionFork` | Whether the runtime can fork an existing session |
-| `sessionLifecycle.forkTargets` | Native fork boundaries: `session`, `message`, or `item` |
-| `sessionLifecycle.supportsListLiveSessions` | Whether the adapter can return live state for sessions that OpenDucktor registered |
-| `sessionLifecycle.supportsQueuedUserMessages` | Whether a busy session can accept messages whose queued state remains observable |
-| `sessionLifecycle.supportsPendingInputSnapshots` | Whether live snapshots retain unresolved approvals and questions |
+| `sessionLifecycle.supportedStartModes` | Supports `fresh`, `reuse`, or `fork` |
+| `sessionLifecycle.supportsSessionFork` | Can fork a session |
+| `sessionLifecycle.forkTargets` | Can fork at `session`, `message`, or `item` |
+| `sessionLifecycle.supportsListLiveSessions` | Can return live state for sessions that OpenDucktor registered |
+| `sessionLifecycle.supportsQueuedUserMessages` | Can keep a queued user message visible while busy |
+| `sessionLifecycle.supportsPendingInputSnapshots` | Can keep unresolved input in snapshots |
 
 ### History
 
 | Field | Meaning |
 |---|---|
-| `history.loadable` | Whether a stored session can be loaded through a supported runtime API |
-| `history.fidelity` | Available detail: `none`, `message`, or `item` |
-| `history.replay` | Available reconstruction: `none`, `snapshot`, `turn_items`, or `event_replay` |
-| `history.stableItemIds` | Whether history items expose stable identity |
-| `history.stableItemOrder` | Whether item ordering is stable across reads |
-| `history.exposesCompletionState` | Whether history distinguishes running and terminal items |
-| `history.limitations` | Explicit native limits that callers must know |
+| `history.loadable` | A supported API can load a stored session |
+| `history.fidelity` | `none`, `message`, or `item` detail |
+| `history.replay` | `none`, `snapshot`, `turn_items`, or `event_replay` rebuild |
+| `history.stableItemIds` | Item IDs stay stable across reads |
+| `history.stableItemOrder` | Item order stays stable across reads |
+| `history.exposesCompletionState` | History marks running and finished items |
+| `history.limitations` | Native limits that callers must know |
 
 ### Approvals
 
 | Field | Meaning |
 |---|---|
-| `approvals.supportedRequestTypes` | Supported request kinds: `command_execution`, `file_change`, `permission_grant`, and `runtime_tool` |
-| `approvals.supportedReplyOutcomes` | Supported replies: `approve_once`, `approve_turn`, `approve_session`, `approve_always`, and `reject` |
-| `approvals.omittedPermissionBehavior` | Behavior without a reply: `deny` or `requires_explicit_response` |
-| `approvals.pendingVisibility` | Where pending requests appear: `live_snapshot`, `history`, or both |
-| `approvals.canClassifyMutatingRequests` | Whether the adapter can identify requests that may mutate state |
-| `approvals.readOnlyAutoRejectSafe` | Whether mutating requests can be rejected safely for read-only roles |
+| `approvals.supportedRequestTypes` | `command_execution`, `file_change`, `permission_grant`, or `runtime_tool` |
+| `approvals.supportedReplyOutcomes` | `approve_once`, `approve_turn`, `approve_session`, `approve_always`, or `reject` |
+| `approvals.omittedPermissionBehavior` | `deny` or `requires_explicit_response` |
+| `approvals.pendingVisibility` | Pending input appears in `live_snapshot`, `history`, or both |
+| `approvals.canClassifyMutatingRequests` | Adapter can identify a request that can change state |
+| `approvals.readOnlyAutoRejectSafe` | Adapter can reject a mutating request for a read-only role |
 
-### Structured input
+### Questions
 
 | Field | Meaning |
 |---|---|
-| `structuredInput.supportsQuestions` | Whether the runtime can ask structured questions |
-| `structuredInput.supportsMultipleQuestions` | Whether one request can contain several questions |
-| `structuredInput.supportedAnswerModes` | Supported answers: `free_text`, `single_select`, and `multi_select` |
-| `structuredInput.supportsRequiredQuestions` | Whether questions can require an answer |
-| `structuredInput.supportsDefaultValues` | Whether questions can define defaults |
-| `structuredInput.supportsSecretInput` | Whether answers can be hidden |
-| `structuredInput.supportsCustomAnswers` | Whether users can answer outside the supplied options |
-| `structuredInput.supportsQuestionResolution` | Whether the adapter can resolve a pending question through the runtime |
-| `structuredInput.pendingVisibility` | Where pending questions appear: `live_snapshot`, `history`, or both |
+| `structuredInput.supportsQuestions` | Runtime can ask a structured question |
+| `structuredInput.supportsMultipleQuestions` | One request can contain more than one question |
+| `structuredInput.supportedAnswerModes` | Supports `free_text`, `single_select`, or `multi_select` |
+| `structuredInput.supportsRequiredQuestions` | A question can require an answer |
+| `structuredInput.supportsDefaultValues` | A question can have a default |
+| `structuredInput.supportsSecretInput` | Input can be hidden |
+| `structuredInput.supportsCustomAnswers` | User can answer outside listed choices |
+| `structuredInput.supportsQuestionResolution` | Adapter can resolve a pending question |
+| `structuredInput.pendingVisibility` | Pending questions appear in `live_snapshot`, `history`, or both |
 
 ### Prompt input
 
 | Field | Meaning |
 |---|---|
-| `promptInput.supportedParts` | Accepted typed prompt parts: `text`, `slash_command`, `file_reference`, `folder_reference`, `skill_mention`, `subagent_reference`, `app_mention`, `plugin_mention`, and `runtime_specific` |
-| `promptInput.supportsAttachments` | Whether the runtime adapter can encode file attachments |
-| `promptInput.supportsSlashCommands` | Whether the runtime exposes and accepts slash commands |
-| `promptInput.supportsFileSearch` | Whether the composer can search native file or folder references |
-| `promptInput.supportsSkillReferences` | Whether user-selected skills can be represented as typed prompt input |
-| `promptInput.supportsSubagentReferences` | Whether user-selected subagents can be represented as typed prompt input |
+| `promptInput.supportedParts` | Typed parts such as `text`, `slash_command`, `file_reference`, `folder_reference`, `skill_mention`, `subagent_reference`, `app_mention`, `plugin_mention`, or `runtime_specific` |
+| `promptInput.supportsAttachments` | Adapter can encode a file attachment |
+| `promptInput.supportsSlashCommands` | Runtime lists and runs slash commands |
+| `promptInput.supportsFileSearch` | Composer can search native file and folder references |
+| `promptInput.supportsSkillReferences` | Composer can send a typed skill reference |
+| `promptInput.supportsSubagentReferences` | Composer can send a typed subagent reference |
 
 #### Attachments
 
-Attachment support has two levels:
+`promptInput.supportsAttachments` says that the adapter can encode an attachment. `AgentModelDescriptor.attachmentSupport` says which `image`, `audio`, `video`, or `pdf` types the model accepts. A type can also have a MIME allowlist.
 
-- `promptInput.supportsAttachments` declares whether the runtime adapter can encode attachments.
-- `AgentModelDescriptor.attachmentSupport` declares whether the selected model accepts `image`, `audio`, `video`, and `pdf` attachments, with optional MIME-type allowlists for each kind.
+If `attachmentSupport` is absent, the runtime did not provide model attachment data. The composer rejects an unsupported kind or MIME type.
 
-An absent `attachmentSupport` means the model did not expose attachment capability data. The composer rejects attachments that the selected model does not support or whose MIME type is outside its allowlist.
+An attachment part has an ID, local path, name, kind, and optional MIME type. In a browser, the frontend asks the host to stage the `File`, then sends the staged path.
 
-An attachment message part contains an ID, local path, name, kind, and optional MIME type. The frontend stages browser `File` data through the host before sending, then passes the staged path to the runtime adapter.
+The adapter owns native encoding. Claude reads the staged file and sends an SDK image or document block. Its catalog permits JPEG, PNG, GIF, WebP, and PDF. Codex maps images to `localImage`. OpenCode sends a native file part with MIME type and local URL.
 
-The native encoding belongs to the runtime adapter. Claude reads the staged file and sends an SDK image or document content block; its catalog allows JPEG, PNG, GIF, and WebP images plus PDF documents. Codex maps supported images to `localImage`. OpenCode sends a native file part with its MIME type and local file URL.
+A prompt cannot mix a slash command and attachments because a slash command uses a separate native call.
 
-Slash commands and attachments cannot be combined in one prompt because slash commands use a separate native execution path.
-
-### Optional surfaces
+### Optional features
 
 | Field | Meaning |
 |---|---|
-| `optionalSurfaces.supportsProfiles` | Whether the runtime exposes model or agent profiles |
-| `optionalSurfaces.supportsVariants` | Whether the runtime exposes model variants such as reasoning effort |
-| `optionalSurfaces.supportsTodos` | Whether native task state can map to OpenDucktor todos |
-| `optionalSurfaces.supportsDiff` | Whether the runtime exposes session or workspace diffs |
-| `optionalSurfaces.supportsFileStatus` | Whether the runtime exposes file status |
-| `optionalSurfaces.supportsMcpStatus` | Whether the runtime exposes MCP connection state |
-| `optionalSurfaces.supportsSubagents` | Whether OpenDucktor can observe runtime-owned subagent execution |
-| `optionalSurfaces.supportedSubagentExecutionModes` | Supported subagent modes: `foreground` and `background` |
+| `optionalSurfaces.supportsProfiles` | Runtime lists model or agent profiles |
+| `optionalSurfaces.supportsVariants` | Runtime lists model variants such as reasoning effort |
+| `optionalSurfaces.supportsTodos` | Native tasks map to OpenDucktor todos |
+| `optionalSurfaces.supportsDiff` | Runtime provides session or workspace diff |
+| `optionalSurfaces.supportsFileStatus` | Runtime provides file status |
+| `optionalSurfaces.supportsMcpStatus` | Runtime provides MCP connection state |
+| `optionalSurfaces.supportsSubagents` | OpenDucktor can observe native subagent work |
+| `optionalSurfaces.supportedSubagentExecutionModes` | Supports `foreground` or `background` subagents |
 
-### Consistency rules
+## Descriptor rules
 
-- Every runtime supports `fresh`.
-- Fork start mode, fork support, and fork targets must agree.
-- Item-level history requires loadable history, stable IDs, stable order, and completion state.
-- A runtime without loadable history uses `none` for history fidelity and replay.
-- A runtime that exposes approval requests supports both rejection and at least one approval outcome.
-- Read-only auto-rejection requires mutating-request classification and rejection support.
-- A runtime without structured questions declares no question details, answer modes, or pending visibility.
-- A runtime with structured questions declares at least one answer mode and supports question resolution.
+- Every runtime supports `fresh` and `text`.
+- Fork mode, fork support, and fork targets agree.
+- Item history requires a loadable API, stable IDs, stable order, and completion state.
+- A runtime without loadable history uses `none` for fidelity and replay.
+- Approval support includes `reject` and at least one approval result.
+- Read-only auto-reject requires mutation classification and rejection support.
+- A runtime without questions leaves all question detail empty.
+- A runtime with questions has an answer mode and can resolve the question.
 - Live pending-input visibility requires pending-input snapshots.
-- Every runtime accepts text prompt input.
-- Slash commands, file search, skill references, and subagent references must agree with their typed prompt parts.
-- A runtime without subagent support declares no subagent execution modes.
+- Slash command, file search, skill, and subagent flags agree with `supportedParts`.
+- A runtime without subagents has no subagent execution modes.
 
-### OpenDucktor capability policy
+`runtimeCapabilityKeyValues` defines product gates.
 
-`runtimeCapabilityKeyValues` defines the descriptor fields used as product capability gates. Other descriptor fields refine those gates but are not independent gates.
-
-| Policy set | Capability keys |
+| Policy | Capability keys |
 |---|---|
-| Mandatory | `workflow.supportsOdtWorkflowTools`, `approvals.readOnlyAutoRejectSafe`, `sessionLifecycle.supportedStartModes`, `promptInput.supportedParts` |
-| Optional | `sessionLifecycle.supportsQueuedUserMessages`, history fidelity and replay, approval request types and reply outcomes, structured questions, attachments, slash commands, file search, skill and subagent references, profiles, variants, todos, diff, file status, MCP status, subagents, and subagent execution modes |
+| Required | ODT workflow tools, read-only auto-reject, start modes, and prompt parts |
+| Optional | Queued messages, history, approvals, questions, attachments, slash commands, file search, skill and subagent references, profiles, variants, todos, diff, file status, MCP status, and subagents |
 
-Mandatory start-mode support means `fresh` is available. Mandatory prompt input means `text` is present in `supportedParts`.
+Capability classes record why a gate exists.
 
-Capability classes identify why a gate exists:
-
-| Class | Capability keys |
+| Class | Use |
 |---|---|
-| `baseline` | Session start modes and prompt parts |
-| `workflow` | OpenDucktor workflow tools, approval request types and replies, read-only auto-rejection, and structured questions |
+| `baseline` | Start modes and prompt parts |
+| `workflow` | ODT tools, approvals, read-only roles, and questions |
 | `role_scoped` | Workflow scopes |
-| `launch_scoped` | Session fork support and history fidelity or replay |
-| `optional_enhancement` | Queued messages, attachments, slash commands, file search, skill and subagent references, profiles, variants, todos, diff, file status, MCP status, subagents, and subagent execution modes |
+| `launch_scoped` | Fork and history |
+| `optional_enhancement` | All optional product features |
 
-Supporting descriptor fields use the class of the feature they refine. Workflow aliases and read-only blocked tools are `workflow`; fork targets and history loadability, identity, ordering, and completion are `launch_scoped`; approval and structured-input details are `workflow`.
-
-Workflow scope requirements are role-specific:
+Workflow aliases and blocked tools are `workflow`. Fork targets and history details are `launch_scoped`. Approval and question details are `workflow`.
 
 | Role | Required scopes |
 |---|---|
@@ -218,77 +185,75 @@ Workflow scope requirements are role-specific:
 | Builder | `build`, `workspace` |
 | QA | `task` |
 
-OpenDucktor accepts a runtime definition only when the descriptor schema is valid, workflow tools and read-only safety are available, all role scopes are covered, and every registered launch action has a supported start mode for its role. Default runtime selection also requires support for every role.
+Accept a runtime definition only when its schema is valid, it can run workflow tools safely, all role scopes exist, and each launch action has a supported mode. A default runtime must support every role.
 
-## Shared runtime behavior
+## Shared behavior
 
-### Session lifecycle and live state
+### Session state
 
-OpenDucktor owns root-session admission. Start, resume, and fork controls register the returned runtime metadata before the session enters the live-state list. A runtime adapter must not scan a native session inventory to add roots. Runtime events may add a descendant only through a parent that OpenDucktor already registered.
+OpenDucktor owns root-session admission. Start, resume, and fork controls register returned runtime metadata before a session enters the live-state list. A runtime adapter cannot scan a native session list to add roots. A runtime event can add a descendant only when OpenDucktor registered its parent.
 
-On reload, the host reads exact root references from durable task session records. The OpenCode adapter may call `session.get`, `session.children`, `session.status`, `permission.list`, and `question.list` for those roots and their verified descendants. It must not call `session.list` or treat runtime data as proof that a new root belongs to OpenDucktor.
+On reload, the host reads exact root references from durable task session records. The OpenCode adapter can call `session.get`, `session.children`, `session.status`, `permission.list`, and `question.list` for those roots and their verified descendants. It cannot call `session.list` or treat runtime data as proof that a new root belongs to OpenDucktor.
 
-Fresh and forked sessions start with a running lease. Replayed native idle state must not make a new session flicker from running to idle and back before its first turn settles.
+A fresh or forked session starts with a running lease. An old native idle event cannot mark it idle before the first turn settles.
 
-Resume keeps the current running turn, pending permission, or pending question until a newer native event replaces it. Control results and native events pass through one ordered coordinator so they cannot update live state in an arbitrary order.
+Resume keeps the current running turn, approval, or question until a newer native event replaces it. One ordered coordinator applies control results and native events.
 
-Renderer attachment is atomic: the first envelope contains the current snapshot, and later changes follow on the same ordered channel. Separate snapshot and subscribe operations create a race.
+Renderer attachment is atomic. Its first envelope has the current snapshot. Later changes use the same ordered channel. Separate snapshot and subscribe calls have a race.
 
-Native completion, stream end, runtime failure, explicit stop, and release have different meanings and must map separately. Final release removes the parent-child session tree and rejects unresolved pending requests.
+Map native completion, stream end, runtime failure, stop, and release as different events. Final release removes the session tree and rejects unresolved requests.
 
-Current context usage is live state, not cumulative result usage. When a direct context read races streamed context events, queued events establish the read baseline and any context event processed during the read wins, even when it repeats the current value.
+Current context use is live state, not total result use. If a direct read races stream events, queued events set the baseline and an event processed during the read wins.
 
 ### Transcript and history
 
-Live events and hydrated history must produce the same OpenDucktor meaning for item identity, role, order, timestamp, completion, errors, tool names, display parts, prompt references, todos, subagents, and compaction.
+Live and loaded items use the same identity, role, order, time, completion, error, tool name, display parts, prompt references, todos, subagents, and compaction meaning.
 
-Use thin native live and history readers that feed the same canonical projector. Load history through the public SDK or API; history loading must not resume a session, drain live events, discover pending input, or mutate live state.
+Feed thin native live and history readers into one projector. Use the public SDK or API for history. A history read does not resume the session, consume live events, discover pending input, or change live state.
 
-Native history may include tool-result wrappers, synthetic messages, queue operations, local command output, compaction records, and child-agent delivery records. Classify them through native fields before generic message projection. Never filter them through displayed text, exact sentences, or regular expressions.
+Use native fields to classify tool-result wrappers, synthetic messages, queue operations, command output, compaction, and child delivery. Do not classify them by displayed text or a regular expression.
 
-Use stable native IDs for messages, tool calls, retractions, and child sessions when available. Deduplicate by identity and lifecycle, not by message text.
+Use stable native IDs when present. Deduplicate by ID and lifecycle, not message text. Keep tool proposal, queue, execution, progress, and completion separate. Measure duration from native execution start. If history omits that point, omit duration.
 
-Keep tool proposal, queueing, execution, progress, and completion separate. Measure duration from the native execution boundary. If history does not expose that boundary, omit hydrated duration rather than inventing one.
+Keep the original tool ID and reason for success, failure, and denial. Read file edits from structured results or supported hooks. Do not infer a diff from tool input or private transcripts.
 
-Every tool success, failure, and denial keeps the original tool identity and reason. File edits come from structured results or supported hooks; do not infer a successful diff from tool input or read private transcripts to recover one.
-
-Accepted prompt parts remain typed until the runtime adapter encodes them. Hydrated user messages must rebuild the same command, skill, file, attachment, and subagent display parts as live messages.
+Keep prompt parts typed until the adapter encodes them. History must rebuild the same command, skill, file, attachment, and subagent parts as the live stream.
 
 ### Configuration and catalogs
 
-Inherit the user's native authentication, providers, settings, global and project instructions, models, skills, commands, permissions, sandbox policy, and MCP servers through supported SDK options. Do not create an isolated runtime home, edit user settings, or reimplement native configuration discovery from private files.
+Use supported SDK options to inherit native auth, providers, settings, instructions, models, skills, commands, permissions, sandbox rules, and MCP servers. Do not create a separate runtime home, edit user settings, or parse private config files.
 
-OpenDucktor may add session-scoped workflow tools, MCP servers, hooks, or instructions. These additions must not erase unrelated native configuration.
+OpenDucktor can add session workflow tools, MCP servers, hooks, or instructions. Keep unrelated native config.
 
-Load the effective model catalog from the runtime so proxy and third-party providers remain available.
+Read the effective model catalog from the runtime so proxy and third-party providers remain present. Use native metadata to separate commands, bundled workflows, user skills, and model skills. Keep a bounded classification rule in one runtime module only when the API has no type field.
 
-Use structured native metadata to distinguish commands, bundled workflows, user-invocable skills, and model-invocable skills. A user-invocable skill belongs in composer autocomplete even when the model cannot invoke it. When a native API mixes kinds without a discriminator, keep the bounded classification rule in one runtime-owned module.
-
-Preserve names accepted by the runtime. A catalog error must identify the invalid entry and remain local to that catalog request; it must not block unrelated history or session reads.
+Keep names that the runtime accepts. A bad catalog entry fails that catalog request and names the entry. It does not block history or session reads.
 
 ### Permissions and pending input
 
-The shared role policy defines which canonical `odt_*` tools each role may call. The runtime descriptor maps canonical tools to native aliases and lists exact native tools blocked for read-only roles.
+Shared role policy lists canonical `odt_*` tools. The descriptor maps them to native aliases and lists native tools blocked for read-only roles.
 
-The adapter inherits the native permission and sandbox settings, adds session-scoped hooks through SDK options, and lets unclassified tools follow the native permission flow. It must not edit user settings or parse shell commands in shared code.
+Inherit native permissions and sandbox settings. Add session hooks through SDK options. Let unclassified tools use the native approval path. Shared code does not edit user settings or parse shell commands.
 
-Do not block Bash only because a role is read-only. Spec, Planner, and QA need shell access for search, tests, lint, and inspection.
+Do not block Bash only because a role is read-only. Spec, Planner, and QA need it for search and checks.
 
-OpenDucktor pending-request IDs are opaque handles. Native reply IDs stay inside the adapter. A child session owns its approvals and questions; the parent may show that the child needs attention, but the child transcript must also display and resolve the request.
+OpenDucktor request IDs are opaque handles. Keep native reply IDs inside the adapter. A child owns its approvals and questions. The parent can show that the child needs input, but the child transcript must also show and resolve it.
 
-### Optional features
+### Optional feature rules
 
-| Feature | Shared contract |
+| Feature | Rule |
 |---|---|
-| Todos | Live native task changes and hydrated history produce the same canonical todo list and tool name |
-| Subagents | The parent card and child session preserve initial description, execution mode, identity, transcript, pending input, and terminal state |
-| Queued messages | One accepted user-message ID carries queued state live and after hydration |
-| Compaction | Native requested, started, completed, and failed states map without leaking synthetic control messages into the transcript |
+| Todos | Live events and history build the same todo list and tool name. |
+| Subagents | Parent and child keep the description, mode, ID, transcript, pending input, and final state. |
+| Queued messages | One user-message ID keeps queued state live and in history. |
+| Compaction | Map requested, started, completed, and failed states without showing synthetic control messages. |
 
 ## Code map
 
-- Runtime and model capability schemas: `packages/contracts/src/agent-runtime-schemas.ts`, `packages/contracts/src/agent-engine-schemas.ts`
-- Live-session contract: `packages/host/src/ports/agent-session-live-adapter-port.ts`
-- Live-session implementations: `packages/host/src/adapters/agent-sessions`
-- Runtime registry: `packages/host/src/adapters/runtimes/runtime-registry.ts`
-- Native reference adapters: `packages/adapters-opencode-sdk/src`, `packages/adapters-codex-app-server/src`, and `packages/host/src/adapters/claude`
+| Part | Path |
+|---|---|
+| Schemas | `packages/contracts/src/agent-runtime-schemas.ts`, `packages/contracts/src/agent-engine-schemas.ts` |
+| Live-session port | `packages/host/src/ports/agent-session-live-adapter-port.ts` |
+| Live-session adapters | `packages/host/src/adapters/agent-sessions` |
+| Runtime registry | `packages/host/src/adapters/runtimes/runtime-registry.ts` |
+| Native adapters | `packages/adapters-opencode-sdk/src`, `packages/adapters-codex-app-server/src`, `packages/host/src/adapters/claude` |

--- a/docs/tanstack-query-cache-strategy.md
+++ b/docs/tanstack-query-cache-strategy.md
@@ -1,160 +1,100 @@
-# TanStack Query Cache Strategy
+# TanStack Query cache strategy
 
-This document describes the frontend cache and stale-time strategy. TanStack Query owns server-read caching in the shared frontend, even when the underlying host implementation uses Effect internally.
+TanStack Query owns the frontend cache for server reads. This rule also applies when the host runs Effect.
 
-## Boundary with Effect
+## Effect boundary
 
-OpenDucktor is adopting Effect progressively, starting with `packages/host`. Effect owns host-side execution concerns: typed failures, dependency wiring, fallible I/O, lifecycle cleanup, and Promise interop at shell-facing boundaries.
+Effect owns typed failures, dependency wiring, I/O, lifecycle, and Promise conversion in the host. TanStack Query owns these frontend read concerns:
 
-TanStack Query still owns frontend server-read behavior:
+- Query keys and stale times.
+- Cache lifetime.
+- In-flight request deduplication.
+- Cache updates and invalidation after a mutation.
+- Loading and error state during render.
 
-- query keys
-- stale-time and garbage-collection policy
-- in-flight read deduplication
-- cache updates and invalidation after mutations
-- render-path loading/error states
-
-Effect-backed host clients or query functions may be used under Query, but they must not introduce a second cache for the same server-owned data. If data is read by React render paths and should be reused, refreshed, invalidated, or deduplicated, it belongs behind TanStack Query. If work is a mutation, process lifecycle action, runtime orchestration step, stream assembly, or local UI interaction, it stays outside Query.
+Put a reusable server read behind TanStack Query. Keep mutations, process lifecycle, runtime orchestration, event streams, and local UI actions outside it. Do not add a second cache for the same server data.
 
 ## Global defaults
 
-Defined in [packages/frontend/src/lib/query-client.ts](../packages/frontend/src/lib/query-client.ts):
+`packages/frontend/src/lib/query-client.ts` sets:
 
 - `retry: false`
 - `refetchOnWindowFocus: false`
 - `refetchOnReconnect: false`
-- default `staleTime: 60_000`
-- default `gcTime: 10 * 60_000`
+- `staleTime: 60_000`
+- `gcTime: 10 * 60_000`
 
-These defaults match the desktop/browser-live host model:
+These values stop hidden retries and surprise traffic after focus or reconnect. Each query group can replace the default stale time.
 
-- we do not want silent retries masking host failures
-- we do not want focus or reconnect to trigger surprise backend traffic
-- we want a short shared cache by default, then override by domain
+## Stale times
 
-## Strategy by data class
+### Configuration
 
-### Long-lived configuration
+Invalidate these read-mostly values after a write.
 
-Used for shared, read-mostly configuration that changes rarely and should be invalidated explicitly after writes.
+| Data | Stale time |
+|---|---:|
+| Settings snapshot | 15 min |
+| Repository config | 10 min |
+| Workspace list | 5 min |
+| Runtime definitions | 30 min |
+| Runtime catalog | 5 min |
 
-- settings snapshot: `15 min`
-- repo config: `10 min`
-- workspace list: `5 min`
-- runtime definitions: `30 min`
-- runtime catalog: `5 min`
+Query modules: `workspace.ts`, `runtime.ts`, and `runtime-catalog.ts` under `packages/frontend/src/state/queries`.
 
-Files:
+### Workflow data
 
-- [packages/frontend/src/state/queries/workspace.ts](../packages/frontend/src/state/queries/workspace.ts)
-- [packages/frontend/src/state/queries/runtime.ts](../packages/frontend/src/state/queries/runtime.ts)
-- [packages/frontend/src/state/queries/runtime-catalog.ts](../packages/frontend/src/state/queries/runtime-catalog.ts)
+| Data | Stale time |
+|---|---:|
+| Task list and runs | 30 sec |
+| Runs | 30 sec |
+| Agent session list | 30 sec |
+| Task documents | 60 sec |
+| Task approval context | 60 sec |
+| Runtime instance list | 10 sec |
 
-### Medium-lived operational reads
+Query modules: `tasks.ts`, `agent-sessions.ts`, `documents.ts`, `task-approval.ts`, and `runtime.ts`.
 
-Used for workflow data that can change during a session, but where we still want deduplication across repeated reads.
+### Checks and file data
 
-- task list plus runs bundle: `30 sec`
-- runs only: `30 sec`
-- agent session list: `30 sec`
-- task documents: `60 sec`
-- task approval context: `60 sec`
-- runtime instance list: `10 sec`
+| Data | Stale time |
+|---|---:|
+| Runtime check | 5 min |
+| Task store check | 60 sec |
+| Repository runtime health | 60 sec |
+| Directory listing | 1 sec |
+| Branches | 60 sec |
+| Current branch | 60 sec |
+| Worktree status | 0 |
+| Worktree status summary | 0 |
 
-Files:
+Use a zero stale time for worktree status. TanStack Query still deduplicates concurrent reads, but the next caller does not trust an old diff snapshot.
 
-- [packages/frontend/src/state/queries/tasks.ts](../packages/frontend/src/state/queries/tasks.ts)
-- [packages/frontend/src/state/queries/agent-sessions.ts](../packages/frontend/src/state/queries/agent-sessions.ts)
-- [packages/frontend/src/state/queries/documents.ts](../packages/frontend/src/state/queries/documents.ts)
-- [packages/frontend/src/state/queries/task-approval.ts](../packages/frontend/src/state/queries/task-approval.ts)
-- [packages/frontend/src/state/queries/runtime.ts](../packages/frontend/src/state/queries/runtime.ts)
+Query modules: `checks.ts`, `filesystem.ts`, and `git.ts`.
 
-### Diagnostics and health
+## Read methods
 
-Used for checks that are somewhat volatile, but still should not refetch constantly.
+Use `ensureQueryData` for configuration that can return a fresh cached value. Examples are `loadSettingsSnapshotFromQuery(...)` and `loadRepoConfigFromQuery(...)`.
 
-- runtime check: `5 min`
-- task store check: `60 sec`
-- repo runtime health: `60 sec`
+Use `fetchQuery` for an imperative read that still needs the shared key and in-flight deduplication. Examples include task refresh, session history, documents, and worktree status.
 
-File:
+Task documents use a 60 second stale time for normal views. Workflow refreshes force a new fetch through `packages/frontend/src/state/queries/documents.ts` so an external ODT write appears without polling.
 
-- [packages/frontend/src/state/queries/checks.ts](../packages/frontend/src/state/queries/checks.ts)
+## Mutations
 
-### Short-lived filesystem browsing
+Do not depend on a background refetch for correct state.
 
-Used for interactive directory exploration where repeated navigation should reuse the most recent response for a brief moment, but the UI must still refresh quickly as the user moves around the real filesystem.
+- Call `invalidateQueries(...)` when the server changed and the client must read it again.
+- Call `setQueryData(...)` when the mutation already returned the new source value.
 
-- filesystem directory listing: `1 sec`
+For example, a settings save updates the settings cache. A repository settings save invalidates repository config. A task mutation invalidates task data and runs.
 
-File:
+## Data that does not belong in Query
 
-- [packages/frontend/src/state/queries/filesystem.ts](../packages/frontend/src/state/queries/filesystem.ts)
+Keep these values outside TanStack Query:
 
-### Git state
-
-Used for repository state where some values are stable and some are intentionally treated as immediately stale.
-
-- branches: `60 sec`
-- current branch: `60 sec`
-- worktree status: `0`
-- worktree status summary: `0`
-
-`worktree status` is intentionally `0` because we want request deduplication and keyed caching, but we do not want the UI to trust an old diff snapshot once control returns to the caller.
-
-File:
-
-- [packages/frontend/src/state/queries/git.ts](../packages/frontend/src/state/queries/git.ts)
-
-## Read patterns
-
-We use two main imperative read patterns:
-
-### `ensureQueryData`
-
-Used for canonical configuration reads that should return fresh cached data if available, otherwise fetch.
-
-Examples:
-
-- `loadSettingsSnapshotFromQuery(...)`
-- `loadRepoConfigFromQuery(...)`
-
-### `fetchQuery`
-
-Used for imperative operational reads where callers want the shared query behavior and in-flight deduplication, while still driving the read explicitly.
-
-Examples:
-
-- task/runs refreshes
-- session history reads
-- document reads
-- worktree status reads
-
-Task documents keep their normal `60 sec` stale time for ordinary viewing, but workflow-driven refreshes use explicit force-fresh fetches in `packages/frontend/src/state/queries/documents.ts` so external ODT document writes bypass stale adapter metadata without adding polling or focus refetching.
-
-## Mutation strategy
-
-We do not depend on background refetch heuristics for correctness.
-
-Instead, mutations must do one of:
-
-- `invalidateQueries(...)` when server truth changed and should be reloaded
-- `setQueryData(...)` when the new canonical value is already known locally
-
-Examples:
-
-- saving settings snapshot updates the settings snapshot cache directly
-- saving repo settings invalidates repo config
-- task mutations invalidate repo task data and runs
-
-## Non-goals
-
-TanStack Query is not the source of truth for:
-
-- streaming agent transcript assembly
-- pending permission/question state
-- composer input state
-- event-driven orchestration state
-- imperative mutation flows like `runtimeEnsure`, `buildStart`, `gitPushBranch`, or `taskTransition`
-
-These remain outside Query on purpose.
+- Live agent transcript assembly.
+- Pending permission and question state.
+- Composer input.
+- Event-driven orchestration state.
+- Commands such as `runtimeEnsure`, `buildStart`, `gitPushBranch`, and `taskTransition`.

--- a/docs/tanstack-query-cache-strategy.md
+++ b/docs/tanstack-query-cache-strategy.md
@@ -78,6 +78,8 @@ Use `ensureQueryData` for configuration that can return a fresh cached value. Ex
 
 Use `fetchQuery` for an imperative read that still needs the shared key and in-flight deduplication. Examples include task refresh, session history, documents, and worktree status.
 
+Use `prefetchQuery` to warm the cache for a read that the user is likely to need next.
+
 Task documents use a 60 second stale time for normal views. Workflow refreshes force a new fetch through `packages/frontend/src/state/queries/documents.ts` so an external ODT write appears without polling.
 
 ## Mutations

--- a/docs/task-description-markdown.md
+++ b/docs/task-description-markdown.md
@@ -30,6 +30,8 @@ The browser route requires the app-session cookie. Electron uses a privileged ap
 
 A workflow agent calls `odt_read_task_assets({ taskId, assetIds })`. It gets UUIDs from the description's `odt-asset:<assetId>` values.
 
+The call requires `workspaceId` when the process has no default workspace.
+
 Send one non-empty batch of at most 50 unique IDs when the raw data is at most 20 MiB. Split a larger set. The host checks the task and every asset before it reads a file. One missing or invalid asset fails the full call.
 
 The result keeps request order. It returns a short label and one native image block for each asset. It does not return file paths, browser URLs, `structuredContent`, or an MCP `outputSchema`.

--- a/docs/task-description-markdown.md
+++ b/docs/task-description-markdown.md
@@ -18,7 +18,7 @@ The task store checks the final Markdown, workspace, task, scope, file limits, a
 
 Files live at `task-assets/<workspaceId>/<taskId>/<assetId>` under the OpenDucktor config directory. SQLite stores the task, scope, name, media type, byte size, and creation time. Closing a task keeps its assets. Deleting a task quarantines its asset directory before it deletes the task and registry rows.
 
-Each host has an owner directory for staging and quarantine. Startup skips live owners, restores quarantines from dead owners, clears their staging files, and removes empty dead-owner state. Shutdown clears the current staging area. A later startup clears files left by a crash. There is no cleanup timer or polling loop. Invalid owner or quarantine data stops recovery and stays on disk for inspection.
+Each host has an owner directory for staging and quarantine. Startup skips live owners and reconciles quarantines from dead owners against SQLite. It restores uncommitted changes, purges committed changes, clears staging files, and removes empty dead-owner state. Shutdown clears the current staging area. A later startup clears files left by a crash. There is no cleanup timer or polling loop. Invalid owner or quarantine data stops recovery and stays on disk for inspection.
 
 ## Serving assets
 

--- a/docs/task-description-markdown.md
+++ b/docs/task-description-markdown.md
@@ -1,31 +1,35 @@
 # Task description Markdown
 
-Task descriptions persist one raw Markdown string. Visual editing uses TipTap only while the form is open; the task store never saves TipTap JSON, editor mode, preview URLs, or rendered output.
+The task store saves one raw Markdown string for each task description. TipTap exists only while the visual editor is open. The task store does not save TipTap JSON, editor mode, preview URLs, or rendered HTML.
 
-## Supported source
+## Supported Markdown
 
-Visual mode supports headings, emphasis, inline and fenced code, links, lists and task lists, blockquotes, rules, simple GFM tables, images, math, and Mermaid fences. The compatibility check keeps raw HTML, reference links, malformed front matter, and Markdown that cannot make a safe semantic round trip in source mode.
+Visual mode supports headings, emphasis, inline and fenced code, links, lists, task lists, blockquotes, rules, simple GFM tables, images, math, and Mermaid fences.
 
-A closed YAML `---` or TOML `+++` block at the start of a description stays outside TipTap. Visual edits reattach that raw prefix without parsing it. Read views omit a valid prefix; copy and source mode keep it.
+The editor stays in source mode for raw HTML, reference links, malformed front matter, or Markdown that cannot make a safe semantic round trip.
+
+A closed YAML `---` or TOML `+++` block can start a description. TipTap does not parse it. A visual edit attaches the unchanged block to the edited body. Read views hide a valid block. Copy and source mode keep it.
 
 ## Task assets
 
-Markdown stores only `odt-asset:<assetId>` image targets. Before save, the host stages approved PNG, JPEG, WebP, or GIF bytes and returns the final asset ID without a path. Task create and update commands carry staged IDs beside the durable task input.
+Markdown stores an image as `odt-asset:<assetId>`. Before save, the host stages approved PNG, JPEG, WebP, or GIF bytes and returns the asset ID. Task create and update commands send staged IDs with the task input.
 
-The asset-aware task store checks the final Markdown, workspace ownership, task ownership, scope, file limits, and registry collisions. It promotes new files and quarantines obsolete files around the SQLite transaction. Failed work restores or removes files where possible and returns a typed partial-state error when cleanup cannot restore a known state.
+The task store checks the final Markdown, workspace, task, scope, file limits, and registry collisions. It promotes new files and quarantines old files around the SQLite transaction. If cleanup cannot restore a known state, it returns a typed partial-state error.
 
-Durable files live below `task-assets/<workspaceId>/<taskId>/<assetId>` in the OpenDucktor config directory. SQLite stores the task, scope, name, media type, byte size, and creation time. Closing a task keeps its assets. Deleting a task quarantines its asset directory before deleting the task and its registry rows.
+Files live at `task-assets/<workspaceId>/<taskId>/<assetId>` under the OpenDucktor config directory. SQLite stores the task, scope, name, media type, byte size, and creation time. Closing a task keeps its assets. Deleting a task quarantines its asset directory before it deletes the task and registry rows.
 
-Staging and quarantine paths sit under a host-instance owner directory. Startup recovery skips live owners, reconciles quarantines from dead owners, clears their staging paths, and removes empty dead-owner state. Clean shutdown clears the current owner's staging. A later startup clears finite state left by a crash; no timer or polling loop owns this cleanup. The startup sweep also handles the older ownerless layout. Invalid owner or quarantine metadata stops recovery with a typed error and remains on disk for inspection.
+Each host has an owner directory for staging and quarantine. Startup skips live owners, restores quarantines from dead owners, clears their staging files, and removes empty dead-owner state. Shutdown clears the current staging area. A later startup clears files left by a crash. There is no cleanup timer or polling loop. Invalid owner or quarantine data stops recovery and stays on disk for inspection.
 
-## Serving
+## Serving assets
 
-The shared host read service validates the full workspace, task, scope, and asset relation before reading a derived path. It rejects symlinks and non-files, checks containment and byte size, and serves only registry-approved image media types with private no-store caching and `nosniff`.
+The host read service checks the workspace, task, scope, and asset row before it builds a path. It rejects symlinks and non-files. It also checks path containment, byte size, and image media type. Responses use private no-store caching and `nosniff`.
 
-The browser route requires the app-session cookie. Electron uses a privileged application protocol. Runtime URLs stay outside Markdown and SQLite.
+The browser route requires the app-session cookie. Electron uses a privileged app protocol. Markdown and SQLite do not store runtime URLs.
 
 ## Agent access
 
-Workflow agents read description images with `odt_read_task_assets({ taskId, assetIds })`. The caller collects the UUIDs from the description's `odt-asset:<assetId>` targets and sends one non-empty batch of up to 50 distinct IDs when their raw total is at most 20 MiB. Larger sets must be split across calls. The host resolves the canonical task, checks every registry row and the aggregate byte limit before reading files, enforces the same workspace/task/description-scope ownership checks as UI rendering, and fails the whole call if any requested asset is missing or invalid.
+A workflow agent calls `odt_read_task_assets({ taskId, assetIds })`. It gets UUIDs from the description's `odt-asset:<assetId>` values.
 
-The MCP result keeps request order and returns a short text label followed by a native image content block for each asset. It does not return storage paths, browser URLs, `structuredContent`, or an MCP `outputSchema`. OpenCode, Codex, and Claude-compatible MCP clients can pass those image blocks to their model without a kickoff-message attachment.
+Send one non-empty batch of at most 50 unique IDs when the raw data is at most 20 MiB. Split a larger set. The host checks the task and every asset before it reads a file. One missing or invalid asset fails the full call.
+
+The result keeps request order. It returns a short label and one native image block for each asset. It does not return file paths, browser URLs, `structuredContent`, or an MCP `outputSchema`.

--- a/docs/task-workflow-actions.md
+++ b/docs/task-workflow-actions.md
@@ -1,19 +1,11 @@
-# Task Workflow Actions
+# Task workflow actions
 
-## Purpose
-This document defines the canonical action contract for task-level workflow operations in OpenDucktor.
-It complements:
-- `docs/task-workflow-status-model.md`
-- `docs/task-workflow-transition-matrix.md`
+The backend returns allowed task actions in `TaskCard.availableActions`. The frontend renders that list. It does not infer actions from status.
 
-The backend is the single source of truth for which actions are currently allowed for a task.
+Read [the status model](task-workflow-status-model.md) for status and issue type rules. Read [the transition matrix](task-workflow-transition-matrix.md) for all transition guards.
 
-## Core Rule
-- Backend computes `availableActions` for each `TaskCard`.
-- Frontend must render actions from `availableActions`.
-- Frontend must not infer allowed actions from local status-only heuristics.
+## Action IDs
 
-## Action Set (Canonical IDs)
 - `view_details`
 - `set_spec`
 - `set_plan`
@@ -27,122 +19,65 @@ The backend is the single source of truth for which actions are currently allowe
 - `human_request_changes`
 - `human_approve`
 
-## Action Semantics
+## Simple actions
 
-### `view_details`
-- Purpose: open task details panel.
-- Transition: none.
+| Action | Effect |
+|---|---|
+| `view_details` | Open task details. No transition. |
+| `build_start` | Move to `in_progress` when backend rules allow it. |
+| `open_builder` | Open the linked Builder session. No transition. |
+| `qa_start` | Open QA from `blocked`, `ai_review`, or `human_review`. No direct transition. |
+| `open_qa` | Open the linked QA session. No transition. |
+| `human_request_changes` | Move `ai_review` or `human_review` to `in_progress`. |
+| `human_approve` | Move `ai_review` or `human_review` to `closed` after the epic child check passes. |
 
-### `set_spec`
-- Purpose: author or revise the specification markdown.
-- Allowed from `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, and `human_review`.
-- Transition: `open -> spec_ready`; all other allowed statuses stay in place as document-only revisions.
+## Document actions
 
-### `set_plan`
-- Purpose: author or revise implementation plan markdown.
-- Allowed statuses:
-  - `feature/epic`: `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, and `human_review`.
-  - `task/bug`: `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, and `human_review`.
-- Transition: valid pre-build planning moves to `ready_for_dev`; `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, and `human_review` stay in place as document-only revisions.
-- Epic subtask proposals are replacement intent; replacing existing direct subtasks is allowed only when those subtasks are still `open`, `spec_ready`, or `ready_for_dev`. Omitting `subtasks` preserves existing direct subtasks.
+`set_spec` writes or revises the specification. From `open`, it moves the task to `spec_ready`. In any other allowed status, it changes only the document.
 
-### `build_start`
-- Purpose: start build execution for this task.
-- Transition: to `in_progress` when allowed by backend transition rules.
+`set_plan` writes or revises the implementation plan. A `feature` or `epic` can use it from `spec_ready` or any later active status. A `task` or `bug` can also use it from `open`. Valid planning before a build moves the task to `ready_for_dev`. A later edit changes only the document.
 
-### `open_builder`
-- Purpose: open existing builder context/run UX.
-- Transition: none.
+For an epic, `subtasks` means replace the direct child proposal. Replacement is allowed only when all current direct children are `open`, `spec_ready`, or `ready_for_dev`. If `subtasks` is absent, keep the current children.
 
-### `reset_implementation`
-- Purpose: discard the current implementation attempt and clean up task-owned build/QA state.
-- Transition: `in_progress`, `blocked`, `ai_review`, or `human_review` -> derived rollback target.
-- Rollback target:
-  - `ready_for_dev` when an implementation plan document is retained.
-  - `spec_ready` when only a spec document is retained.
-  - `open` when neither document is retained.
-- Guardrails:
-  - reject while any live task role uses the canonical worktree.
-  - validate the canonical worktree and expected task branch before mutation.
-  - restore tracked content to the locally available base and remove ordinary untracked files while preserving ignored files.
-  - retain the canonical worktree and task branch; do not rerun copy paths or hooks.
-  - preserve retained spec and plan documents.
+## Reset implementation
 
-### `reset_task`
-- Purpose: fully restart a non-completed task without deleting the task record.
-- Transition: `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, or `human_review` -> `open`.
-- Cleanup:
-  - clear spec, plan, and QA documents.
-  - clear linked spec/planner/build/QA sessions.
-  - clear linked pull request and direct-merge metadata.
-  - clear in-memory run state.
-  - stop task-scoped dev servers.
-  - remove task-managed worktrees and related local branches.
-- Guardrails:
-  - reject while live spec/planner/build/QA activity still exists for the task.
-  - reject on unsafe branch cleanup, including checked-out branches.
-  - preserve task identity and user-authored task fields.
+`reset_implementation` discards the current build and QA attempt. It can run from `in_progress`, `blocked`, `ai_review`, or `human_review`.
 
-### `qa_start`
-- Purpose: request or start a QA review loop for the current task state.
-- Transition: none directly; it opens the QA workflow from `blocked`, `ai_review`, or `human_review`.
+Choose the target from the documents that remain:
 
-### `open_qa`
-- Purpose: open existing QA context/run UX.
-- Transition: none.
+- Use `ready_for_dev` when the plan remains.
+- Use `spec_ready` when only the specification remains.
+- Use `open` when neither remains.
 
-### `close_task`
-- Purpose: manually close a task as an administrative override from the task detail sheet only.
-- Allowed from every non-`closed` status.
-- Transition: any non-`closed` status -> `closed`.
-- Semantics:
-  - marks the task as Done without merging code, creating or updating a pull request, or approving QA.
-  - bypasses unfinished workflow steps explicitly; it is not proof of merge, QA approval, or implementation completion.
-  - preserves the task record, user-authored fields, workflow documents, QA reports, linked history, pull request metadata, and direct-merge metadata.
-- Cleanup:
-  - stop task-scoped dev servers.
-  - remove task-managed worktrees and related local branches when present.
-  - fail with an actionable error when cleanup is unsafe or incomplete.
-- Guardrails:
-  - reject while live spec/planner/build/QA activity still owns mutable runtime state.
-  - epic completion checks direct children and blocks while any direct child is not `closed`.
-- UI placement: task detail sheet workflow actions only. Kanban cards, Agent Studio quick actions, bulk actions, headers, and command palettes must not render this action.
+Before the reset:
 
-### `human_request_changes`
-- Purpose: human review rejects current output and requests a rework loop.
-- Transition: `ai_review -> in_progress` or `human_review -> in_progress`.
+- Reject the action while a live task role uses the canonical worktree.
+- Check the canonical worktree and task branch.
+- Restore tracked files to the local base. Remove ordinary untracked files and keep ignored files.
+- Keep the canonical worktree, task branch, specification, and plan. Do not rerun copy paths or hooks.
 
-### `human_approve`
-- Purpose: human review accepts completion.
-- Transition: `ai_review -> closed` or `human_review -> closed`.
-- Guardrail: epic completion checks direct children and blocks while any direct child is not `closed`.
+## Reset task
 
-## UI Mapping Guidance
-- A task can expose multiple actions at once.
-- UI should surface:
-  - one primary action (based on product ordering preferences),
-  - remaining actions in a secondary menu.
-- Primary ordering is a UI concern; allowed action set is backend authority.
+`reset_task` moves any non-closed task to `open`. It keeps the task ID and user fields.
 
-## Current UI Scope
-Current card/detail primary+menu rendering uses workflow actions:
-- `set_spec`
-- `set_plan`
-- `build_start`
-- `open_builder`
-- `reset_implementation`
-- `reset_task`
-- `qa_start`
-- `open_qa`
-- `close_task` (detail sheet only)
-- `human_request_changes`
-- `human_approve`
+It clears workflow documents, linked role sessions, pull request data, direct merge data, and in-memory runs. It stops task dev servers, then removes task worktrees and related local branches.
 
-`view_details` is handled via card click / details panel affordance and is not shown as a dedicated workflow button.
+Reject the action while a live role still owns task state. Reject it when branch cleanup is unsafe, such as when another worktree has the branch checked out.
 
-## Notes For Future Changes
-- Add new action IDs only with:
-  1. backend action derivation update,
-  2. transition-matrix update,
-  3. docs update here and in transition/status model docs,
-  4. UI mapping update.
+## Close task
+
+`close_task` moves any non-closed task to `closed` from the task detail sheet. It is an administrative override.
+
+The action keeps the task record, user fields, documents, QA reports, session history, pull request data, and direct merge data. It stops task dev servers and removes managed worktrees and local branches. If cleanup is unsafe or incomplete, it fails with an error.
+
+Reject it while a live role owns mutable task state. Reject an epic while a direct child is not closed.
+
+Only the task detail sheet can show `close_task`. Do not show it on a Kanban card, Agent Studio quick action, bulk action, header, or command palette.
+
+## UI rules
+
+A task can have more than one action. The UI can choose one primary action and put the rest in a menu. Display order is a UI rule. The backend list remains the authority.
+
+Current card and detail views use all action IDs except `view_details`, which the card click and details panel already provide.
+
+When you add an action ID, update backend derivation, the transition matrix, the status and action docs, and UI mapping in one change.

--- a/docs/task-workflow-status-model.md
+++ b/docs/task-workflow-status-model.md
@@ -46,7 +46,7 @@ open -> in_progress
 
 `qaRequired` defaults to `true` for all four issue types.
 
-When `qaRequired` is `true`, build completion moves to `ai_review` until the latest QA result is `approved`. When it is `false`, or QA already approved the current work, build completion moves to `human_review`.
+When `qaRequired` is `true`, build completion moves to `ai_review` until the latest QA result is `approved`. When it is `false`, or the latest stored QA result is already `approved`, build completion moves to `human_review`.
 
 ## Epic rules
 

--- a/docs/task-workflow-status-model.md
+++ b/docs/task-workflow-status-model.md
@@ -1,94 +1,71 @@
-# Task Workflow Status Model
+# Task workflow status model
 
-## Purpose
-This document defines the canonical task workflow model for OpenDucktor.
-It is the source of truth for:
-- persisted task statuses,
-- UI status labels,
-- type-specific behavior,
-- metadata ownership for agent-authored documents.
+This document defines persisted task status, UI labels, issue type rules, and task document ownership.
 
-## Core Principles
-- The persisted task `status` is the canonical lifecycle state.
-- OpenDucktor does not use labels for lifecycle state.
-- Transitions are backend-enforced and mostly tool-driven.
-- User-authored fields and agent-authored documents are separated.
+## Source of truth
 
-## Persisted Statuses
-OpenDucktor uses the following task statuses:
-- Built-in: `open`, `in_progress`, `blocked`, `closed`
-- Custom: `spec_ready`, `ready_for_dev`, `ai_review`, `human_review`
+- The persisted `status` is the task lifecycle state.
+- The backend validates each transition.
+- The frontend renders the actions in `TaskCard.availableActions`. It does not infer actions from status.
+- User fields and agent documents have separate owners.
 
-Notes:
-- `open` is used as the persisted backlog state.
-- UI displays `open` as `Backlog`.
-- `human_review` is considered in-progress work from an orchestration perspective.
-- Manual close is an administrative override to `closed`/Done. It is not evidence that code was merged, QA was approved, or unfinished workflow steps were completed.
+## Statuses
 
-## UI Mapping
-- `open` -> `Backlog`
-- `spec_ready` -> `Spec Ready`
-- `ready_for_dev` -> `Ready for Dev`
-- `in_progress` -> `In Progress`
-- `blocked` -> `Blocked needs input`
-- `ai_review` -> `AI Review`
-- `human_review` -> `Human Review`
-- `closed` -> `Done`
+| Stored status | UI label | Note |
+|---|---|---|
+| `open` | Backlog | Persisted backlog state. |
+| `spec_ready` | Spec Ready | The task has a specification. |
+| `ready_for_dev` | Ready for Dev | The task can start a build. |
+| `in_progress` | In Progress | Build work is active or can resume. |
+| `blocked` | Blocked needs input | Build work needs input. |
+| `ai_review` | AI Review | QA can review the build. |
+| `human_review` | Human Review | This still counts as work in progress for orchestration. |
+| `closed` | Done | The task is closed. |
 
-## Task Capability Contract (Backend-Driven)
-- Backend computes allowed task actions and returns them on each `TaskCard` as `availableActions`.
-- Frontend must render action buttons from `availableActions` and must not infer workflow actions from local status heuristics.
-- This keeps workflow authority in the backend transition matrix while allowing UI-specific presentation (button order, emphasis, labels).
+`close_task` is an administrative override. It does not prove that code was merged, QA passed, or all workflow steps finished.
 
-## Issue Types in Scope
-Allowed issue types in OpenDucktor UI:
-- `epic`
-- `feature`
-- `task`
-- `bug`
+## Issue types
 
-Removed from OpenDucktor UI scope:
-- `chore`
-- `decision`
+The UI supports `epic`, `feature`, `task`, and `bug`. It does not support `chore` or `decision`.
 
-## Type-Specific Flow Rules
-- `feature` and `epic` follow the standard path:
-  `open -> spec_ready -> ready_for_dev -> in_progress -> ai_review/human_review -> closed`
-- `feature` and `epic` cannot start planning directly from `open`; `set_plan` is allowed from `spec_ready`, `ready_for_dev`, and later active/review states as document revisions.
-- `task` and `bug` may skip spec/planning:
-  `open -> in_progress`
-- Spec and plan documents can be revised during `in_progress`, `blocked`, `ai_review`, and `human_review` without changing task status.
+`feature` and `epic` use this path:
 
-## QA Requirement Defaults
-`qaRequired` defaults by issue type:
-- `epic`: `true`
-- `feature`: `true`
-- `task`: `true` (for now)
-- `bug`: `true` (for now)
+```text
+open -> spec_ready -> ready_for_dev -> in_progress -> ai_review/human_review -> closed
+```
 
-When `qaRequired=true`, build completion returns to `ai_review` until the latest QA verdict is `approved`.
-When `qaRequired=false`, or when the latest QA verdict is already `approved`, build completion goes directly to `human_review`.
+They cannot plan from `open`. A later spec or plan edit does not change a task that is already in `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, or `human_review`.
 
-## Epic/Subtask Rules
-- Only `epic` can have subtasks.
-- Max hierarchy depth is 1 level.
-- Subtasks cannot have subtasks.
-- Epic completion guard checks direct children only.
-- Epic completion guard blocks while any direct child is not `closed`.
+`task` and `bug` can skip the spec and plan:
 
-## Document Contract (Agent-Owned Documents)
-Agent-authored documents are stored as task documents only, never in user-authored task fields.
+```text
+open -> in_progress
+```
 
-SQLite stores document bodies as plain markdown with an explicit `format` value. The current document kinds are:
+## QA defaults
 
-- `spec`
-- `implementationPlan`
-- `qaReports`
+`qaRequired` defaults to `true` for all four issue types.
 
-Document rows include task id, kind, revision, markdown, format, optional QA verdict, source tool, updater, and update timestamp.
-Frontend and MCP callers receive plain markdown on successful reads.
+When `qaRequired` is `true`, build completion moves to `ai_review` until the latest QA result is `approved`. When it is `false`, or QA already approved the current work, build completion moves to `human_review`.
 
-Example document rows keep canonical workflow source tools explicit:
+## Epic rules
+
+- Only an `epic` can have direct children.
+- The hierarchy has one child level.
+- A child cannot have children.
+- An epic cannot close while a direct child is not `closed`.
+
+## Task documents
+
+Store agent-written output as task documents, not user task fields. SQLite stores plain Markdown and an explicit `format`.
+
+| Kind | Current UI read |
+|---|---|
+| `spec` | Latest entry. |
+| `implementationPlan` | Latest entry. |
+| `qaReports` | Latest entry. |
+
+The store can keep history. Each row has a task ID, kind, revision, Markdown body, format, optional QA result, source tool, updater, and update time. Frontend and MCP reads return plain Markdown.
 
 ```json
 [
@@ -98,11 +75,4 @@ Example document rows keep canonical workflow source tools explicit:
 ]
 ```
 
-## Document History Policy
-- `qaReports`: history may be retained, but V1 UI surfaces the latest entry.
-- `spec`: history may be retained, but V1 UI surfaces the latest entry.
-- `implementationPlan`: history may be retained, but V1 UI surfaces the latest entry.
-
-## Write Safety Rules
-- Task-store updates must preserve unrelated durable task fields.
-- No workflow-critical data should depend on UI-only labels.
+Each write must keep unrelated durable task fields. Workflow rules use stored status, not UI labels.

--- a/docs/task-workflow-transition-matrix.md
+++ b/docs/task-workflow-transition-matrix.md
@@ -1,21 +1,14 @@
-# Task Workflow Transition Matrix
+# Task workflow transition matrix
 
-## Purpose
-This document defines the only allowed lifecycle transitions for OpenDucktor tasks,
-including trigger tools/actions and guardrails.
+This matrix lists every allowed task transition. The backend validates it. The UI cannot set a status directly. A workflow tool or task action must start each automatic transition.
 
-## Transition Policy
-- Backend owns transition validation.
-- UI cannot directly set arbitrary status values.
-- Auto-transitions are triggered only by explicit workflow tools/actions.
+## Workflow tools
 
-## Tool Naming (Canonical)
-MCP workflow tools:
 - `odt_read_task(taskId)`
 - `odt_read_task_assets(taskId, assetIds)`
 - `odt_read_task_documents(taskId, includeSpec?, includePlan?, includeQaReport?)`
 - `odt_set_spec(taskId, markdown)`
-- `odt_set_plan(taskId, markdown, subtasks?)` (epic only for `subtasks`, one level max)
+- `odt_set_plan(taskId, markdown, subtasks?)`
 - `odt_build_blocked(taskId, reason)`
 - `odt_build_resumed(taskId)`
 - `odt_build_completed(taskId, summary?)`
@@ -23,65 +16,44 @@ MCP workflow tools:
 - `odt_qa_approved(taskId, reportMarkdown)`
 - `odt_qa_rejected(taskId, reportMarkdown)`
 
-Read flow:
-- Call `odt_read_task` first for the returned `task` summary object, including task state, `qaVerdict`, and document presence booleans.
-- When task Markdown contains `odt-asset:<assetId>` images needed for the work, collect the relevant IDs and call `odt_read_task_assets` once when their raw total is at most 20 MiB. Split only larger sets.
-- Call `odt_read_task_documents` only when spec, implementation plan, or latest QA markdown bodies are needed.
+Call `odt_read_task` first. Use its `task` object for status, `qaVerdict`, and document presence. Read document bodies only when the work needs them. Read image assets only when the work needs them.
 
-`subtasks` payload (optional):
-- `title` (required)
-- `issueType` (`task` | `feature` | `bug`, defaults to `task`)
-- `priority` (0..4, defaults to `2`)
-- `description` (optional)
+One `odt_read_task_assets` call can contain at most 50 unique IDs and 20 MiB of raw data. Split only a larger set.
 
-Human actions:
-- `human_request_changes(taskId, note)`
-- `human_approve(taskId)`
+An epic `subtasks` item has a required `title`, an optional `description`, an `issueType` of `task`, `feature`, or `bug`, and a `priority` from 0 through 4. The defaults are `task` and 2. Children can have one level only.
 
-Native task actions:
-- `reset_implementation(taskId)`
-- `reset_task(taskId)`
-- `close_task(taskId)`
+Human actions are `human_request_changes(taskId, note)` and `human_approve(taskId)`. Native task actions are `reset_implementation(taskId)`, `reset_task(taskId)`, and `close_task(taskId)`.
 
-## Transition Matrix
-| Trigger | From | Guards | To |
+## Matrix
+
+| Trigger | From | Guard | To |
 |---|---|---|---|
-| `task_create` | n/a | always | `open` |
-| `odt_set_spec` | `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | non-empty markdown | `spec_ready` when starting from `open`, otherwise unchanged |
-| `odt_set_plan` (feature/epic) | `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | non-empty markdown | `ready_for_dev` when starting from `spec_ready`, otherwise unchanged |
-| `odt_set_plan` (task/bug) | `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | non-empty markdown | `ready_for_dev` when starting from `open` or `spec_ready`, otherwise unchanged |
-| `odt_set_plan` (epic with subtasks) | `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | plan includes subtask proposals; replacing existing direct subtasks requires all direct subtasks to be `open`, `spec_ready`, or `ready_for_dev` | `ready_for_dev` when starting from `spec_ready`, otherwise unchanged |
-| `odt_build_resumed` | `ready_for_dev` | feature/epic standard flow | `in_progress` |
-| `odt_build_resumed` | `open`, `spec_ready`, `ready_for_dev`, `blocked` | task/bug optional flow + blocked resume | `in_progress` |
-| `odt_build_blocked` | `in_progress` | reason required | `blocked` |
-| `reset_implementation` | `in_progress`, `blocked`, `ai_review`, `human_review` | reject while live build/QA activity exists; reject on unsafe branch cleanup; retained plan/spec determine rollback target | `ready_for_dev`, `spec_ready`, or `open` |
-| `reset_task` | `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | reject while live spec/planner/build/QA activity exists; reject on unsafe branch cleanup; clear workflow documents, linked sessions, delivery metadata, and in-memory runs | `open` |
-| `odt_build_completed` | `in_progress` | `qaRequired=true` and latest QA verdict is not `approved` (including no QA verdict yet) | `ai_review` |
-| `odt_build_completed` | `in_progress` | `qaRequired=false` or latest QA verdict is `approved` | `human_review` |
-| `odt_build_completed` | `blocked` | `qaRequired=true` and latest QA verdict is not `approved` (including no QA verdict yet) | `ai_review` |
-| `odt_build_completed` | `blocked` | `qaRequired=false` or latest QA verdict is `approved` | `human_review` |
-| `odt_build_completed` | `ai_review`, `human_review` | idempotent no-op (no hooks, no transition patch) | unchanged |
-| `odt_set_pull_request` | `in_progress`, `ai_review`, `human_review` | provider id and PR number required; OpenDucktor resolves canonical PR metadata | unchanged |
-| `odt_qa_rejected` | `blocked`, `ai_review`, `human_review` | report markdown required | `in_progress` |
-| `odt_qa_approved` | `blocked`, `ai_review`, `human_review` | report markdown required | `human_review` |
-| `human_request_changes` | `ai_review`, `human_review` | note optional | `in_progress` |
-| `human_approve` | `ai_review`, `human_review` | epic completion guard passes | `closed` |
-| `close_task` | `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | manual override from task detail sheet only; reject while live spec/planner/build/QA activity exists; epic completion guard passes; cleanup of task-scoped dev servers, task-managed worktrees, and related local branches succeeds | `closed` |
+| `task_create` | none | Always. | `open` |
+| `odt_set_spec` | `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | Markdown is not empty. | `spec_ready` from `open`; otherwise unchanged. |
+| `odt_set_plan` for `feature` or `epic` | `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | Markdown is not empty. | `ready_for_dev` from `spec_ready`; otherwise unchanged. |
+| `odt_set_plan` for `task` or `bug` | `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | Markdown is not empty. | `ready_for_dev` from `open` or `spec_ready`; otherwise unchanged. |
+| `odt_set_plan` with epic children | Same as epic plan. | Replacement requires all current direct children to be `open`, `spec_ready`, or `ready_for_dev`. | Same as epic plan. |
+| `odt_build_resumed` for `feature` or `epic` | `ready_for_dev` | Standard flow. | `in_progress` |
+| `odt_build_resumed` for `task` or `bug` | `open`, `spec_ready`, `ready_for_dev`, `blocked` | Optional short flow or blocked resume. | `in_progress` |
+| `odt_build_blocked` | `in_progress` | `reason` is present. | `blocked` |
+| `reset_implementation` | `in_progress`, `blocked`, `ai_review`, `human_review` | No live build or QA activity. Branch cleanup is safe. | `ready_for_dev`, `spec_ready`, or `open` from retained documents. |
+| `reset_task` | Any non-closed status. | No live role activity. Branch cleanup is safe. | `open` |
+| `odt_build_completed` | `in_progress`, `blocked` | QA is required and the latest result is not `approved`. | `ai_review` |
+| `odt_build_completed` | `in_progress`, `blocked` | QA is not required, or the latest result is `approved`. | `human_review` |
+| `odt_build_completed` | `ai_review`, `human_review` | Idempotent. No hook or patch runs. | Unchanged. |
+| `odt_set_pull_request` | `in_progress`, `ai_review`, `human_review` | `providerId` and pull request number are present. | Unchanged. |
+| `odt_qa_rejected` | `blocked`, `ai_review`, `human_review` | Report Markdown is present. | `in_progress` |
+| `odt_qa_approved` | `blocked`, `ai_review`, `human_review` | Report Markdown is present. | `human_review` |
+| `human_request_changes` | `ai_review`, `human_review` | `note` is optional. | `in_progress` |
+| `human_approve` | `ai_review`, `human_review` | All direct epic children are closed. | `closed` |
+| `close_task` | Any non-closed status. | Detail sheet only. No live role activity. Epic children are closed. Cleanup succeeds. | `closed` |
 
-## Guardrails
-- Epic completion guard: block close if direct children are still open states.
-- Only epics can have direct children.
-- Subtasks cannot have children.
+`reset_task` clears documents, linked sessions, delivery data, and in-memory runs. `close_task` stops task dev servers and removes task worktrees and related local branches.
 
-## Invalid Transition Examples
-- `open -> closed` without an explicit `close_task` action.
-- `ai_review -> closed` without an explicit `human_approve` or `close_task` action.
-- `blocked -> closed` directly without `close_task`.
+## Invalid examples
 
-## Board Semantics
-UI labels are presentation only:
-- `Backlog` is persisted as `open`.
-- `Done` is persisted as `closed`.
-- `Blocked needs input` is persisted as `blocked`.
+- `open -> closed` without `close_task`.
+- `ai_review -> closed` without `human_approve` or `close_task`.
+- `blocked -> closed` without `close_task`.
 
-Any analytics/reporting must use persisted statuses, not UI labels.
+UI labels are display text. Analytics and reports use stored status values. `Backlog` means `open`, `Done` means `closed`, and `Blocked needs input` means `blocked`.

--- a/docs/task-workflow-transition-matrix.md
+++ b/docs/task-workflow-transition-matrix.md
@@ -4,21 +4,23 @@ This matrix lists every allowed task transition. The backend validates it. The U
 
 ## Workflow tools
 
-- `odt_read_task(taskId)`
-- `odt_read_task_assets(taskId, assetIds)`
-- `odt_read_task_documents(taskId, includeSpec?, includePlan?, includeQaReport?)`
-- `odt_set_spec(taskId, markdown)`
-- `odt_set_plan(taskId, markdown, subtasks?)`
-- `odt_build_blocked(taskId, reason)`
-- `odt_build_resumed(taskId)`
-- `odt_build_completed(taskId, summary?)`
-- `odt_set_pull_request(taskId, providerId, number)`
-- `odt_qa_approved(taskId, reportMarkdown)`
-- `odt_qa_rejected(taskId, reportMarkdown)`
+- `odt_read_task`: `taskId`
+- `odt_read_task_assets`: `taskId`, `assetIds`
+- `odt_read_task_documents`: `taskId`, `includeSpec?`, `includePlan?`, `includeQaReport?`
+- `odt_set_spec`: `taskId`, `markdown`
+- `odt_set_plan`: `taskId`, `markdown`, `subtasks?`
+- `odt_build_blocked`: `taskId`, `reason`
+- `odt_build_resumed`: `taskId`
+- `odt_build_completed`: `taskId`, `summary?`
+- `odt_set_pull_request`: `taskId`, `providerId`, `number`
+- `odt_qa_approved`: `taskId`, `reportMarkdown`
+- `odt_qa_rejected`: `taskId`, `reportMarkdown`
 
-Call `odt_read_task` first. Use its `task` object for status, `qaVerdict`, and document presence. Read document bodies only when the work needs them. Read image assets only when the work needs them.
+Call `odt_read_task` first for the returned `task` summary object, including task state, `qaVerdict`, and document presence booleans.
 
-One `odt_read_task_assets` call can contain at most 50 unique IDs and 20 MiB of raw data. Split only a larger set.
+When task Markdown contains `odt-asset:<assetId>` images needed for the work, collect the relevant IDs and call `odt_read_task_assets` once when their raw total is at most 20 MiB. Split only larger sets.
+
+Call `odt_read_task_documents` only when spec, implementation plan, or latest QA markdown bodies are needed.
 
 An epic `subtasks` item has a required `title`, an optional `description`, an `issueType` of `task`, `feature`, or `bug`, and a `priority` from 0 through 4. The defaults are `task` and 2. Children can have one level only.
 
@@ -30,9 +32,9 @@ Human actions are `human_request_changes(taskId, note)` and `human_approve(taskI
 |---|---|---|---|
 | `task_create` | none | Always. | `open` |
 | `odt_set_spec` | `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | Markdown is not empty. | `spec_ready` from `open`; otherwise unchanged. |
-| `odt_set_plan` for `feature` or `epic` | `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | Markdown is not empty. | `ready_for_dev` from `spec_ready`; otherwise unchanged. |
-| `odt_set_plan` for `task` or `bug` | `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | Markdown is not empty. | `ready_for_dev` from `open` or `spec_ready`; otherwise unchanged. |
-| `odt_set_plan` with epic children | Same as epic plan. | Replacement requires all current direct children to be `open`, `spec_ready`, or `ready_for_dev`. | Same as epic plan. |
+| `odt_set_plan` (feature/epic) | `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | Markdown is not empty. | `ready_for_dev` from `spec_ready`; otherwise unchanged. |
+| `odt_set_plan` (task/bug) | `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | Markdown is not empty. | `ready_for_dev` from `open` or `spec_ready`; otherwise unchanged. |
+| `odt_set_plan` (epic with subtasks) | Same as epic plan. | Replacement requires all current direct children to be `open`, `spec_ready`, or `ready_for_dev`. | Same as epic plan. |
 | `odt_build_resumed` for `feature` or `epic` | `ready_for_dev` | Standard flow. | `in_progress` |
 | `odt_build_resumed` for `task` or `bug` | `open`, `spec_ready`, `ready_for_dev`, `blocked` | Optional short flow or blocked resume. | `in_progress` |
 | `odt_build_blocked` | `in_progress` | `reason` is present. | `blocked` |

--- a/docs/task-workflow-transition-matrix.md
+++ b/docs/task-workflow-transition-matrix.md
@@ -35,7 +35,7 @@ Human actions are `human_request_changes(taskId, note)` and `human_approve(taskI
 | `odt_set_plan` (feature/epic) | `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | Markdown is not empty. | `ready_for_dev` from `spec_ready`; otherwise unchanged. |
 | `odt_set_plan` (task/bug) | `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | Markdown is not empty. | `ready_for_dev` from `open` or `spec_ready`; otherwise unchanged. |
 | `odt_set_plan` (epic with subtasks) | Same as epic plan. | Replacement requires all current direct children to be `open`, `spec_ready`, or `ready_for_dev`. | Same as epic plan. |
-| `odt_build_resumed` for `feature` or `epic` | `ready_for_dev` | Standard flow. | `in_progress` |
+| `odt_build_resumed` for `feature` or `epic` | `ready_for_dev`, `blocked` | Standard flow or blocked resume. | `in_progress` |
 | `odt_build_resumed` for `task` or `bug` | `open`, `spec_ready`, `ready_for_dev`, `blocked` | Optional short flow or blocked resume. | `in_progress` |
 | `odt_build_blocked` | `in_progress` | `reason` is present. | `blocked` |
 | `reset_implementation` | `in_progress`, `blocked`, `ai_review`, `human_review` | No live build or QA activity. Branch cleanup is safe. | `ready_for_dev`, `spec_ready`, or `open` from retained documents. |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -33,7 +33,7 @@ Bun can interleave test files in one process. A file-wide module mock or process
 - Provide the smallest required context providers for hooks and components.
 - Give each fixture new nested objects and arrays.
 
-A `renderToStaticMarkup` test needs the same Query and context providers as a client-rendered test.
+A `renderToStaticMarkup` test that uses Query or app context needs the same providers as a client-rendered test.
 
 ## Async and flaky tests
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,49 @@
+# Testing guide
+
+Read this guide before you add or change tests.
+
+## Coverage
+
+- Test each changed behavior in its owning package.
+- Add deep tests for changed behavior in `packages/host`, `packages/core`, adapters, and MCP.
+- Add frontend tests for changed frontend behavior.
+- Do not change a production API, constructor, option, or exported type only to make a test easier or faster.
+- Use a narrow test helper, a local fake around an existing boundary, or a production refactor that improves the design.
+
+## Bun module mocks
+
+- Prefer dependency injection, a direct function parameter, or `spyOn` to `mock.module(...)`.
+- Mock the source module that owns an export. Do not mock a shared barrel such as `@/state`, `@/components`, or another `index.ts` module.
+- Match the exact import string used by production code.
+- Scope `mock.module(...)` to the smallest test span.
+- Restore the exact module ID to a captured real module or a source path that the mock does not replace.
+- Do not load the real module through the mocked specifier while the mock is active.
+- Do not use process-wide `mock.restore()` to clean up `mock.module(...)`.
+- Do not leave a module mock active after its test scope.
+
+Bun can interleave test files in one process. A file-wide module mock or process-wide restore can change another test.
+
+## Test isolation
+
+- Prefer a focused hook or module test to a broad page test for orchestration or routing behavior.
+- Use an injected fake when a test only checks one dependency input.
+- Do not mutate `host`, a shared query client, an exported adapter, or another module singleton when a local seam can replace it.
+- Restore an unavoidable singleton mutation in `finally` or `afterEach`.
+- Give each TanStack Query test its own query client through `QueryProvider` with `useIsolatedClient`.
+- Provide the smallest required context providers for hooks and components.
+- Give each fixture new nested objects and arrays.
+
+A `renderToStaticMarkup` test needs the same Query and context providers as a client-rendered test.
+
+## Async and flaky tests
+
+- Use an explicit `waitFor(...)` or test-harness timeout for async Query, portal, or render work.
+- Keep each explicit wait below the Bun test timeout.
+- Run flake checks in sequence.
+
+## Browser validation
+
+- Use `agent-browser` against the live app and the real OpenDucktor backend.
+- Use browser mode when it can cover the UI change.
+- Ask the user to start `bun run browser:dev`.
+- Connect to the running app. Do not start the browser runner yourself.

--- a/docs/web-runner.md
+++ b/docs/web-runner.md
@@ -1,59 +1,57 @@
-# OpenDucktor Web Runner
+# OpenDucktor web runner
 
-The web runner lets OpenDucktor run in a browser without a desktop window. It uses the same shared React frontend and TypeScript host boundary as the Electron shell.
+The web runner opens OpenDucktor in a browser. It uses the same React frontend and TypeScript host contract as the Electron app.
 
-## Command
+## Start the runner
+
+Use the published package:
 
 ```sh
 bunx @openducktor/web
 ```
 
-During repository development, use the root wrapper:
+Use this command while you work in the repository:
 
 ```sh
 bun run browser:dev
 ```
 
-Both commands start a loopback-only TypeScript host backend and serve the shared frontend.
+Both commands start a loopback-only host and serve the shared frontend.
 
 ## Architecture
 
-- `packages/frontend` owns the shared React app and shell bootstrap. It exposes `bootstrapOpenDucktorShell` and the `ShellBridge` contract types.
-- `apps/electron` is a thin Electron shell that implements the bridge with Electron IPC/preload and delegates host behavior to `@openducktor/host`.
-- `packages/openducktor-web` is a browser shell and launcher. It implements the bridge with HTTP invoke calls and SSE subscriptions against the local TypeScript host backend.
-- `packages/openducktor-web/src/typescript-host-backend.ts` adapts `@openducktor/host` to the browser HTTP/SSE contract.
+- `packages/frontend` owns the React app, `bootstrapOpenDucktorShell`, and `ShellBridge` types.
+- `apps/electron` implements the bridge with preload IPC and delegates host work to `@openducktor/host`.
+- `packages/openducktor-web` implements the bridge with HTTP calls and SSE subscriptions.
+- `packages/openducktor-web/src/typescript-host-backend.ts` maps `@openducktor/host` to the HTTP and SSE contract.
 
-Shared frontend code must not import shell internals directly. The root `bun run frontend:boundary-guard` check enforces that boundary.
+Shared frontend code cannot import shell internals. `bun run frontend:boundary-guard` checks this rule.
 
-## Control Plane
+## Access control
 
-The launcher generates two tokens for each run and passes both to the TypeScript host backend:
+The launcher creates two tokens for each run:
 
-- a control token for launcher-only operations such as `/shutdown`, sent with the `x-openducktor-control-token` header;
-- an app token for browser-facing API bootstrap. The browser shell sends it once to `/session` with the `x-openducktor-app-token` header. The host then sets an HttpOnly `openducktor_web_session` cookie for SSE streams and attachment previews, so app tokens are not placed in URLs. Invoke requests still include the app-token header and credentials.
+- The control token authorizes launcher calls such as `/shutdown`. The launcher sends it in `x-openducktor-control-token`.
+- The app token starts a browser session. The browser sends it once to `/session` in `x-openducktor-app-token`.
 
-The browser shell fails fast if the launcher does not inject `VITE_ODT_BROWSER_BACKEND_URL` and `VITE_ODT_BROWSER_AUTH_TOKEN`. There is no default backend URL, so a page cannot accidentally attach to a stale local host.
+The host then sets the HttpOnly `openducktor_web_session` cookie for SSE and attachment previews. Invoke requests keep the app-token header and credentials. Tokens do not appear in URLs.
 
-The web host validates the configured frontend origin for CORS. The origin must be an `http` loopback origin with an explicit port and no credentials, path, query, or fragment. There is no fallback from the web host to a desktop runtime route.
+The browser shell requires `VITE_ODT_BROWSER_BACKEND_URL` and `VITE_ODT_BROWSER_AUTH_TOKEN`. It does not use a default URL. The host accepts only a configured `http` loopback origin with an explicit port and no user info, path, query, or fragment. The web host does not fall back to a desktop runtime route.
 
-## Release Packaging
+## Package
 
-Published installs are self-contained in the `@openducktor/web` package:
+The published `@openducktor/web` package contains:
 
-- `dist/cli.js` contains the launcher and TypeScript host backend.
-- `dist/web-shell/**` contains the built browser shell.
+- `dist/cli.js` for the launcher and TypeScript host.
+- `dist/web-shell/**` for the built browser UI.
 
-Release automation owns the package in `.github/workflows/publish-web.yml`. The workflow builds `@openducktor/web`, verifies package contents with `scripts/prepare-web-publish-packages.ts`, runs `npm publish --dry-run`, and publishes the package through npm Trusted Publisher.
+`.github/workflows/publish-web.yml` builds and checks the package. It runs `scripts/prepare-web-publish-packages.ts` and `npm publish --dry-run`, then publishes through npm Trusted Publisher.
 
-Workspace development mode (`bun run browser:dev`) runs the same launcher in `--workspace` mode. It starts the TypeScript host backend in-process and serves the repo-local frontend with Vite.
+`bun run browser:dev` runs the same launcher in workspace mode and serves the local frontend with Vite. Both modes stop with an error when config, session setup, or a host command fails.
 
-The published package and workspace mode both fail fast if runtime config is missing, if the launcher cannot establish a session with the app token, or if a host command is unavailable.
+The web runner supports local browser use. Its platform behavior follows the TypeScript host and local runtime discovery.
 
-The web runner is currently intended for local development and local browser use. Platform behavior follows the TypeScript host and local runtime discovery behavior.
-
-## Verification
-
-Relevant checks for web-runner changes:
+## Verify a change
 
 ```sh
 bun run frontend:boundary-guard
@@ -64,4 +62,4 @@ bun run --filter @openducktor/web typecheck
 bun run --filter @openducktor/web build
 ```
 
-Full release confidence also requires the root repo checks (`bun run lint`, `bun run typecheck`, `bun run test`, `bun run build`) and a browser smoke against the live `bun run browser:dev` app. Desktop changes should be smoke-tested with `bun run electron:dev` or a packaged desktop artifact before publishing the draft release.
+Before a release, also run the root lint, typecheck, test, and build. Test the live browser app. Test desktop changes with `bun run electron:dev` or a packaged app before you publish the draft.


### PR DESCRIPTION
The documentation had long, vague prose and mixed instruction styles. This made project rules hard to scan and made agent instructions easier to misread.

This PR rewrites `docs/` in ASD-STE100 Simplified Technical English and removes stock AI wording. It also restores `AGENTS.md` as an instruction file with direct commands, explicit constraints, and branch-specific reading rules.

Exact code terms, commands, schema fields, workflow tool names, state transitions, and other contracts stay intact. `README.md` is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized and condensed project guidance covering architecture, runtimes, task workflows, security, dependencies, and release procedures.
  * Added frontend development, testing, task-description Markdown, and interactive terminal architecture guides.
  * Clarified workflow actions, status transitions, MCP usage, runtime integration, cache strategy, and local HTTP security requirements.
  * Updated architecture decision records, including superseded and approved runtime decisions.
  * Refined documentation indexes with streamlined, task-oriented navigation and consistent formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->