### PR TITLE
fix: restore Windows terminals and preserve error details

### DIFF
--- a/apps/electron/src/main/terminals/node-pty-adapter.test.ts
+++ b/apps/electron/src/main/terminals/node-pty-adapter.test.ts
@@ -41,16 +41,21 @@ describe("createNodePtyPort", () => {
     { exitCode: 1, signal: 0, requestedClose: false, failed: true },
     { exitCode: 0, signal: 15, requestedClose: false, failed: true },
     { exitCode: 0, signal: 15, requestedClose: true, failed: false },
+    { exitCode: -1, signal: 0, requestedClose: false, failed: true, pid: 0 },
   ])(
     "classifies silent exit $exitCode, signal $signal, requested close $requestedClose",
-    async ({ exitCode, signal, requestedClose, failed }) => {
+    async ({ exitCode, signal, requestedClose, failed, pid = 42 }) => {
       let exitListener: (event: { exitCode: number; signal: number }) => void = () => undefined;
       const events: string[] = [];
+      const terminatedPids: number[] = [];
       const port = createNodePtyPort({
-        processTreeTerminator: () => Effect.void,
+        processTreeTerminator: ({ pid }) =>
+          Effect.sync(() => {
+            terminatedPids.push(pid);
+          }),
         nodePty: {
           spawn: () => ({
-            pid: 42,
+            pid,
             onData: () => ({ dispose: () => undefined }),
             onExit: (listener) => {
               exitListener = listener;
@@ -76,6 +81,8 @@ describe("createNodePtyPort", () => {
       if (requestedClose) await Effect.runPromise(handle.terminate());
       exitListener({ exitCode, signal });
       await Bun.sleep(0);
+      await Effect.runPromise(handle.terminate());
+      expect(terminatedPids).toEqual(pid === 0 ? [] : [pid]);
       expect(events.at(-1)).toBe("exit");
       if (!failed) expect(events).toEqual(["exit"]);
       else {

--- a/apps/electron/src/main/terminals/node-pty-adapter.test.ts
+++ b/apps/electron/src/main/terminals/node-pty-adapter.test.ts
@@ -4,6 +4,83 @@ import { Effect } from "effect";
 import { createNodePtyPort } from "./node-pty-adapter";
 
 describe("createNodePtyPort", () => {
+  test("includes the native spawn error, shell, and directory in startup failures", async () => {
+    const port = createNodePtyPort({
+      nodePty: {
+        spawn: () => {
+          throw new Error("Access is denied");
+        },
+      },
+    });
+    const result = await Effect.runPromise(
+      Effect.either(
+        port.start(
+          {
+            shell: "C:\\Windows\\System32\\cmd.exe",
+            args: [],
+            cwd: "C:\\repo",
+            env: {},
+            grid: { columns: 80, rows: 24 },
+          },
+          { onOutput: () => undefined, onFailure: () => undefined, onExit: () => undefined },
+        ),
+      ),
+    );
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left.code).toBe("spawn_failed");
+      expect(result.left.message).toContain("Access is denied");
+      expect(result.left.message).toContain("C:\\Windows\\System32\\cmd.exe");
+      expect(result.left.message).toContain("C:\\repo");
+      expect(result.left.message).toContain("Check that");
+    }
+  });
+
+  test.each([0, 1])(
+    "reports a silent unsuccessful shell exit, but not a clean exit (%i)",
+    async (exitCode) => {
+      let exitListener: (event: { exitCode: number }) => void = () => undefined;
+      const events: string[] = [];
+      const port = createNodePtyPort({
+        processTreeTerminator: () => Effect.void,
+        nodePty: {
+          spawn: () => ({
+            pid: 42,
+            onData: () => ({ dispose: () => undefined }),
+            onExit: (listener) => {
+              exitListener = listener;
+              return { dispose: () => undefined };
+            },
+            write: () => undefined,
+            resize: () => undefined,
+            pause: () => undefined,
+            resume: () => undefined,
+          }),
+        },
+      });
+      await Effect.runPromise(
+        port.start(
+          { shell: "cmd.exe", args: [], cwd: "C:\\repo", env: {}, grid: { columns: 80, rows: 24 } },
+          {
+            onOutput: () => undefined,
+            onFailure: (failure) => events.push(failure.message),
+            onExit: () => events.push("exit"),
+          },
+        ),
+      );
+      exitListener({ exitCode });
+      await Bun.sleep(0);
+      expect(events.at(-1)).toBe("exit");
+      if (exitCode === 0) expect(events).toEqual(["exit"]);
+      else {
+        expect(events).toHaveLength(2);
+        expect(events[0]).toContain(
+          "cmd.exe exited with code 1 before producing output in C:\\repo",
+        );
+        expect(events[0]).toContain("outside OpenDucktor");
+      }
+    },
+  );
   test("maps raw output, resize, pause, resume, input, exit, and cleanup", async () => {
     const calls: string[] = [];
     let dataListener: (data: string | Buffer) => void = () => undefined;
@@ -84,14 +161,13 @@ describe("createNodePtyPort", () => {
     expect(calls).toContain("terminate-tree:42");
   });
 
-  test("surfaces an invalid raw-output contract before terminating the PTY", async () => {
+  test("preserves Windows UTF-8 text output without terminating the PTY", async () => {
     let dataListener: (data: string | Buffer) => void = () => undefined;
     const calls: string[] = [];
     const port = createNodePtyPort({
       processTreeTerminator: (input) =>
         Effect.sync(() => {
           calls.push(`terminate-tree:${input.pid}`);
-          exitListener({ exitCode: 1, signal: 15 });
         }),
       nodePty: {
         spawn: () => ({
@@ -109,19 +185,23 @@ describe("createNodePtyPort", () => {
       },
     });
     const failures: string[] = [];
+    const output: Uint8Array[] = [];
     await Effect.runPromise(
       port.start(
         { shell: "/bin/zsh", args: [], cwd: "/repo", env: {}, grid: { columns: 80, rows: 24 } },
         {
-          onOutput: () => undefined,
+          onOutput: (data) => output.push(data),
           onFailure: (failure) => failures.push(failure.message),
           onExit: () => undefined,
         },
       ),
     );
-    dataListener("unexpected text");
-    expect(failures).toEqual(["node-pty emitted text despite raw-buffer mode."]);
+    dataListener("\u001b[32mPrêt 日本語 🦆\u001b[0m\r\nC:\\repo>");
+    expect(failures).toEqual([]);
+    expect(output).toEqual([
+      new TextEncoder().encode("\u001b[32mPrêt 日本語 🦆\u001b[0m\r\nC:\\repo>"),
+    ]);
     await Bun.sleep(0);
-    expect(calls).toEqual(["terminate-tree:42"]);
+    expect(calls).toEqual([]);
   });
 });

--- a/apps/electron/src/main/terminals/node-pty-adapter.test.ts
+++ b/apps/electron/src/main/terminals/node-pty-adapter.test.ts
@@ -36,10 +36,15 @@ describe("createNodePtyPort", () => {
     }
   });
 
-  test.each([0, 1])(
-    "reports a silent unsuccessful shell exit, but not a clean exit (%i)",
-    async (exitCode) => {
-      let exitListener: (event: { exitCode: number }) => void = () => undefined;
+  test.each([
+    { exitCode: 0, signal: 0, requestedClose: false, failed: false },
+    { exitCode: 1, signal: 0, requestedClose: false, failed: true },
+    { exitCode: 0, signal: 15, requestedClose: false, failed: true },
+    { exitCode: 0, signal: 15, requestedClose: true, failed: false },
+  ])(
+    "classifies silent exit $exitCode, signal $signal, requested close $requestedClose",
+    async ({ exitCode, signal, requestedClose, failed }) => {
+      let exitListener: (event: { exitCode: number; signal: number }) => void = () => undefined;
       const events: string[] = [];
       const port = createNodePtyPort({
         processTreeTerminator: () => Effect.void,
@@ -58,7 +63,7 @@ describe("createNodePtyPort", () => {
           }),
         },
       });
-      await Effect.runPromise(
+      const handle = await Effect.runPromise(
         port.start(
           { shell: "cmd.exe", args: [], cwd: "C:\\repo", env: {}, grid: { columns: 80, rows: 24 } },
           {
@@ -68,14 +73,15 @@ describe("createNodePtyPort", () => {
           },
         ),
       );
-      exitListener({ exitCode });
+      if (requestedClose) await Effect.runPromise(handle.terminate());
+      exitListener({ exitCode, signal });
       await Bun.sleep(0);
       expect(events.at(-1)).toBe("exit");
-      if (exitCode === 0) expect(events).toEqual(["exit"]);
+      if (!failed) expect(events).toEqual(["exit"]);
       else {
         expect(events).toHaveLength(2);
         expect(events[0]).toContain(
-          "cmd.exe exited with code 1 before producing output in C:\\repo",
+          `cmd.exe exited with code ${exitCode}${signal ? ` (signal ${signal})` : ""} before producing output in C:\\repo`,
         );
         expect(events[0]).toContain("outside OpenDucktor");
       }

--- a/apps/electron/src/main/terminals/node-pty-adapter.ts
+++ b/apps/electron/src/main/terminals/node-pty-adapter.ts
@@ -49,6 +49,7 @@ export const createNodePtyPort = ({
         let exitPublished = false;
         type NativeExit = { exitCode: number; signal: string | null };
         let nativeExit: NativeExit | null = null;
+        let receivedOutput = false;
         let cleanupPromise: Promise<void> | null = null;
         const pty = nodePty.spawn(plan.shell, [...plan.args], {
           cols: plan.grid.columns,
@@ -59,30 +60,24 @@ export const createNodePtyPort = ({
           rows: plan.grid.rows,
         });
         const dataSubscription = pty.onData((value) => {
-          if (!Buffer.isBuffer(value)) {
-            dataSubscription.dispose();
-            handlers.onFailure(
-              new TerminalPtyError({
-                code: "operation_failed",
-                operation: "start",
-                message: "node-pty emitted text despite raw-buffer mode.",
-              }),
-            );
-            Effect.runFork(
-              finalizeExit().pipe(
-                Effect.tapError((failure) => Effect.sync(() => handlers.onFailure(failure))),
-              ),
-            );
-            return;
-          }
-          handlers.onOutput(
-            new Uint8Array(value.buffer, value.byteOffset, value.byteLength).slice(),
-          );
+          // Windows node-pty decodes its ConPTY socket as UTF-8 even with encoding: null.
+          const data = Buffer.isBuffer(value) ? value : Buffer.from(value, "utf8");
+          receivedOutput ||= data.byteLength > 0;
+          handlers.onOutput(new Uint8Array(data.buffer, data.byteOffset, data.byteLength).slice());
         });
         const exitSubscription = pty.onExit(({ exitCode, signal }) => {
           if (closed) return;
           closed = true;
           nativeExit = { exitCode, signal: signal === undefined ? null : String(signal) };
+          if (!receivedOutput && exitCode !== 0 && !cleanupPromise) {
+            handlers.onFailure(
+              new TerminalPtyError({
+                code: "spawn_failed",
+                operation: "start",
+                message: `Terminal shell ${plan.shell} exited with code ${exitCode} before producing output in ${plan.cwd}. Check that the shell starts in this directory outside OpenDucktor.`,
+              }),
+            );
+          }
           for (const waiter of exitWaiters) waiter();
           Effect.runFork(
             finalizeExit().pipe(
@@ -178,7 +173,7 @@ export const createNodePtyPort = ({
         new TerminalPtyError({
           code: "spawn_failed",
           operation: "start",
-          message: `node-pty could not start ${plan.shell}.`,
+          message: `Could not start terminal shell ${plan.shell} in ${plan.cwd}: ${cause instanceof Error ? cause.message : String(cause)}. Check that the shell executable and working directory are accessible.`,
           cause,
         }),
     }),

--- a/apps/electron/src/main/terminals/node-pty-adapter.ts
+++ b/apps/electron/src/main/terminals/node-pty-adapter.ts
@@ -141,7 +141,10 @@ export const createNodePtyPort = ({
           handlers.onExit(nativeExit);
         };
         const finalizeExit = (): Effect.Effect<void, TerminalPtyError> =>
-          ensureProcessTreeTerminated().pipe(Effect.tap(() => Effect.sync(publishExit)));
+          // node-pty releases ConPTY before reporting a connection failure with no process ID.
+          closed && pty.pid === 0
+            ? Effect.sync(publishExit)
+            : ensureProcessTreeTerminated().pipe(Effect.tap(() => Effect.sync(publishExit)));
         const requireOpen = (name: TerminalPtyError["operation"], run: () => void) =>
           operation(name, () => {
             if (closed) throw new Error("The terminal is already closed.");

--- a/apps/electron/src/main/terminals/node-pty-adapter.ts
+++ b/apps/electron/src/main/terminals/node-pty-adapter.ts
@@ -69,12 +69,12 @@ export const createNodePtyPort = ({
           if (closed) return;
           closed = true;
           nativeExit = { exitCode, signal: signal === undefined ? null : String(signal) };
-          if (!receivedOutput && exitCode !== 0 && !cleanupPromise) {
+          if (!receivedOutput && (exitCode !== 0 || Boolean(signal)) && !cleanupPromise) {
             handlers.onFailure(
               new TerminalPtyError({
                 code: "spawn_failed",
                 operation: "start",
-                message: `Terminal shell ${plan.shell} exited with code ${exitCode} before producing output in ${plan.cwd}. Check that the shell starts in this directory outside OpenDucktor.`,
+                message: `Terminal shell ${plan.shell} exited with code ${exitCode}${signal ? ` (signal ${signal})` : ""} before producing output in ${plan.cwd}. Check that the shell starts in this directory outside OpenDucktor.`,
               }),
             );
           }

--- a/packages/frontend/src/features/terminals/terminal-panel.test.tsx
+++ b/packages/frontend/src/features/terminals/terminal-panel.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, spyOn, test } from "bun:test";
 import type { TerminalSummary } from "@openducktor/contracts";
 import {
   act,
@@ -9,6 +9,8 @@ import {
 } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { QueryProvider } from "@/lib/query-provider";
+import * as terminalMount from "./interactive-terminal-mount";
+import { createTerminalTransportController } from "./terminal-transport-controller";
 import { TerminalPanel } from "./terminal-panel";
 import type { TerminalPanelModel, TerminalTab } from "./use-terminals";
 
@@ -74,6 +76,64 @@ const model: TerminalPanelModel = {
 };
 
 describe("TerminalPanel", () => {
+  test("keeps the terminal failure visible after exit and reattachment", async () => {
+    const mounts: Parameters<typeof terminalMount.mountInteractiveTerminal>[0][] = [];
+    const mount = spyOn(terminalMount, "mountInteractiveTerminal").mockImplementation((input) => {
+      mounts.push(input);
+      return { activate: () => undefined, dispose: () => undefined };
+    });
+    const controller = createTerminalTransportController(
+      {
+        connect: async () => ({
+          send: async () => undefined,
+          close: () => undefined,
+        }),
+      },
+      () => undefined,
+    );
+    const summary: TerminalSummary = {
+      terminalId: "terminal-failed",
+      label: "Shell 1",
+      context: {},
+      initialWorkingDir: "C:\\repo",
+      createdAt: "2026-07-12T00:00:00.000Z",
+      lifecycle: "running",
+      exit: null,
+    };
+    let unmount: () => void = () => undefined;
+    try {
+      const view = render(
+        <TerminalPanel
+          model={{
+            ...model,
+            ...tabsModel([readyTab(summary)]),
+            activeTabId: "tab:terminal-failed",
+            controller,
+          }}
+        />,
+      );
+      unmount = view.unmount;
+      await waitFor(() => expect(mounts).toHaveLength(1));
+      const callbacks = mounts[0];
+      if (!callbacks) throw new Error("Terminal did not mount");
+      act(() => callbacks.onAttention("Shell access denied. Check the shell executable."));
+      act(() => callbacks.onLifecycle("exited", "Exited with code 1."));
+      expect(screen.getByRole("status", { name: "Terminal status" }).textContent).toContain(
+        "Shell access denied.",
+      );
+      expect(screen.getByRole("status", { name: "Terminal status" }).textContent).not.toBe(
+        "Exited with code 1.",
+      );
+      act(() => callbacks.onLifecycle("exited", null));
+      expect(screen.getByRole("status", { name: "Terminal status" }).textContent).toContain(
+        "Check the shell executable.",
+      );
+    } finally {
+      unmount();
+      mount.mockRestore();
+      await controller.dispose();
+    }
+  });
   test("shows an explicit lost-session state", () => {
     render(<TerminalPanel model={model} />);
     expect(screen.getByText("This terminal belonged to a previous host session.")).toBeTruthy();

--- a/packages/frontend/src/features/terminals/terminal-panel.test.tsx
+++ b/packages/frontend/src/features/terminals/terminal-panel.test.tsx
@@ -76,7 +76,14 @@ const model: TerminalPanelModel = {
 };
 
 describe("TerminalPanel", () => {
-  test("keeps the terminal failure visible after exit and reattachment", async () => {
+  test.each([
+    { notice: "exit code", attention: null, expected: "Exited with code 1." },
+    {
+      notice: "failure",
+      attention: "Shell access denied. Check the shell executable.",
+      expected: "Shell access denied. Check the shell executable.",
+    },
+  ])("keeps the $notice visible after exit and reattachment", async ({ attention, expected }) => {
     const mount = spyOn(terminalMount, "mountInteractiveTerminal").mockReturnValue({
       activate: () => undefined,
       dispose: () => undefined,
@@ -115,14 +122,14 @@ describe("TerminalPanel", () => {
       await waitFor(() => expect(mount).toHaveBeenCalledTimes(1));
       const callbacks = mount.mock.calls[0]?.[0];
       if (!callbacks) throw new Error("Terminal did not mount");
-      act(() => callbacks.onAttention("Shell access denied. Check the shell executable."));
+      if (attention) act(() => callbacks.onAttention(attention));
       act(() => callbacks.onLifecycle("exited", "Exited with code 1."));
       expect(screen.getByRole("status", { name: "Terminal status" }).textContent).toContain(
-        "Shell access denied.",
+        expected,
       );
       act(() => callbacks.onLifecycle("exited", null));
       expect(screen.getByRole("status", { name: "Terminal status" }).textContent).toContain(
-        "Check the shell executable.",
+        expected,
       );
     } finally {
       unmount();

--- a/packages/frontend/src/features/terminals/terminal-panel.test.tsx
+++ b/packages/frontend/src/features/terminals/terminal-panel.test.tsx
@@ -77,10 +77,9 @@ const model: TerminalPanelModel = {
 
 describe("TerminalPanel", () => {
   test("keeps the terminal failure visible after exit and reattachment", async () => {
-    const mounts: Parameters<typeof terminalMount.mountInteractiveTerminal>[0][] = [];
-    const mount = spyOn(terminalMount, "mountInteractiveTerminal").mockImplementation((input) => {
-      mounts.push(input);
-      return { activate: () => undefined, dispose: () => undefined };
+    const mount = spyOn(terminalMount, "mountInteractiveTerminal").mockReturnValue({
+      activate: () => undefined,
+      dispose: () => undefined,
     });
     const controller = createTerminalTransportController(
       {
@@ -113,16 +112,13 @@ describe("TerminalPanel", () => {
         />,
       );
       unmount = view.unmount;
-      await waitFor(() => expect(mounts).toHaveLength(1));
-      const callbacks = mounts[0];
+      await waitFor(() => expect(mount).toHaveBeenCalledTimes(1));
+      const callbacks = mount.mock.calls[0]?.[0];
       if (!callbacks) throw new Error("Terminal did not mount");
       act(() => callbacks.onAttention("Shell access denied. Check the shell executable."));
       act(() => callbacks.onLifecycle("exited", "Exited with code 1."));
       expect(screen.getByRole("status", { name: "Terminal status" }).textContent).toContain(
         "Shell access denied.",
-      );
-      expect(screen.getByRole("status", { name: "Terminal status" }).textContent).not.toBe(
-        "Exited with code 1.",
       );
       act(() => callbacks.onLifecycle("exited", null));
       expect(screen.getByRole("status", { name: "Terminal status" }).textContent).toContain(

--- a/packages/frontend/src/features/terminals/terminal-panel.test.tsx
+++ b/packages/frontend/src/features/terminals/terminal-panel.test.tsx
@@ -107,17 +107,14 @@ describe("TerminalPanel", () => {
       exit: null,
     };
     let unmount: () => void = () => undefined;
+    const panelModel: TerminalPanelModel = {
+      ...model,
+      ...tabsModel([readyTab(summary)]),
+      activeTabId: "tab:terminal-failed",
+      controller,
+    };
     try {
-      const view = render(
-        <TerminalPanel
-          model={{
-            ...model,
-            ...tabsModel([readyTab(summary)]),
-            activeTabId: "tab:terminal-failed",
-            controller,
-          }}
-        />,
-      );
+      const view = render(<TerminalPanel model={panelModel} />);
       unmount = view.unmount;
       await waitFor(() => expect(mount).toHaveBeenCalledTimes(1));
       const callbacks = mount.mock.calls[0]?.[0];
@@ -131,6 +128,23 @@ describe("TerminalPanel", () => {
       expect(screen.getByRole("status", { name: "Terminal status" }).textContent).toContain(
         expected,
       );
+      view.rerender(
+        <TerminalPanel
+          model={{ ...panelModel, scopeKey: "/repo:task-2", tabs: [], activeTabId: null }}
+        />,
+      );
+      expect(screen.queryByRole("status", { name: "Terminal status" })).toBeNull();
+      view.rerender(<TerminalPanel model={panelModel} />);
+      expect(screen.getByRole("status", { name: "Terminal status" }).textContent).toContain(
+        expected,
+      );
+      expect(mount).toHaveBeenCalledTimes(1);
+      view.rerender(
+        <TerminalPanel model={{ ...panelModel, ...tabsModel([]), activeTabId: null }} />,
+      );
+      view.rerender(<TerminalPanel model={panelModel} />);
+      await waitFor(() => expect(mount).toHaveBeenCalledTimes(2));
+      expect(screen.queryByRole("status", { name: "Terminal status" })).toBeNull();
     } finally {
       unmount();
       mount.mockRestore();

--- a/packages/frontend/src/features/terminals/terminal-panel.tsx
+++ b/packages/frontend/src/features/terminals/terminal-panel.tsx
@@ -210,7 +210,9 @@ export function TerminalPanel({
       exitText: string | null,
     ): void => {
       onLifecycle(scopeKey, terminalId, lifecycle);
-      setExitByTab((current) => ({ ...current, [tabId]: exitText }));
+      if (exitText !== null) {
+        setExitByTab((current) => ({ ...current, [tabId]: exitText }));
+      }
     },
     [onLifecycle],
   );

--- a/packages/frontend/src/features/terminals/terminal-panel.tsx
+++ b/packages/frontend/src/features/terminals/terminal-panel.tsx
@@ -41,7 +41,6 @@ const TerminalViewport = memo(function TerminalViewport({
   active,
   platform,
   onRetryCreate,
-  onAttention,
   onLifecycle,
   onForgotten,
   onTitleChange,
@@ -53,26 +52,19 @@ const TerminalViewport = memo(function TerminalViewport({
   active: boolean;
   platform: AppPlatform | undefined;
   onRetryCreate: TerminalPanelModel["onRetryCreate"];
-  onAttention: (tabId: string, message: string | null) => void;
-  onLifecycle: (
-    scopeKey: string,
-    tabId: string,
-    terminalId: string,
-    lifecycle: TerminalLifecycle,
-    exitText: string | null,
-  ) => void;
+  onLifecycle: TerminalPanelModel["onLifecycle"];
   onForgotten: (scopeKey: string, terminalId: string, message: string) => void;
   onTitleChange: (scopeKey: string, terminalId: string, title: string) => void;
 }): ReactElement {
-  const handleAttention = useCallback(
-    (message: string | null) => onAttention(tab.tabId, message),
-    [onAttention, tab.tabId],
-  );
+  const [attention, setAttention] = useState<string | null>(null);
+  const [exitText, setExitText] = useState<string | null>(null);
+  const notice = attention ?? exitText;
   const handleLifecycle = useCallback(
-    (lifecycle: TerminalLifecycle, exitText: string | null) => {
-      if (tab.terminalId) onLifecycle(scopeKey, tab.tabId, tab.terminalId, lifecycle, exitText);
+    (lifecycle: TerminalLifecycle, text: string | null) => {
+      if (tab.terminalId) onLifecycle(scopeKey, tab.terminalId, lifecycle);
+      if (text !== null) setExitText(text);
     },
-    [onLifecycle, scopeKey, tab.tabId, tab.terminalId],
+    [onLifecycle, scopeKey, tab.terminalId],
   );
   const handleForgotten = useCallback(
     (message: string) => {
@@ -119,43 +111,92 @@ const TerminalViewport = memo(function TerminalViewport({
     );
   }
   return (
-    <Suspense
-      fallback={
-        <div
-          data-testid="terminal-loading-surface"
-          className="h-full min-h-0 bg-[var(--dev-server-terminal-panel)]"
-        />
-      }
-    >
-      <LazyInteractiveTerminal
-        terminalId={tab.terminalId}
-        controller={controller}
-        platform={platform}
-        active={active}
-        focusRequest={focusRequest}
-        onAttention={handleAttention}
-        onLifecycle={handleLifecycle}
-        onForgotten={handleForgotten}
-        onTitleChange={handleTitleChange}
-      />
-    </Suspense>
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="min-h-0 flex-1">
+        <Suspense
+          fallback={
+            <div
+              data-testid="terminal-loading-surface"
+              className="h-full min-h-0 bg-[var(--dev-server-terminal-panel)]"
+            />
+          }
+        >
+          <LazyInteractiveTerminal
+            terminalId={tab.terminalId}
+            controller={controller}
+            platform={platform}
+            active={active}
+            focusRequest={focusRequest}
+            onAttention={setAttention}
+            onLifecycle={handleLifecycle}
+            onForgotten={handleForgotten}
+            onTitleChange={handleTitleChange}
+          />
+        </Suspense>
+      </div>
+      {notice ? (
+        <p
+          role="status"
+          aria-label="Terminal status"
+          className="shrink-0 border-t border-border bg-warning-surface px-3 py-1.5 text-xs text-warning-surface-foreground"
+        >
+          {notice}
+        </p>
+      ) : null}
+    </div>
   );
 });
 
-export function TerminalPanel({
+function MountedTerminals({
   model,
-  headerLeading,
+  onRetryCreate,
 }: {
   model: TerminalPanelModel;
-  headerLeading?: ReactNode;
+  onRetryCreate: TerminalPanelModel["onRetryCreate"];
 }): ReactElement {
-  const { onLifecycle } = model;
+  const activeTab = model.tabs.find((tab) => tab.tabId === model.activeTabId);
+  return (
+    <div className="relative min-h-0 flex-1 overflow-hidden">
+      {model.mountedTabs.map((mountedTab) => {
+        const active =
+          model.isVisible &&
+          mountedTab.scopeKey === model.scopeKey &&
+          mountedTab.tab.tabId === activeTab?.tabId;
+        return (
+          <TabsContent
+            key={`${mountedTab.scopeKey}:${mountedTab.tab.tabId}`}
+            forceMount
+            value={mountedTab.tab.tabId}
+            data-terminal-viewport
+            data-viewport-state={active ? "active" : "inactive"}
+            aria-hidden={!active}
+            inert={!active}
+            className="h-full min-h-0 data-[viewport-state=inactive]:pointer-events-none data-[viewport-state=inactive]:absolute data-[viewport-state=inactive]:top-0 data-[viewport-state=inactive]:left-[calc(100%+1px)] data-[viewport-state=inactive]:w-full"
+          >
+            <TerminalViewport
+              scopeKey={mountedTab.scopeKey}
+              tab={mountedTab.tab}
+              controller={model.controller}
+              focusRequest={active ? model.focusRequest : 0}
+              active={active}
+              platform={model.platform}
+              onRetryCreate={onRetryCreate}
+              onLifecycle={model.onLifecycle}
+              onForgotten={model.onForgotten}
+              onTitleChange={model.onTitleChange}
+            />
+          </TabsContent>
+        );
+      })}
+    </div>
+  );
+}
+
+function useTerminalClose(model: TerminalPanelModel) {
   const [pendingCloseCandidate, setPendingCloseCandidate] = useState<{
     scopeKey: string | null;
     tab: TerminalTab;
   } | null>(null);
-  const [attentionByTab, setAttentionByTab] = useState<Record<string, string | null>>({});
-  const [exitByTab, setExitByTab] = useState<Record<string, string | null>>({});
   const [pendingCloseError, setPendingCloseError] = useState<{
     scopeKey: string | null;
     message: string;
@@ -163,16 +204,11 @@ export function TerminalPanel({
   const [confirmingScopeKey, setConfirmingScopeKey] = useState<string | null | undefined>(
     undefined,
   );
+
   const currentScopeKey = useRef(model.scopeKey);
-  const retryCreateRef = useRef(model.onRetryCreate);
   useLayoutEffect(() => {
     currentScopeKey.current = model.scopeKey;
-    retryCreateRef.current = model.onRetryCreate;
-  }, [model.onRetryCreate, model.scopeKey]);
-  const retryTerminalCreation = useCallback((ownerScopeKey: string, tabId: string): void => {
-    if (ownerScopeKey !== currentScopeKey.current) return;
-    retryCreateRef.current(ownerScopeKey, tabId);
-  }, []);
+  }, [model.scopeKey]);
   const closeCandidate =
     pendingCloseCandidate?.scopeKey === model.scopeKey ? pendingCloseCandidate.tab : null;
   const closeError =
@@ -182,40 +218,6 @@ export function TerminalPanel({
     confirmingScopeKey !== undefined &&
     confirmingScopeKey === pendingCloseCandidate?.scopeKey;
 
-  useEffect(() => {
-    if (!model.platformError) return;
-    const toastId = "terminal:platform";
-    toast.error("Terminal shortcuts unavailable", {
-      id: toastId,
-      description: model.platformError,
-    });
-    return () => {
-      toast.dismiss(toastId);
-    };
-  }, [model.platformError]);
-  const activeTab = model.tabs.find((tab) => tab.tabId === model.activeTabId) ?? null;
-  const hasCurrentScopeMountedTabs = model.mountedTabs.some(
-    (mountedTab) => mountedTab.scopeKey === model.scopeKey,
-  );
-  const showsEmptyTerminalState = model.tabs.length === 0 && !hasCurrentScopeMountedTabs;
-  const setTabAttention = useCallback((tabId: string, message: string | null): void => {
-    setAttentionByTab((current) => ({ ...current, [tabId]: message }));
-  }, []);
-  const setTerminalLifecycle = useCallback(
-    (
-      scopeKey: string,
-      tabId: string,
-      terminalId: string,
-      lifecycle: TerminalLifecycle,
-      exitText: string | null,
-    ): void => {
-      onLifecycle(scopeKey, terminalId, lifecycle);
-      if (exitText !== null) {
-        setExitByTab((current) => ({ ...current, [tabId]: exitText }));
-      }
-    },
-    [onLifecycle],
-  );
   const closeTab = async (tab: TerminalTab): Promise<void> => {
     const scopeKey = model.scopeKey;
     try {
@@ -254,6 +256,57 @@ export function TerminalPanel({
       setConfirmingScopeKey((current) => (current === candidate.scopeKey ? undefined : current));
     }
   };
+
+  return {
+    closeCandidate,
+    closeError,
+    isConfirmingClose,
+    closeTab,
+    confirmClose,
+    setPendingCloseCandidate,
+  };
+}
+
+export function TerminalPanel({
+  model,
+  headerLeading,
+}: {
+  model: TerminalPanelModel;
+  headerLeading?: ReactNode;
+}): ReactElement {
+  const {
+    closeCandidate,
+    closeError,
+    isConfirmingClose,
+    closeTab,
+    confirmClose,
+    setPendingCloseCandidate,
+  } = useTerminalClose(model);
+  const currentScopeKey = useRef(model.scopeKey);
+  const retryCreateRef = useRef(model.onRetryCreate);
+  useLayoutEffect(() => {
+    currentScopeKey.current = model.scopeKey;
+    retryCreateRef.current = model.onRetryCreate;
+  }, [model.onRetryCreate, model.scopeKey]);
+  const retryTerminalCreation = useCallback((ownerScopeKey: string, tabId: string): void => {
+    if (ownerScopeKey !== currentScopeKey.current) return;
+    retryCreateRef.current(ownerScopeKey, tabId);
+  }, []);
+  useEffect(() => {
+    if (!model.platformError) return;
+    const toastId = "terminal:platform";
+    toast.error("Terminal shortcuts unavailable", {
+      id: toastId,
+      description: model.platformError,
+    });
+    return () => {
+      toast.dismiss(toastId);
+    };
+  }, [model.platformError]);
+  const hasCurrentScopeMountedTabs = model.mountedTabs.some(
+    (mountedTab) => mountedTab.scopeKey === model.scopeKey,
+  );
+  const showsEmptyTerminalState = model.tabs.length === 0 && !hasCurrentScopeMountedTabs;
   return (
     <Tabs
       {...(model.activeTabId ? { value: model.activeTabId } : {})}
@@ -296,49 +349,7 @@ export function TerminalPanel({
       </div>
       {model.mountedTabs.length > 0 ? (
         <div className="flex min-h-0 flex-1 flex-col">
-          <div className="relative min-h-0 flex-1 overflow-hidden">
-            {model.mountedTabs.map((mountedTab) => {
-              const active =
-                model.isVisible &&
-                mountedTab.scopeKey === model.scopeKey &&
-                mountedTab.tab.tabId === activeTab?.tabId;
-              return (
-                <TabsContent
-                  key={`${mountedTab.scopeKey}:${mountedTab.tab.tabId}`}
-                  forceMount
-                  value={mountedTab.tab.tabId}
-                  data-terminal-viewport
-                  data-viewport-state={active ? "active" : "inactive"}
-                  aria-hidden={!active}
-                  inert={!active}
-                  className="h-full min-h-0 data-[viewport-state=inactive]:pointer-events-none data-[viewport-state=inactive]:absolute data-[viewport-state=inactive]:top-0 data-[viewport-state=inactive]:left-[calc(100%+1px)] data-[viewport-state=inactive]:w-full"
-                >
-                  <TerminalViewport
-                    scopeKey={mountedTab.scopeKey}
-                    tab={mountedTab.tab}
-                    controller={model.controller}
-                    focusRequest={active ? model.focusRequest : 0}
-                    active={active}
-                    platform={model.platform}
-                    onRetryCreate={retryTerminalCreation}
-                    onAttention={setTabAttention}
-                    onLifecycle={setTerminalLifecycle}
-                    onForgotten={model.onForgotten}
-                    onTitleChange={model.onTitleChange}
-                  />
-                </TabsContent>
-              );
-            })}
-          </div>
-          {activeTab && (attentionByTab[activeTab.tabId] || exitByTab[activeTab.tabId]) ? (
-            <p
-              role="status"
-              aria-label="Terminal status"
-              className="border-t border-border bg-warning-surface px-3 py-1.5 text-xs text-warning-surface-foreground"
-            >
-              {attentionByTab[activeTab.tabId] ?? exitByTab[activeTab.tabId]}
-            </p>
-          ) : null}
+          <MountedTerminals model={model} onRetryCreate={retryTerminalCreation} />
           {closeError ? (
             <p className="border-t border-border px-3 py-1.5 text-xs text-destructive">
               Close failed: {closeError}

--- a/packages/frontend/src/features/terminals/terminal-panel.tsx
+++ b/packages/frontend/src/features/terminals/terminal-panel.tsx
@@ -155,6 +155,7 @@ export function TerminalPanel({
     tab: TerminalTab;
   } | null>(null);
   const [attentionByTab, setAttentionByTab] = useState<Record<string, string | null>>({});
+  const [exitByTab, setExitByTab] = useState<Record<string, string | null>>({});
   const [pendingCloseError, setPendingCloseError] = useState<{
     scopeKey: string | null;
     message: string;
@@ -209,9 +210,9 @@ export function TerminalPanel({
       exitText: string | null,
     ): void => {
       onLifecycle(scopeKey, terminalId, lifecycle);
-      if (exitText) setTabAttention(tabId, exitText);
+      setExitByTab((current) => ({ ...current, [tabId]: exitText }));
     },
-    [onLifecycle, setTabAttention],
+    [onLifecycle],
   );
   const closeTab = async (tab: TerminalTab): Promise<void> => {
     const scopeKey = model.scopeKey;
@@ -327,9 +328,13 @@ export function TerminalPanel({
               );
             })}
           </div>
-          {activeTab && attentionByTab[activeTab.tabId] ? (
-            <p className="border-t border-border bg-warning-surface px-3 py-1.5 text-xs text-warning-surface-foreground">
-              {attentionByTab[activeTab.tabId]}
+          {activeTab && (attentionByTab[activeTab.tabId] || exitByTab[activeTab.tabId]) ? (
+            <p
+              role="status"
+              aria-label="Terminal status"
+              className="border-t border-border bg-warning-surface px-3 py-1.5 text-xs text-warning-surface-foreground"
+            >
+              {attentionByTab[activeTab.tabId] ?? exitByTab[activeTab.tabId]}
             </p>
           ) : null}
           {closeError ? (

--- a/packages/host/src/application/terminals/terminal-service.test.ts
+++ b/packages/host/src/application/terminals/terminal-service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { posix } from "node:path";
+import type { TerminalServerMessage } from "@openducktor/contracts";
 import { Effect } from "effect";
 import { createTerminalLaunchEnvironment } from "../../infrastructure/terminals/terminal-launch-environment";
 import type { FilesystemPort } from "../../ports/filesystem-port";
@@ -69,6 +70,7 @@ const makePty = (supportsOutputPause = true, hasChildProcesses = true) => {
     operations,
     emit: (data: Uint8Array) => handlers?.onOutput(data),
     exit: (exitCode: number | null = 0) => handlers?.onExit({ exitCode, signal: null }),
+    fail: (failure: TerminalPtyError) => handlers?.onFailure(failure),
     failTerminate: () => {
       terminateFails = true;
     },
@@ -121,6 +123,45 @@ const makeService = async (
 };
 
 describe("TerminalService", () => {
+  test("retains PTY failure details for live attachments and attachments after exit", async () => {
+    const { service, pty } = await makeService();
+    await Effect.runPromise(service.create({ workingDir: "/repo", context: {} }));
+    const live: TerminalServerMessage[] = [];
+    const attach = (attachmentId: string, events: TerminalServerMessage[]) =>
+      Effect.runPromise(
+        service.attach({
+          terminalId: "terminal-1",
+          attachmentId,
+          lastConsumedSequence: 0,
+          sink: (event) => events.push(event),
+        }),
+      );
+    await attach("live", live);
+    pty.fail(
+      new TerminalPtyError({
+        code: "spawn_failed",
+        operation: "start",
+        message: "Shell access denied.",
+      }),
+    );
+    pty.exit(1);
+    const late: TerminalServerMessage[] = [];
+    await attach("late", late);
+    const failures = (events: TerminalServerMessage[]) =>
+      events.filter((event) => event.type === "protocol_error");
+    expect(failures(live)).toEqual([
+      expect.objectContaining({
+        failure: expect.objectContaining({
+          code: "spawn_failed",
+          terminalId: "terminal-1",
+          workingDir: "/canonical/repo",
+          message: expect.stringContaining("Shell access denied."),
+        }),
+      }),
+    ]);
+    expect(failures(late)).toEqual(failures(live));
+    expect(late[0]).toMatchObject({ type: "snapshot", lifecycle: "exited" });
+  });
   beforeEach(() => {
     directoryAvailable = true;
   });

--- a/packages/host/src/application/terminals/terminal-session-engine.ts
+++ b/packages/host/src/application/terminals/terminal-session-engine.ts
@@ -110,7 +110,18 @@ export const createTerminalSessionEngine = ({
               session.resources.consumeOutput(data);
               applyStreamEvents(session, session.output.accept(data, session.resources.handle));
             },
-            onFailure: () => handleFailure(session),
+            onFailure: (failure) => {
+              applyStreamEvents(
+                session,
+                session.output.publishFailure({
+                  code: failure.code === "operation_failed" ? "protocol_error" : failure.code,
+                  message: `${failure.message} Close this tab and create a new terminal after resolving the error.`,
+                  terminalId: summary.terminalId,
+                  workingDir: plan.cwd,
+                }),
+              );
+              handleFailure(session);
+            },
             onExit: ({ exitCode, signal }) => handleExit(session, exitCode, signal),
           }),
         );

--- a/packages/host/src/application/terminals/terminal-session-output.test.ts
+++ b/packages/host/src/application/terminals/terminal-session-output.test.ts
@@ -26,6 +26,71 @@ const pausableHandle: TerminalPtyHandle = {
 };
 
 describe("TerminalSessionOutput", () => {
+  test("publishes and replays the latest failure", () => {
+    const output = new TerminalSessionOutput("terminal-1", TERMINAL_LIMITS.replayBytes);
+    const frames: TerminalServerMessage[] = [];
+    const input = {
+      terminalId: "terminal-1",
+      attachmentId: "client",
+      lastConsumedSequence: 0,
+      sink: (frame: TerminalServerMessage) => frames.push(frame),
+    };
+    output.attach(input, summary, null);
+    output.publishFailure({ code: "spawn_failed", message: "Shell failed." });
+    const failure = { code: "protocol_error" as const, message: "Process cleanup failed." };
+    output.publishFailure(failure);
+    expect(frames.at(-1)).toMatchObject({ type: "protocol_error", failure });
+    frames.length = 0;
+    output.attach(input, summary, null);
+    expect(frames.at(-1)).toMatchObject({ type: "protocol_error", failure });
+  });
+
+  test("continues bounded exited replay on ACK before publishing exit and failure", async () => {
+    const output = new TerminalSessionOutput("terminal-1", TERMINAL_LIMITS.replayBytes);
+    const bytes = new Uint8Array(TERMINAL_LIMITS.pendingOutputBytes * 2 + 1);
+    output.accept(bytes, null);
+    output.publishFailure({ code: "spawn_failed", message: "Shell failed." });
+    const frames: TerminalServerMessage[] = [];
+    let delivered = 0;
+    output.attach(
+      {
+        terminalId: "terminal-1",
+        attachmentId: "client",
+        lastConsumedSequence: 0,
+        sink: (frame) => {
+          frames.push(frame);
+          if (frame.type === "output") delivered = frame.sequenceEnd;
+        },
+      },
+      {
+        ...summary,
+        lifecycle: "exited",
+        exit: {
+          exitCode: 1,
+          signal: null,
+          finalSequence: bytes.length,
+          exitedAt: "2026-07-17T00:00:01.000Z",
+        },
+      },
+      null,
+    );
+    for (let batch = 1; batch <= 2; batch += 1) {
+      expect(delivered).toBe(TERMINAL_LIMITS.pendingOutputBytes * batch);
+      expect(
+        frames.some((frame) => frame.type === "lifecycle" || frame.type === "protocol_error"),
+      ).toBe(false);
+      output.acknowledge("client", delivered);
+      expect(await Effect.runPromise(output.resumeIfUnblocked(null))).toEqual([]);
+    }
+    expect(delivered).toBe(bytes.length);
+    expect(frames.slice(-2).map((frame) => frame.type)).toEqual(["lifecycle", "protocol_error"]);
+    expect(frames.at(-2)).toMatchObject({ finalSequence: bytes.length, exitCode: 1 });
+    const count = frames.length;
+    output.acknowledge("client", delivered);
+    await Effect.runPromise(output.resumeIfUnblocked(null));
+    expect(frames).toHaveLength(count);
+  });
+
   test("replays final output and exit details before the retained failure", () => {
     const output = new TerminalSessionOutput("terminal-1", TERMINAL_LIMITS.replayBytes);
     output.accept(new TextEncoder().encode("done"), null);

--- a/packages/host/src/application/terminals/terminal-session-output.test.ts
+++ b/packages/host/src/application/terminals/terminal-session-output.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { TerminalSummary } from "@openducktor/contracts";
+import type { TerminalServerMessage, TerminalSummary } from "@openducktor/contracts";
 import { Effect } from "effect";
 import type { TerminalPtyHandle } from "../../ports/terminal-pty-port";
 import { TERMINAL_LIMITS } from "./terminal-limits";
@@ -26,6 +26,94 @@ const pausableHandle: TerminalPtyHandle = {
 };
 
 describe("TerminalSessionOutput", () => {
+  test("replays final output and exit details before the retained failure", () => {
+    const output = new TerminalSessionOutput("terminal-1", TERMINAL_LIMITS.replayBytes);
+    output.accept(new TextEncoder().encode("done"), null);
+    output.publishFailure({ code: "spawn_failed", message: "Shell failed." });
+    const frames: TerminalServerMessage[] = [];
+    output.attach(
+      {
+        terminalId: "terminal-1",
+        attachmentId: "late",
+        lastConsumedSequence: 0,
+        sink: (frame) => frames.push(frame),
+      },
+      {
+        ...summary,
+        lifecycle: "exited",
+        exit: {
+          exitCode: 1,
+          signal: null,
+          finalSequence: 4,
+          exitedAt: "2026-07-17T00:00:01.000Z",
+        },
+      },
+      null,
+    );
+    expect(frames.map((frame) => frame.type)).toEqual([
+      "snapshot",
+      "output",
+      "lifecycle",
+      "protocol_error",
+    ]);
+    expect(frames[2]).toMatchObject({
+      lifecycle: "exited",
+      exitCode: 1,
+      signal: null,
+      finalSequence: 4,
+    });
+  });
+
+  test.each(["output", "lifecycle", "protocol_error"])(
+    "removes a sink that fails during %s replay without restoring its old attachment",
+    (failedType) => {
+      const output = new TerminalSessionOutput("terminal-1", TERMINAL_LIMITS.replayBytes);
+      let oldCalls = 0;
+      output.attach(
+        {
+          terminalId: "terminal-1",
+          attachmentId: "client",
+          lastConsumedSequence: 0,
+          sink: () => {
+            oldCalls += 1;
+          },
+        },
+        summary,
+        null,
+      );
+      output.accept(new TextEncoder().encode("done"), null);
+      output.publishFailure({ code: "spawn_failed", message: "Shell failed." });
+      const callsBeforeReplacement = oldCalls;
+      const delivered: string[] = [];
+      const events = output.attach(
+        {
+          terminalId: "terminal-1",
+          attachmentId: "client",
+          lastConsumedSequence: 0,
+          sink: (frame) => {
+            delivered.push(frame.type);
+            if (frame.type === failedType) throw new Error("Disconnected");
+          },
+        },
+        {
+          ...summary,
+          lifecycle: "exited",
+          exit: {
+            exitCode: 1,
+            signal: null,
+            finalSequence: 4,
+            exitedAt: "2026-07-17T00:00:01.000Z",
+          },
+        },
+        null,
+      );
+      expect(events).toEqual([{ type: "attachments_empty" }]);
+      expect(delivered.at(-1)).toBe(failedType);
+      expect(() => output.acknowledge("client", 4)).toThrow("Terminal attachment not found");
+      output.publishFailure({ code: "spawn_failed", message: "Still failed." });
+      expect(oldCalls).toBe(callsBeforeReplacement);
+    },
+  );
   test("requests output pause when replay attachment reaches its pending byte bound", () => {
     const output = new TerminalSessionOutput("terminal-1", TERMINAL_LIMITS.replayBytes);
     output.accept(new Uint8Array(TERMINAL_LIMITS.pendingOutputBytes + 1), pausableHandle);

--- a/packages/host/src/application/terminals/terminal-session-output.ts
+++ b/packages/host/src/application/terminals/terminal-session-output.ts
@@ -119,8 +119,24 @@ export class TerminalSessionOutput {
         title: summary.label,
         complete: requested >= this.earliestRetainedSequence,
       });
-      const events = this.flush(attachment, true, handle);
-      if (this.failureFrame) this.publishTo(attachment, this.failureFrame);
+      let events = this.flush(attachment, true, handle);
+      if (!this.attachments.has(input.attachmentId)) return events;
+      if (summary.exit) {
+        const published = this.tryPublish(attachment, {
+          version: TERMINAL_PROTOCOL_VERSION,
+          type: "lifecycle",
+          terminalId: this.terminalId,
+          lifecycle: summary.lifecycle,
+          exitCode: summary.exit.exitCode,
+          signal: summary.exit.signal,
+          finalSequence: summary.exit.finalSequence,
+        });
+        events = mergeEvents(events, published.events);
+        if (!published.delivered) return events;
+      }
+      if (this.failureFrame) {
+        events = mergeEvents(events, this.tryPublish(attachment, this.failureFrame).events);
+      }
       return events;
     } catch (cause) {
       if (previous) this.attachments.set(input.attachmentId, previous);

--- a/packages/host/src/application/terminals/terminal-session-output.ts
+++ b/packages/host/src/application/terminals/terminal-session-output.ts
@@ -72,7 +72,7 @@ export class TerminalSessionOutput {
   private readonly attachments = new Map<string, TerminalAttachment>();
   private paused = false;
   private overflowed = false;
-  private failure: TerminalFailure | null = null;
+  private failureFrame: Extract<TerminalServerMessage, { type: "protocol_error" }> | null = null;
 
   constructor(
     private readonly terminalId: string,
@@ -120,14 +120,7 @@ export class TerminalSessionOutput {
         complete: requested >= this.earliestRetainedSequence,
       });
       const events = this.flush(attachment, true, handle);
-      if (this.failure) {
-        this.publishTo(attachment, {
-          version: TERMINAL_PROTOCOL_VERSION,
-          type: "protocol_error",
-          terminalId: this.terminalId,
-          failure: this.failure,
-        });
-      }
+      if (this.failureFrame) this.publishTo(attachment, this.failureFrame);
       return events;
     } catch (cause) {
       if (previous) this.attachments.set(input.attachmentId, previous);
@@ -146,13 +139,13 @@ export class TerminalSessionOutput {
   }
 
   publishFailure(failure: TerminalFailure): TerminalOutputEvents {
-    this.failure ??= failure;
-    return this.publish({
+    this.failureFrame ??= {
       version: TERMINAL_PROTOCOL_VERSION,
       type: "protocol_error",
       terminalId: this.terminalId,
-      failure: this.failure,
-    });
+      failure,
+    };
+    return this.publish(this.failureFrame);
   }
 
   accept(data: Uint8Array, handle: TerminalPtyHandle | null): TerminalOutputEvents {

--- a/packages/host/src/application/terminals/terminal-session-output.ts
+++ b/packages/host/src/application/terminals/terminal-session-output.ts
@@ -1,5 +1,6 @@
 import {
   TERMINAL_PROTOCOL_VERSION,
+  type TerminalFailure,
   type TerminalServerMessage,
   type TerminalSummary,
 } from "@openducktor/contracts";
@@ -71,6 +72,7 @@ export class TerminalSessionOutput {
   private readonly attachments = new Map<string, TerminalAttachment>();
   private paused = false;
   private overflowed = false;
+  private failure: TerminalFailure | null = null;
 
   constructor(
     private readonly terminalId: string,
@@ -117,7 +119,16 @@ export class TerminalSessionOutput {
         title: summary.label,
         complete: requested >= this.earliestRetainedSequence,
       });
-      return this.flush(attachment, true, handle);
+      const events = this.flush(attachment, true, handle);
+      if (this.failure) {
+        this.publishTo(attachment, {
+          version: TERMINAL_PROTOCOL_VERSION,
+          type: "protocol_error",
+          terminalId: this.terminalId,
+          failure: this.failure,
+        });
+      }
+      return events;
     } catch (cause) {
       if (previous) this.attachments.set(input.attachmentId, previous);
       else this.attachments.delete(input.attachmentId);
@@ -132,6 +143,16 @@ export class TerminalSessionOutput {
       events = mergeEvents(events, this.tryPublish(attachment, message).events);
     }
     return events;
+  }
+
+  publishFailure(failure: TerminalFailure): TerminalOutputEvents {
+    this.failure ??= failure;
+    return this.publish({
+      version: TERMINAL_PROTOCOL_VERSION,
+      type: "protocol_error",
+      terminalId: this.terminalId,
+      failure: this.failure,
+    });
   }
 
   accept(data: Uint8Array, handle: TerminalPtyHandle | null): TerminalOutputEvents {

--- a/packages/host/src/application/terminals/terminal-session-output.ts
+++ b/packages/host/src/application/terminals/terminal-session-output.ts
@@ -23,6 +23,7 @@ type TerminalAttachment = {
   acknowledgedSequence: number;
   deliveredSequence: number;
   pendingBytes: number;
+  replaySummary: TerminalSummary | null;
 };
 
 export type TerminalSessionAttachInput = {
@@ -105,6 +106,7 @@ export class TerminalSessionOutput {
       acknowledgedSequence: requested,
       deliveredSequence: requested,
       pendingBytes: 0,
+      replaySummary: summary,
     };
     const previous = this.attachments.get(input.attachmentId);
     this.attachments.set(input.attachmentId, attachment);
@@ -119,25 +121,7 @@ export class TerminalSessionOutput {
         title: summary.label,
         complete: requested >= this.earliestRetainedSequence,
       });
-      let events = this.flush(attachment, true, handle);
-      if (!this.attachments.has(input.attachmentId)) return events;
-      if (summary.exit) {
-        const published = this.tryPublish(attachment, {
-          version: TERMINAL_PROTOCOL_VERSION,
-          type: "lifecycle",
-          terminalId: this.terminalId,
-          lifecycle: summary.lifecycle,
-          exitCode: summary.exit.exitCode,
-          signal: summary.exit.signal,
-          finalSequence: summary.exit.finalSequence,
-        });
-        events = mergeEvents(events, published.events);
-        if (!published.delivered) return events;
-      }
-      if (this.failureFrame) {
-        events = mergeEvents(events, this.tryPublish(attachment, this.failureFrame).events);
-      }
-      return events;
+      return this.flush(attachment, true, handle);
     } catch (cause) {
       if (previous) this.attachments.set(input.attachmentId, previous);
       else this.attachments.delete(input.attachmentId);
@@ -155,7 +139,7 @@ export class TerminalSessionOutput {
   }
 
   publishFailure(failure: TerminalFailure): TerminalOutputEvents {
-    this.failureFrame ??= {
+    this.failureFrame = {
       version: TERMINAL_PROTOCOL_VERSION,
       type: "protocol_error",
       terminalId: this.terminalId,
@@ -209,22 +193,26 @@ export class TerminalSessionOutput {
   resumeIfUnblocked(
     handle: TerminalPtyHandle | null,
   ): Effect.Effect<TerminalOutputEvents, TerminalPtyError> {
-    if (
-      !this.paused ||
-      ![...this.attachments.values()].every(
-        (candidate) => candidate.pendingBytes <= TERMINAL_LIMITS.resumeOutputBytes,
-      )
-    ) {
-      return Effect.succeed([]);
-    }
-    if (!handle) return Effect.succeed([]);
     return Effect.gen(this, function* () {
-      yield* handle.resumeOutput();
-      this.paused = false;
+      if (this.paused) {
+        if (
+          ![...this.attachments.values()].every(
+            (candidate) => candidate.pendingBytes <= TERMINAL_LIMITS.resumeOutputBytes,
+          )
+        )
+          return [];
+        if (handle) yield* handle.resumeOutput();
+        this.paused = false;
+      }
       let events: TerminalOutputEvents = [];
       // oxlint-disable-next-line unicorn/no-useless-spread -- flushing can change attachments
       for (const attachment of [...this.attachments.values()]) {
-        events = mergeEvents(events, this.flush(attachment, false, handle));
+        if (attachment.deliveredSequence < this.sequence || attachment.replaySummary) {
+          events = mergeEvents(
+            events,
+            this.flush(attachment, attachment.replaySummary !== null, handle),
+          );
+        }
       }
       return events;
     });
@@ -346,7 +334,26 @@ export class TerminalSessionOutput {
     for (const chunk of this.replay) {
       const delivered = this.deliver(attachment, chunk, replay, handle);
       events = mergeEvents(events, delivered.events);
-      if (!delivered.delivered) break;
+      if (!delivered.delivered) return events;
+    }
+    const summary = attachment.replaySummary;
+    if (!summary) return events;
+    attachment.replaySummary = null;
+    if (summary.exit) {
+      const published = this.tryPublish(attachment, {
+        version: TERMINAL_PROTOCOL_VERSION,
+        type: "lifecycle",
+        terminalId: this.terminalId,
+        lifecycle: summary.lifecycle,
+        exitCode: summary.exit.exitCode,
+        signal: summary.exit.signal,
+        finalSequence: summary.exit.finalSequence,
+      });
+      events = mergeEvents(events, published.events);
+      if (!published.delivered) return events;
+    }
+    if (this.failureFrame) {
+      events = mergeEvents(events, this.tryPublish(attachment, this.failureFrame).events);
     }
     return events;
   }


### PR DESCRIPTION
Windows terminals closed immediately because the adapter rejected the UTF-8 text that node-pty emits on Windows. The host then discarded the error details and showed only an exit code.

Accept Windows text output and preserve terminal bytes. Include the shell, working directory, and recovery instructions in startup errors. Detect silent failures with a nonzero exit code or a signal. Complete failed startup cleanup when node-pty exits before it acquires a process ID.

Publish and replay the latest failure. Continue bounded replay on ACK after exit, then send structured exit details and the retained failure. Remove failed sinks through the existing stream error path. Keep notices in each mounted terminal view so task switches preserve them and closed views release them. Separate mounted views and close confirmation logic to pass React Doctor without rule changes.

Validation: A native Windows interactive shell check and 42 terminal regression tests passed. Formatting, lint, type checking, and build passed. All 4,613 frontend tests passed on the final local run. The local full-suite command still has 15 Windows symlink permission failures and one failure because Node 22.12 cannot load node:sqlite. React Doctor, Knip, and the full Linux, macOS, and Windows workspace checks pass in CI on 86c15a2d3 with Node 24.