### PR TITLE
fix(agent-studio): edit tasks without leaving Agent Studio

### DIFF
--- a/packages/frontend/src/components/features/task-create/use-task-create-modal-controller.test.tsx
+++ b/packages/frontend/src/components/features/task-create/use-task-create-modal-controller.test.tsx
@@ -1,7 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { act, render } from "@testing-library/react";
 import type { ReactElement, ReactNode } from "react";
 import { QueryProvider } from "@/lib/query-provider";
+import {
+  type AgentStudioTaskDetailsLauncherModel,
+  useAgentStudioTaskDetailsLauncher,
+} from "@/pages/agents/shell/use-agent-studio-task-details-launcher";
 import {
   SpecStateContext,
   TasksStateContext,
@@ -191,4 +195,110 @@ describe("useTaskCreateModalController", () => {
     expect(updateCalls).toEqual([]);
     harness.unmount();
   });
+});
+
+describe("Agent Studio task editor save ownership", () => {
+  test.each(["another workspace", "the same task after returning"])(
+    "keeps the replacement draft in %s when an old save completes",
+    async (replacement) => {
+      const taskA = createTaskCardFixture({ id: "task-a", title: "Task A" });
+      const taskB = createTaskCardFixture({ id: "task-b", title: "Task B" });
+      const workspaceA = workspaceState.activeWorkspace;
+      const workspaceB = { ...workspaceA, workspaceId: "workspace-2", repoPath: "/other" };
+      let resolveSave = (): void => {};
+      const pendingSave = new Promise<void>((resolve) => {
+        resolveSave = resolve;
+      });
+      const updateTask = mock(async () => {
+        await pendingSave;
+      });
+      let launcher: AgentStudioTaskDetailsLauncherModel;
+      let controller: Controller;
+      let submission: Promise<void> | undefined;
+      const getLauncher = () => launcher;
+      const getController = () => controller;
+      type ProbeProps = {
+        workspace: typeof workspaceA;
+        task: typeof taskA;
+      };
+
+      const EditorProbe = ({
+        editor,
+      }: {
+        editor: NonNullable<AgentStudioTaskDetailsLauncherModel["taskEditor"]>;
+      }): null => {
+        controller = useTaskCreateModalController({ ...editor, task: editor.task ?? null });
+        return null;
+      };
+      const LauncherProbe = ({ workspace, task }: ProbeProps): ReactElement | null => {
+        launcher = useAgentStudioTaskDetailsLauncher({
+          activeWorkspace: workspace,
+          tasks: [task],
+          selectedTaskId: task.id,
+          detectingPullRequestTaskId: null,
+          unlinkingPullRequestTaskId: null,
+          onDetectPullRequest: () => {},
+          onUnlinkPullRequest: () => {},
+        });
+        return launcher.taskEditor ? <EditorProbe editor={launcher.taskEditor} /> : null;
+      };
+      const tree = (workspace: typeof workspaceA, task: typeof taskA): ReactElement => (
+        <QueryProvider useIsolatedClient>
+          <WorkspaceStateContext.Provider value={{ ...workspaceState, activeWorkspace: workspace }}>
+            <TasksStateContext.Provider value={{ ...createTasksState(updateTask), tasks: [task] }}>
+              <SpecStateContext.Provider value={specState}>
+                <LauncherProbe workspace={workspace} task={task} />
+              </SpecStateContext.Provider>
+            </TasksStateContext.Provider>
+          </WorkspaceStateContext.Provider>
+        </QueryProvider>
+      );
+      const view = render(tree(workspaceA, taskA));
+      try {
+        act(() => getLauncher().taskDetailsSheetProps.onEdit?.(taskA.id));
+        act(() => getController().updateState({ title: "Saved A" }));
+        act(() => {
+          submission = getController().submit();
+        });
+        expect(getController().isSubmitting).toBe(true);
+        expect(updateTask).toHaveBeenCalledWith(
+          taskA.id,
+          expect.objectContaining({ title: "Saved A" }),
+          undefined,
+        );
+
+        view.rerender(tree(workspaceB, taskB));
+        expect(getLauncher().taskEditor).toBeNull();
+        const nextTask = replacement === "another workspace" ? taskB : taskA;
+        if (replacement !== "another workspace") {
+          view.rerender(tree(workspaceA, taskA));
+        }
+        act(() => getLauncher().taskDetailsSheetProps.onEdit?.(nextTask.id));
+        act(() => getController().updateState({ title: "Unsaved replacement" }));
+        await act(async () => {
+          resolveSave();
+          await submission;
+        });
+        expect(getLauncher().taskEditor?.task?.id).toBe(nextTask.id);
+        expect(getController().state.title).toBe("Unsaved replacement");
+        expect(getController().isSubmitting).toBe(false);
+
+        await act(async () => {
+          await getController().submit();
+        });
+        expect(updateTask).toHaveBeenLastCalledWith(
+          nextTask.id,
+          expect.objectContaining({ title: "Unsaved replacement" }),
+          undefined,
+        );
+        expect(getLauncher().taskEditor).toBeNull();
+      } finally {
+        await act(async () => {
+          resolveSave();
+          await submission;
+        });
+        view.unmount();
+      }
+    },
+  );
 });

