### PR TITLE
refactor(host): remove unused tool discovery options

### DIFF
--- a/packages/host/src/adapters/system/tool-discovery-descriptors.ts
+++ b/packages/host/src/adapters/system/tool-discovery-descriptors.ts
@@ -1,6 +1,6 @@
 import { posix, win32 } from "node:path";
 import { normalizeUserPathInput, resolveNormalizedUserPath } from "@openducktor/path-support";
-import type { ToolDiscoveryId, ToolDiscoverySourceCategory } from "../../ports/tool-discovery-port";
+import type { ToolDiscoveryId } from "../../ports/tool-discovery-port";
 
 export type ToolDiscoveryPathOptions = {
   applicationsDir?: string;
@@ -21,22 +21,14 @@ export type ToolDiscoveryContext = {
 export type ToolDiscoverySource =
   | {
       directories: (context: ToolDiscoveryContext) => (string | undefined)[];
-      displayLabel?: string;
       kind: "searchDirectories";
-      label?: string;
-      requiredMissingMessage?: (input: {
-        descriptor: ToolDiscoveryDescriptor;
-        directories: readonly string[];
-      }) => string;
-      sourceCategory?: ToolDiscoverySourceCategory;
+      label: string;
       policy: "candidate" | "required";
     }
   | {
       candidates: (context: ToolDiscoveryContext) => string[];
-      displayLabel?: string;
       kind: "candidateFiles";
       label: string;
-      sourceCategory?: ToolDiscoverySourceCategory;
     };
 
 export type ToolDiscoveryDescriptor = {

--- a/packages/host/src/adapters/system/tool-discovery.test.ts
+++ b/packages/host/src/adapters/system/tool-discovery.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -145,55 +145,89 @@ describe("discoverToolPath", () => {
   test("uses descriptor bundled and standard sources before PATH", async () => {
     await withTempDir(async (root) => {
       const bundledDir = join(root, "bundled");
-      await mkdir(bundledDir);
-      const bundled = join(bundledDir, "opencode");
-      await writeExecutable(bundled);
-
-      const bundledOptions = {
-        bundledToolBinDirs: { opencode: bundledDir },
-        homeDir: root,
-        platform: "linux" as const,
-      };
-      await expect(
-        discoverBuiltInTool({
-          options: bundledOptions,
-          systemCommands: createSystemCommandRunner({
-            env: { PATH: "" },
-            platform: "linux",
-          }),
-          toolId: "opencode",
-        }),
-      ).resolves.toBe(bundled);
-
-      await rm(bundledDir, { force: true, recursive: true });
       const standardDir = join(root, ".opencode", "bin");
-      await mkdir(standardDir, { recursive: true });
-      const standard = join(standardDir, "opencode");
-      await writeExecutable(standard);
-      const standardOptions = {
-        homeDir: root,
-        platform: "linux" as const,
-      };
+      const pathDir = join(root, "path");
+      for (const directory of [bundledDir, standardDir, pathDir]) {
+        await mkdir(directory, { recursive: true });
+        await writeExecutable(join(directory, "opencode"));
+      }
+      const env = { PATH: pathDir };
+      const systemCommands = createSystemCommandRunner({ env, platform: "linux" });
+      const resolve = spyOn(systemCommands, "resolveCommandPath");
+      const options = { homeDir: root, platform: "linux" as const };
 
       await expect(
-        discoverBuiltInTool({
-          options: standardOptions,
-          systemCommands: createSystemCommandRunner({
-            env: { PATH: "" },
-            platform: "linux",
-          }),
+        discoverBuiltInToolResult({
+          env,
+          options: { ...options, bundledToolBinDirs: { opencode: bundledDir } },
+          systemCommands,
           toolId: "opencode",
         }),
-      ).resolves.toBe(standard);
+      ).resolves.toEqual({
+        displayLabel: "bundled tool directory",
+        path: join(bundledDir, "opencode"),
+        sourceCategory: "system_path",
+      });
+      expect(resolve.mock.calls).toEqual([["opencode", { env, searchPath: [bundledDir] }]]);
+      resolve.mockClear();
+
+      await expect(
+        discoverBuiltInToolResult({ env, options, systemCommands, toolId: "opencode" }),
+      ).resolves.toEqual({
+        displayLabel: "standard install directories",
+        path: join(standardDir, "opencode"),
+        sourceCategory: "system_path",
+      });
+      expect(resolve.mock.calls).toEqual([["opencode", { env, searchPath: [standardDir] }]]);
+      resolve.mockClear();
 
       await rm(standardDir, { force: true, recursive: true });
       await expect(
-        discoverBuiltInTool({
-          options: standardOptions,
-          systemCommands: createSystemCommands({ available: ["opencode"] }),
-          toolId: "opencode",
-        }),
-      ).resolves.toBe("/path/opencode");
+        discoverBuiltInTool({ env, options, systemCommands, toolId: "opencode" }),
+      ).resolves.toBe(join(pathDir, "opencode"));
+      expect(resolve.mock.calls).toEqual([
+        ["opencode", { env, searchPath: [standardDir] }],
+        ["opencode", { env }],
+      ]);
+    });
+  });
+
+  test("uses macOS application candidates in order before PATH", async () => {
+    await withTempDir(async (root) => {
+      const applicationsDir = join(root, "Applications");
+      const homeDir = join(root, "home");
+      const appResources = ["Codex.app", "Contents", "Resources"];
+      const systemAppDir = join(applicationsDir, ...appResources);
+      const userAppDir = join(homeDir, "Applications", ...appResources);
+      for (const directory of [systemAppDir, userAppDir]) {
+        await mkdir(directory, { recursive: true });
+        await writeExecutable(join(directory, "codex"));
+      }
+      const systemCommands = createSystemCommands({ available: ["codex"] });
+      const resolve = spyOn(systemCommands, "resolveCommandPath");
+      const options = { applicationsDir, homeDir, platform: "darwin" as const };
+
+      for (const directory of [systemAppDir, userAppDir]) {
+        const executable = join(directory, "codex");
+        await expect(
+          discoverBuiltInToolResult({ options, systemCommands, toolId: "codex" }),
+        ).resolves.toEqual({
+          displayLabel: "standard install locations",
+          path: executable,
+          sourceCategory: "system_path",
+        });
+        expect(resolve).not.toHaveBeenCalled();
+        await rm(executable);
+      }
+
+      await expect(
+        discoverBuiltInToolResult({ options, systemCommands, toolId: "codex" }),
+      ).resolves.toEqual({
+        displayLabel: "System PATH",
+        path: "/path/codex",
+        sourceCategory: "system_path",
+      });
+      expect(resolve.mock.calls).toEqual([["codex", { env: {} }]]);
     });
   });
 
@@ -277,22 +311,29 @@ describe("discoverToolPath", () => {
   });
 
   test("fails at a required bundled source before PATH", async () => {
+    const systemCommands = createSystemCommands({ available: ["opencode"] });
+    const resolve = spyOn(systemCommands, "resolveCommandPath");
     const adapter = createToolDiscoveryAdapter({
       env: {},
       options: {
         bundledToolBinDirs: { opencode: "/opt/OpenDucktor/bin" },
         platform: "linux",
       },
-      systemCommands: createSystemCommands({ available: ["opencode"] }),
+      systemCommands,
     });
     const exit = await Effect.runPromiseExit(adapter.resolveToolPath("opencode"));
 
+    expect(resolve.mock.calls).toEqual([
+      ["opencode", { env: {}, searchPath: ["/opt/OpenDucktor/bin"] }],
+    ]);
     expect(Exit.isFailure(exit)).toBe(true);
     if (Exit.isFailure(exit)) {
       const failures = Array.from(Cause.failures(exit.cause));
       expect(failures).toEqual([
         expect.objectContaining({
           _tag: "HostDependencyError",
+          dependency: "opencode",
+          operation: "toolDiscovery.discoverTool",
           details: {
             directories: ["/opt/OpenDucktor/bin"],
             requiredSource: true,

--- a/packages/host/src/adapters/system/tool-discovery.ts
+++ b/packages/host/src/adapters/system/tool-discovery.ts
@@ -21,7 +21,6 @@ import {
   type ToolDiscoveryContext,
   type ToolDiscoveryDescriptor,
   type ToolDiscoveryPathOptions,
-  type ToolDiscoverySource,
 } from "./tool-discovery-descriptors";
 
 export type { ToolDiscoveryPathOptions } from "./tool-discovery-descriptors";
@@ -179,15 +178,12 @@ const missingToolError = (descriptor: ToolDiscoveryDescriptor, checked: readonly
 const missingRequiredSourceError = (
   descriptor: ToolDiscoveryDescriptor,
   checked: readonly string[],
-  source: Extract<ToolDiscoverySource, { kind: "searchDirectories" }>,
   directories: readonly string[],
 ) =>
   new HostDependencyError<ToolDiscoveryDetails>({
     dependency: descriptor.command,
     operation: "toolDiscovery.discoverTool",
-    message:
-      source.requiredMissingMessage?.({ descriptor, directories }) ??
-      `${descriptor.command} not found. Checked ${checked.join(", ")}. ${descriptor.installHint}`,
+    message: `${descriptor.command} not found. Checked ${checked.join(", ")}. ${descriptor.installHint}`,
     details: { directories, requiredSource: true },
   });
 
@@ -247,9 +243,9 @@ const discoverDescriptorToolPath = ({
           for (const candidate of candidates) {
             if (yield* isExecutableCommandFile(candidate, context.platform)) {
               return {
-                displayLabel: source.displayLabel ?? source.label,
+                displayLabel: source.label,
                 path: candidate,
-                sourceCategory: source.sourceCategory ?? "system_path",
+                sourceCategory: "system_path",
               } satisfies ResolvedTool;
             }
           }
@@ -264,9 +260,7 @@ const discoverDescriptorToolPath = ({
           if (directories.length === 0) {
             break;
           }
-          checked.push(
-            `${source.label ?? "search directories"} (${describeLocations(directories)})`,
-          );
+          checked.push(`${source.label} (${describeLocations(directories)})`);
           const resolved = yield* resolveDirectoryCommand(
             descriptor.command,
             directories,
@@ -275,15 +269,13 @@ const discoverDescriptorToolPath = ({
           );
           if (resolved !== null) {
             return {
-              displayLabel: source.displayLabel ?? source.label ?? "Search directory",
+              displayLabel: source.label,
               path: resolved,
-              sourceCategory: source.sourceCategory ?? "system_path",
+              sourceCategory: "system_path",
             } satisfies ResolvedTool;
           }
           if (source.policy === "required") {
-            return yield* Effect.fail(
-              missingRequiredSourceError(descriptor, checked, source, directories),
-            );
+            return yield* Effect.fail(missingRequiredSourceError(descriptor, checked, directories));
           }
           break;
         }


### PR DESCRIPTION
Tool discovery exposed label, category, and missing-source message overrides that no configured source used. These options added branches to an internal adapter without supporting any current configuration.

Remove the unused overrides and require a label for each directory source so contributors can follow one label and error rule. Preserve discovery order, provenance, required-source failures, path options, and the public port. Extend the existing tests with exact bundled, standard, and macOS result assertions and probe-order checks.
