### PR TITLE
fix(electron): enable notifications in local macOS builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,8 @@ Useful alternative:
 
 - Browser mode if you want agents to access it with tools like `agent-browser`: `bun run browser:dev`.
 
+Use `bun run electron:package` to build a local desktop installer. Local macOS packages use an ad-hoc signature, as the development launcher does, so macOS can identify the app for notifications. These local packages do not use a Developer ID certificate or notarization.
+
 ## Local Tooling Reference
 
 Core tooling:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,6 @@ Useful alternative:
 
 - Browser mode if you want agents to access it with tools like `agent-browser`: `bun run browser:dev`.
 
-Use `bun run electron:package` to build a local desktop installer. Local macOS packages use an ad-hoc signature, as the development launcher does, so macOS can identify the app for notifications. These local packages do not use a Developer ID certificate or notarization.
-
 ## Local Tooling Reference
 
 Core tooling:

--- a/apps/electron/scripts/package-build.test.ts
+++ b/apps/electron/scripts/package-build.test.ts
@@ -118,10 +118,10 @@ describe("build Electron release artifact", () => {
     ]);
   });
 
-  it("builds local unsigned macOS packages without update metadata", () => {
+  it.each(["arm64", "x64"] as const)("ad-hoc signs local macOS %s packages", (arch) => {
     expect(
       resolveElectronBuilderArgs({
-        arch: "x64",
+        arch,
         platform: "macos",
         signed: false,
         stageReleaseArtifacts: false,
@@ -131,10 +131,12 @@ describe("build Electron release artifact", () => {
       "electron-builder.yml",
       "--mac",
       "dmg",
-      "--x64",
+      `--${arch}`,
       "--publish",
       "never",
       "-c.mac.notarize=false",
+      "-c.mac.identity=-",
+      "-c.mac.hardenedRuntime=false",
       "-c.dmg.writeUpdateInfo=false",
     ]);
 

--- a/apps/electron/scripts/package-build.ts
+++ b/apps/electron/scripts/package-build.ts
@@ -148,7 +148,8 @@ export const resolveElectronBuilderArgs = ({
   }
 
   if (!signed && platform === "macos") {
-    args.push("-c.mac.notarize=false");
+    // Match development signing so macOS can authorize native notifications.
+    args.push("-c.mac.notarize=false", "-c.mac.identity=-", "-c.mac.hardenedRuntime=false");
   }
 
   if (!signed && platform === "windows") {

--- a/bun.lock
+++ b/bun.lock
@@ -269,6 +269,12 @@
       },
     },
   },
+  "trustedDependencies": [
+    "electron-winstaller",
+    "node-pty",
+    "node-mac-permissions",
+    "esbuild",
+  ],
   "overrides": {
     "@hono/node-server": "^1.19.11",
     "express-rate-limit": "^8.2.2",

--- a/package.json
+++ b/package.json
@@ -68,5 +68,11 @@
   "engines": {
     "node": ">=22.6.0"
   },
-  "packageManager": "bun@1.3.14"
+  "packageManager": "bun@1.3.14",
+  "trustedDependencies": [
+    "electron-winstaller",
+    "esbuild",
+    "node-mac-permissions",
+    "node-pty"
+  ]
 }


### PR DESCRIPTION
Local macOS builds could fail to enable notifications because Bun skipped the native permission module build and packaged apps lacked a valid app signature.

Allow the required dependency installation scripts and apply the existing development ad-hoc signing policy to local macOS packages. This lets macOS identify the app when it requests notification permission. Developer ID signing and notarization for release builds keep their existing behavior.

Notification delivery was confirmed after enabling the app in macOS System Settings.