--- a/packages/frontend/src/pages/agents/shell/agents-page-modal-content.tsx
+++ b/packages/frontend/src/pages/agents/shell/agents-page-modal-content.tsx
@@ -1,6 +1,7 @@
 import type { ComponentProps, ReactElement } from "react";
 import { SessionStartModal } from "@/components/features/agents/session-start-modal";
 import { MergedPullRequestConfirmDialog } from "@/components/features/pull-requests/merged-pull-request-confirm-dialog";
+import { TaskCreateModal } from "@/components/features/task-create/task-create-modal";
 import { TaskDetailsSheetController } from "@/components/features/task-details/task-details-sheet-controller";
 import { HumanReviewFeedbackModal } from "@/features/human-review-feedback/human-review-feedback-modal";
 import type { AgentStudioPullRequestModalModel } from "./use-agent-studio-pull-request-modal-model";
@@ -32,6 +33,9 @@ export function AgentsPageModalContent({ model }: AgentsPageModalContentProps): 
       ) : null}
       <HumanReviewFeedbackModal model={humanReviewFeedbackModal} />
       {sessionStartModal ? <SessionStartModal model={sessionStartModal} /> : null}
+      {taskDetailsLauncher.taskEditor ? (
+        <TaskCreateModal {...taskDetailsLauncher.taskEditor} />
+      ) : null}
       <TaskDetailsSheetController
         ref={taskDetailsLauncher.taskDetailsSheetRef}
         {...taskDetailsLauncher.taskDetailsSheetProps}

--- a/packages/frontend/src/pages/agents/shell/use-agent-studio-task-details-launcher.test.tsx
+++ b/packages/frontend/src/pages/agents/shell/use-agent-studio-task-details-launcher.test.tsx
@@ -115,4 +115,66 @@ describe("useAgentStudioTaskDetailsLauncher", () => {
       await harness.unmount();
     }
   });
+  test("edits the sheet task and closes the sheet without changing the selected task", async () => {
+    const otherTask = createTaskCardFixture({ id: "task-2", title: "Task 2" });
+    const args = createArgs({ tasks: [task, otherTask] });
+    const harness = createHookHarness(args);
+    try {
+      await harness.mount();
+      const handle = attachControllerHandle(harness.getLatest());
+      expect(harness.getLatest().taskEditor).toBeNull();
+      await harness.run((model) => model.taskDetailsSheetProps.onEdit?.("task-2"));
+      expect(handle.close).toHaveBeenCalledTimes(1);
+      expect(harness.getLatest().taskEditor?.task).toBe(otherTask);
+      expect(harness.getLatest().taskEditor?.open).toBe(true);
+      expect(harness.getLatest().taskEditor?.tasks).toBe(args.tasks);
+      expect(harness.getLatest().taskDetailsSheetProps.workflowActionsEnabled).toBe(false);
+
+      const updatedTask = { ...otherTask, title: "Updated task" };
+      await harness.update({ ...args, tasks: [task, updatedTask], selectedTaskId: null });
+      expect(harness.getLatest().taskEditor?.task).toBe(updatedTask);
+      await harness.run((model) => model.taskEditor?.onOpenChange(false));
+      expect(harness.getLatest().taskEditor).toBeNull();
+      await harness.run((model) => model.taskDetailsSheetProps.onEdit?.("task-1"));
+      expect(harness.getLatest().taskEditor?.task).toBe(task);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("clears the editor when its workspace changes", async () => {
+    const args = createArgs();
+    const harness = createHookHarness(args);
+    try {
+      await harness.mount();
+      await harness.run((model) => model.taskDetailsSheetProps.onEdit?.("task-1"));
+      await harness.update({
+        ...args,
+        activeWorkspace: { ...activeWorkspace, workspaceId: "other" },
+      });
+      expect(harness.getLatest().taskEditor).toBeNull();
+      await harness.update(args);
+      expect(harness.getLatest().taskEditor).toBeNull();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("does not open a create form for a removed task or absent workspace", async () => {
+    const args = createArgs();
+    const harness = createHookHarness(args);
+    try {
+      await harness.mount();
+      await harness.run((model) => model.taskDetailsSheetProps.onEdit?.("task-1"));
+      await harness.update({ ...args, tasks: [] });
+      expect(harness.getLatest().taskEditor).toBeNull();
+      await harness.update(args);
+      expect(harness.getLatest().taskEditor).toBeNull();
+      await harness.update({ ...args, activeWorkspace: null });
+      await harness.run((model) => model.taskDetailsSheetProps.onEdit?.("task-1"));
+      expect(harness.getLatest().taskEditor).toBeNull();
+    } finally {
+      await harness.unmount();
+    }
+  });
 });

--- a/packages/frontend/src/pages/agents/shell/use-agent-studio-task-details-launcher.ts
+++ b/packages/frontend/src/pages/agents/shell/use-agent-studio-task-details-launcher.ts
@@ -1,9 +1,10 @@
 import type { AgentSessionRecord, RepositoryGitProviderContext } from "@openducktor/contracts";
-import { type ComponentProps, type RefObject, useCallback, useMemo, useRef } from "react";
+import { type ComponentProps, type RefObject, useCallback, useMemo, useRef, useState } from "react";
 import type {
   ActiveTaskSessionContextByTaskId,
   KanbanTaskSession,
 } from "@/components/features/kanban/kanban-task-activity";
+import type { TaskCreateModal } from "@/components/features/task-create/task-create-modal";
 import type {
   TaskDetailsSheetController,
   TaskDetailsSheetControllerHandle,
@@ -28,6 +29,7 @@ export type AgentStudioTaskDetailsSheetProps = Omit<
 >;
 
 export type AgentStudioTaskDetailsLauncherModel = {
+  taskEditor: ComponentProps<typeof TaskCreateModal> | null;
   openTaskDetails: () => void;
   taskDetailsSheetRef: RefObject<TaskDetailsSheetControllerHandle | null>;
   taskDetailsSheetProps: AgentStudioTaskDetailsSheetProps;
@@ -49,6 +51,43 @@ export function useAgentStudioTaskDetailsLauncher({
   gitProviderReadError = null,
 }: UseAgentStudioTaskDetailsLauncherArgs): AgentStudioTaskDetailsLauncherModel {
   const taskDetailsSheetRef = useRef<TaskDetailsSheetControllerHandle | null>(null);
+  const [editTarget, setEditTarget] = useState<{ workspaceId: string; taskId: string } | null>(
+    null,
+  );
+  const workspaceId = activeWorkspace?.workspaceId;
+  const editingTask =
+    editTarget?.workspaceId === workspaceId
+      ? tasks.find((task) => task.id === editTarget?.taskId)
+      : undefined;
+
+  if (editTarget && !editingTask) {
+    setEditTarget(null);
+  }
+
+  const onEdit = useCallback(
+    (taskId: string): void => {
+      if (!workspaceId || !tasks.some((task) => task.id === taskId)) {
+        return;
+      }
+      taskDetailsSheetRef.current?.close();
+      setEditTarget({ workspaceId, taskId });
+    },
+    [tasks, workspaceId],
+  );
+
+  const onEditorOpenChange = useCallback((open: boolean): void => {
+    if (!open) {
+      setEditTarget(null);
+    }
+  }, []);
+
+  const taskEditor = useMemo<AgentStudioTaskDetailsLauncherModel["taskEditor"]>(
+    () =>
+      editingTask
+        ? { open: true, task: editingTask, tasks, onOpenChange: onEditorOpenChange }
+        : null,
+    [editingTask, onEditorOpenChange, tasks],
+  );
 
   const openTaskDetails = useCallback((): void => {
     if (!selectedTaskId) {
@@ -65,6 +104,7 @@ export function useAgentStudioTaskDetailsLauncher({
       historicalSessionsByTaskId: EMPTY_HISTORICAL_SESSIONS_BY_TASK_ID,
       activeTaskSessionContextByTaskId: EMPTY_ACTIVE_TASK_SESSION_CONTEXT_BY_TASK_ID,
       workflowActionsEnabled: false,
+      onEdit,
       onDetectPullRequest,
       gitProviderContext,
       gitProviderReadError,
@@ -78,6 +118,7 @@ export function useAgentStudioTaskDetailsLauncher({
       gitProviderContext,
       gitProviderReadError,
       onDetectPullRequest,
+      onEdit,
       onUnlinkPullRequest,
       tasks,
       unlinkingPullRequestTaskId,
@@ -87,9 +128,10 @@ export function useAgentStudioTaskDetailsLauncher({
   return useMemo(
     () => ({
       openTaskDetails,
+      taskEditor,
       taskDetailsSheetRef,
       taskDetailsSheetProps,
     }),
-    [openTaskDetails, taskDetailsSheetProps],
+    [openTaskDetails, taskDetailsSheetProps, taskEditor],
   );
 }

--- a/packages/frontend/src/pages/agents/shell/use-agent-studio-task-details-launcher.ts
+++ b/packages/frontend/src/pages/agents/shell/use-agent-studio-task-details-launcher.ts
@@ -75,11 +75,14 @@ export function useAgentStudioTaskDetailsLauncher({
     [tasks, workspaceId],
   );
 
-  const onEditorOpenChange = useCallback((open: boolean): void => {
-    if (!open) {
-      setEditTarget(null);
-    }
-  }, []);
+  const onEditorOpenChange = useCallback(
+    (open: boolean): void => {
+      if (!open) {
+        setEditTarget((current) => (current === editTarget ? null : current));
+      }
+    },
+    [editTarget],
+  );
 
   const taskEditor = useMemo<AgentStudioTaskDetailsLauncherModel["taskEditor"]>(
     () =>


### PR DESCRIPTION
Agent Studio task details has no Edit action, so users must return to Kanban to change task fields.

Add Edit to open the existing task editor directly from the sheet. The editor follows current task data and keeps each open instance separate, so a delayed save from a previous editor cannot close a newer editor or discard its draft.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added task editing through a dedicated editor modal in Agent Studio.
  - Users can open a task from the details view, edit it, and save changes.
  - The details view closes automatically when editing begins.

- **Bug Fixes**
  - Prevented earlier, pending saves from overwriting newer task drafts.
  - Improved handling when the selected workspace or task changes, preventing invalid editors from opening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->