### PR TITLE
fix(notifications): prevent false startup failure alerts

### DIFF
--- a/packages/frontend/src/components/features/settings/settings-notifications-section.test.tsx
+++ b/packages/frontend/src/components/features/settings/settings-notifications-section.test.tsx
@@ -38,6 +38,7 @@ const createNotificationContext = (
   taskStreamSink: {
     onChange: async () => {},
     onSnapshot: async () => {},
+    onSnapshotFailed: () => {},
     onFailure: () => {},
   },
   ...overrides,

--- a/packages/frontend/src/components/layout/app-shell.test.tsx
+++ b/packages/frontend/src/components/layout/app-shell.test.tsx
@@ -99,6 +99,7 @@ const notificationContextValue = {
   taskStreamSink: {
     onChange: async () => {},
     onSnapshot: async () => {},
+    onSnapshotFailed: () => {},
     onFailure: () => {},
   },
 } satisfies NotificationContextValue;

--- a/packages/frontend/src/features/notifications/notification-task-observer.ts
+++ b/packages/frontend/src/features/notifications/notification-task-observer.ts
@@ -100,7 +100,7 @@ export const createNotificationTaskObserver = ({
     } catch (cause) {
       if (isCancelledError(cause)) {
         if (
-          workspaces.get(workspace.repoPath) === workspace &&
+          isCurrentAttempt() &&
           entries.get(workspace.repoPath)?.label !== workspace.repositoryLabel
         ) {
           interruptedBaselines.add(workspace.repoPath);

--- a/packages/frontend/src/features/notifications/notification-task-observer.ts
+++ b/packages/frontend/src/features/notifications/notification-task-observer.ts
@@ -7,6 +7,7 @@ import type {
   TaskCard,
   TaskEventTaskSnapshot,
 } from "@openducktor/contracts";
+import { isCancelledError } from "@tanstack/react-query";
 import type { TaskStreamNotificationSink } from "@/state/tasks/task-stream-controller";
 import { createTaskOccurrenceProjector } from "./task-occurrence-projector";
 
@@ -45,6 +46,7 @@ export const createNotificationTaskObserver = ({
 }) => {
   const workspaces = new Map<string, NotificationWorkspace>();
   const entries = new Map<string, TaskObserverEntry>();
+  const interruptedBaselines = new Set<string>();
   const baselineLoads = new Map<
     string,
     { workspace: NotificationWorkspace; promise: Promise<void> }
@@ -77,7 +79,18 @@ export const createNotificationTaskObserver = ({
         projector,
         tasks: new Map(tasks.map((task) => [task.id, task])),
       });
+      interruptedBaselines.delete(workspace.repoPath);
     } catch (cause) {
+      if (isCancelledError(cause)) {
+        if (
+          workspaces.get(workspace.repoPath) === workspace &&
+          entries.get(workspace.repoPath)?.label !== workspace.repositoryLabel
+        ) {
+          interruptedBaselines.add(workspace.repoPath);
+        }
+        return;
+      }
+      interruptedBaselines.delete(workspace.repoPath);
       reportFailure(workspace.repoPath, cause);
     }
   };
@@ -143,6 +156,7 @@ export const createNotificationTaskObserver = ({
     hasBaseline: (repoPath: string): boolean =>
       entries.get(repoPath)?.label === workspaces.get(repoPath)?.repositoryLabel &&
       entries.has(repoPath),
+    isBaselineInterrupted: (repoPath: string): boolean => interruptedBaselines.has(repoPath),
     async syncWorkspaces(nextWorkspaces: readonly NotificationWorkspace[]): Promise<void> {
       const nextRepoPaths = new Set(nextWorkspaces.map((workspace) => workspace.repoPath));
       for (const repoPath of workspaces.keys()) {
@@ -150,6 +164,7 @@ export const createNotificationTaskObserver = ({
           workspaces.delete(repoPath);
           entries.delete(repoPath);
           baselineLoads.delete(repoPath);
+          interruptedBaselines.delete(repoPath);
         }
       }
       const baselines: Promise<void>[] = [];

--- a/packages/frontend/src/features/notifications/notification-task-observer.ts
+++ b/packages/frontend/src/features/notifications/notification-task-observer.ts
@@ -172,9 +172,18 @@ export const createNotificationTaskObserver = ({
     await Promise.all([...workspaces.values()].map(loadBaseline));
   };
 
+  const failInterruptedBaselines = (): void => {
+    const repoPaths = [...interruptedBaselines];
+    interruptedBaselines.clear();
+    for (const repoPath of repoPaths) {
+      notifyBaselineOutcome({ repoPath, status: "failed" });
+    }
+  };
+
   const sink: TaskStreamNotificationSink = {
     onChange: refreshForChange,
     onSnapshot: refreshAllBaselines,
+    onSnapshotFailed: failInterruptedBaselines,
     onFailure: (cause) => onFailure({ repoPath: "task-stream", source: "task", cause }),
   };
 

--- a/packages/frontend/src/features/notifications/notification-task-observer.ts
+++ b/packages/frontend/src/features/notifications/notification-task-observer.ts
@@ -53,6 +53,7 @@ export const createNotificationTaskObserver = ({
   const entries = new Map<string, TaskObserverEntry>();
   const interruptedBaselines = new Set<string>();
   const baselineOutcomeListeners = new Set<(outcome: BaselineOutcome) => void>();
+  const baselineAttempts = new Map<string, object>();
   const baselineLoads = new Map<
     string,
     { workspace: NotificationWorkspace; promise: Promise<void> }
@@ -67,13 +68,18 @@ export const createNotificationTaskObserver = ({
   };
 
   const loadBaseline = async (workspace: NotificationWorkspace): Promise<void> => {
+    const attempt = {};
+    baselineAttempts.set(workspace.repoPath, attempt);
+    const isCurrentAttempt = (): boolean =>
+      workspaces.get(workspace.repoPath) === workspace &&
+      baselineAttempts.get(workspace.repoPath) === attempt;
     try {
       const tasks = await loadTasks(workspace.repoPath);
       await loadSessionRecords(
         workspace.repoPath,
         tasks.map((task) => task.id),
       );
-      if (workspaces.get(workspace.repoPath) !== workspace) {
+      if (!isCurrentAttempt()) {
         return;
       }
       const previous = entries.get(workspace.repoPath);
@@ -101,13 +107,17 @@ export const createNotificationTaskObserver = ({
         }
         return;
       }
-      if (workspaces.get(workspace.repoPath) !== workspace) {
+      if (!isCurrentAttempt()) {
         return;
       }
       const recoveryFailed = interruptedBaselines.delete(workspace.repoPath);
       reportFailure(workspace.repoPath, cause);
       if (recoveryFailed) {
         notifyBaselineOutcome({ repoPath: workspace.repoPath, status: "failed" });
+      }
+    } finally {
+      if (baselineAttempts.get(workspace.repoPath) === attempt) {
+        baselineAttempts.delete(workspace.repoPath);
       }
     }
   };
@@ -184,6 +194,7 @@ export const createNotificationTaskObserver = ({
         if (!nextRepoPaths.has(repoPath)) {
           workspaces.delete(repoPath);
           entries.delete(repoPath);
+          baselineAttempts.delete(repoPath);
           baselineLoads.delete(repoPath);
           interruptedBaselines.delete(repoPath);
         }

--- a/packages/frontend/src/features/notifications/notification-task-observer.ts
+++ b/packages/frontend/src/features/notifications/notification-task-observer.ts
@@ -47,6 +47,7 @@ export const createNotificationTaskObserver = ({
   const workspaces = new Map<string, NotificationWorkspace>();
   const entries = new Map<string, TaskObserverEntry>();
   const interruptedBaselines = new Set<string>();
+  const baselineReadyListeners = new Set<(repoPath: string) => void>();
   const baselineLoads = new Map<
     string,
     { workspace: NotificationWorkspace; promise: Promise<void> }
@@ -80,6 +81,7 @@ export const createNotificationTaskObserver = ({
         tasks: new Map(tasks.map((task) => [task.id, task])),
       });
       interruptedBaselines.delete(workspace.repoPath);
+      for (const listener of baselineReadyListeners) listener(workspace.repoPath);
     } catch (cause) {
       if (isCancelledError(cause)) {
         if (
@@ -157,6 +159,10 @@ export const createNotificationTaskObserver = ({
       entries.get(repoPath)?.label === workspaces.get(repoPath)?.repositoryLabel &&
       entries.has(repoPath),
     isBaselineInterrupted: (repoPath: string): boolean => interruptedBaselines.has(repoPath),
+    subscribeBaselineReady(listener: (repoPath: string) => void): () => void {
+      baselineReadyListeners.add(listener);
+      return () => baselineReadyListeners.delete(listener);
+    },
     async syncWorkspaces(nextWorkspaces: readonly NotificationWorkspace[]): Promise<void> {
       const nextRepoPaths = new Set(nextWorkspaces.map((workspace) => workspace.repoPath));
       for (const repoPath of workspaces.keys()) {

--- a/packages/frontend/src/features/notifications/notification-task-observer.ts
+++ b/packages/frontend/src/features/notifications/notification-task-observer.ts
@@ -129,10 +129,17 @@ export const createNotificationTaskObserver = ({
     if (!workspace) {
       return;
     }
-    const entry = entries.get(event.repoPath);
+    let entry = entries.get(event.repoPath);
     if (!entry || entry.label !== workspace.repositoryLabel) {
-      await loadBaseline(workspace);
-      return;
+      const pending = baselineLoads.get(event.repoPath);
+      if (pending?.workspace !== workspace) {
+        await loadBaseline(workspace);
+        return;
+      }
+      await pending.promise;
+      if (workspaces.get(event.repoPath) !== workspace) return;
+      entry = entries.get(event.repoPath);
+      if (!entry || entry.label !== workspace.repositoryLabel) return;
     }
     if (!entry.tasks.has(event.taskId)) {
       entry.tasks.set(event.taskId, event.taskSnapshot);

--- a/packages/frontend/src/features/notifications/notification-task-observer.ts
+++ b/packages/frontend/src/features/notifications/notification-task-observer.ts
@@ -28,6 +28,11 @@ type TaskObserverEntry = {
   tasks: Map<string, TaskEventTaskSnapshot>;
 };
 
+type BaselineOutcome = {
+  repoPath: string;
+  status: "failed" | "ready";
+};
+
 export const createNotificationTaskObserver = ({
   loadTasks,
   loadSessionRecords,
@@ -47,7 +52,7 @@ export const createNotificationTaskObserver = ({
   const workspaces = new Map<string, NotificationWorkspace>();
   const entries = new Map<string, TaskObserverEntry>();
   const interruptedBaselines = new Set<string>();
-  const baselineReadyListeners = new Set<(repoPath: string) => void>();
+  const baselineOutcomeListeners = new Set<(outcome: BaselineOutcome) => void>();
   const baselineLoads = new Map<
     string,
     { workspace: NotificationWorkspace; promise: Promise<void> }
@@ -55,6 +60,10 @@ export const createNotificationTaskObserver = ({
 
   const reportFailure = (repoPath: string, cause: unknown): void => {
     onFailure({ repoPath, source: "task", cause });
+  };
+
+  const notifyBaselineOutcome = (outcome: BaselineOutcome): void => {
+    for (const listener of baselineOutcomeListeners) listener(outcome);
   };
 
   const loadBaseline = async (workspace: NotificationWorkspace): Promise<void> => {
@@ -81,7 +90,7 @@ export const createNotificationTaskObserver = ({
         tasks: new Map(tasks.map((task) => [task.id, task])),
       });
       interruptedBaselines.delete(workspace.repoPath);
-      for (const listener of baselineReadyListeners) listener(workspace.repoPath);
+      notifyBaselineOutcome({ repoPath: workspace.repoPath, status: "ready" });
     } catch (cause) {
       if (isCancelledError(cause)) {
         if (
@@ -92,8 +101,14 @@ export const createNotificationTaskObserver = ({
         }
         return;
       }
-      interruptedBaselines.delete(workspace.repoPath);
+      if (workspaces.get(workspace.repoPath) !== workspace) {
+        return;
+      }
+      const recoveryFailed = interruptedBaselines.delete(workspace.repoPath);
       reportFailure(workspace.repoPath, cause);
+      if (recoveryFailed) {
+        notifyBaselineOutcome({ repoPath: workspace.repoPath, status: "failed" });
+      }
     }
   };
 
@@ -159,9 +174,9 @@ export const createNotificationTaskObserver = ({
       entries.get(repoPath)?.label === workspaces.get(repoPath)?.repositoryLabel &&
       entries.has(repoPath),
     isBaselineInterrupted: (repoPath: string): boolean => interruptedBaselines.has(repoPath),
-    subscribeBaselineReady(listener: (repoPath: string) => void): () => void {
-      baselineReadyListeners.add(listener);
-      return () => baselineReadyListeners.delete(listener);
+    subscribeBaselineOutcome(listener: (outcome: BaselineOutcome) => void): () => void {
+      baselineOutcomeListeners.add(listener);
+      return () => baselineOutcomeListeners.delete(listener);
     },
     async syncWorkspaces(nextWorkspaces: readonly NotificationWorkspace[]): Promise<void> {
       const nextRepoPaths = new Set(nextWorkspaces.map((workspace) => workspace.repoPath));

--- a/packages/frontend/src/features/notifications/notification-workspace-observer.test.ts
+++ b/packages/frontend/src/features/notifications/notification-workspace-observer.test.ts
@@ -245,7 +245,7 @@ test.each(["tasks", "sessions"])(
   },
 );
 
-test("publishes a buffered request when the task stream recovers a cancelled startup baseline", async () => {
+test("publishes a buffered request after effect replay and cancelled startup recovery", async () => {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const firstReadStarted = createDeferred<void>();
   const firstRead = createDeferred<TaskCard[]>();
@@ -285,6 +285,9 @@ test("publishes a buffered request when the task stream recovers a cancelled sta
     publish: (occurrence) => published.push(occurrence),
     onFailure,
   });
+
+  await observer.syncWorkspaces([]);
+  observer.dispose();
 
   const startup = observer.syncWorkspaces([{ repoPath: "/repo-a", repositoryLabel: "Repo A" }]);
   await firstReadStarted.promise;

--- a/packages/frontend/src/features/notifications/notification-workspace-observer.test.ts
+++ b/packages/frontend/src/features/notifications/notification-workspace-observer.test.ts
@@ -6,21 +6,26 @@ import type {
   NotificationOccurrence,
   TaskCard,
 } from "@openducktor/contracts";
+import { CancelledError, useQueryClient } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import { createTaskViewSync } from "@/state/queries/task-view-sync";
+import { agentSessionQueryKeys } from "@/state/queries/agent-sessions";
+import { readCachedAgentSessionAssociation } from "@/state/queries/agent-session-association";
+import { taskQueryKeys, type RepoTaskData } from "@/state/queries/tasks";
+import { IsolatedQueryWrapper } from "@/test-utils/isolated-query-wrapper";
 import { createDeferred, createTaskCardFixture } from "@/test-utils/shared-test-fixtures";
 import { createNotificationTaskObserver as createTaskObserver } from "./notification-task-observer";
 import { createNotificationWorkspaceObserver } from "./notification-workspace-observer";
 
 type AgentSessionLiveSnapshotEnvelope = Extract<AgentSessionLiveEnvelope, { type: "snapshot" }>;
 
-import { QueryClient } from "@tanstack/react-query";
-import { agentSessionQueryKeys } from "@/state/queries/agent-sessions";
-import { readCachedAgentSessionAssociation } from "@/state/queries/agent-session-association";
-import { taskQueryKeys } from "@/state/queries/tasks";
+const renderIsolatedQueryClient = () =>
+  renderHook(() => useQueryClient(), { wrapper: IsolatedQueryWrapper });
 
 const createNotificationTaskObserver = (
   options: Omit<Parameters<typeof createTaskObserver>[0], "resolveSessionAssociation">,
+  queryClient = renderIsolatedQueryClient().result.current,
 ) => {
-  const queryClient = new QueryClient();
   return createTaskObserver({
     ...options,
     resolveSessionAssociation: (ref) => readCachedAgentSessionAssociation(queryClient, ref),
@@ -246,7 +251,8 @@ test.each(["tasks", "sessions"])(
 );
 
 test("publishes a buffered request after effect replay and cancelled startup recovery", async () => {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const queryClientHook = renderIsolatedQueryClient();
+  const queryClient = queryClientHook.result.current;
   const firstReadStarted = createDeferred<void>();
   const firstRead = createDeferred<TaskCard[]>();
   let readCount = 0;
@@ -269,12 +275,15 @@ test("publishes a buffered request after effect replay and cancelled startup rec
   const stop = mock(() => {});
   const published: NotificationOccurrence[] = [];
   let receive = (_envelope: AgentSessionLiveEnvelope) => {};
-  const taskObserver = createNotificationTaskObserver({
-    loadTasks,
-    loadSessionRecords: loadWorkflowSessionRecords,
-    publish: () => {},
-    onFailure,
-  });
+  const taskObserver = createNotificationTaskObserver(
+    {
+      loadTasks,
+      loadSessionRecords: loadWorkflowSessionRecords,
+      publish: () => {},
+      onFailure,
+    },
+    queryClient,
+  );
   const observer = createNotificationWorkspaceObserver({
     observe: async (_input, listener) => {
       receive = listener;
@@ -286,38 +295,176 @@ test("publishes a buffered request after effect replay and cancelled startup rec
     onFailure,
   });
 
-  await observer.syncWorkspaces([]);
-  observer.dispose();
+  try {
+    await observer.syncWorkspaces([]);
+    observer.dispose();
 
-  const startup = observer.syncWorkspaces([{ repoPath: "/repo-a", repositoryLabel: "Repo A" }]);
-  await firstReadStarted.promise;
-  await queryClient.cancelQueries(
-    { queryKey: taskQueryKeys.repoData("/repo-a"), exact: true },
-    { silent: true },
-  );
-  await startup;
+    const startup = observer.syncWorkspaces([{ repoPath: "/repo-a", repositoryLabel: "Repo A" }]);
+    await firstReadStarted.promise;
+    await queryClient.cancelQueries(
+      { queryKey: taskQueryKeys.repoData("/repo-a"), exact: true },
+      { silent: true },
+    );
+    await startup;
 
-  expect(onFailure).not.toHaveBeenCalled();
-  expect(stop).not.toHaveBeenCalled();
+    expect(onFailure).not.toHaveBeenCalled();
+    expect(stop).not.toHaveBeenCalled();
 
-  receive(liveUpsert(["existing", "new"]));
-  expect(published).toEqual([]);
+    receive(liveUpsert(["existing", "new"]));
+    expect(published).toEqual([]);
 
-  await taskObserver.sink.onSnapshot();
+    await taskObserver.sink.onSnapshot();
 
-  expect(published).toMatchObject([
-    {
-      kind: "agent.permission_requested",
-      task: { id: "task-1" },
-    },
-  ]);
-  firstRead.resolve([]);
-  observer.dispose();
+    expect(published).toMatchObject([
+      {
+        kind: "agent.permission_requested",
+        task: { id: "task-1" },
+      },
+    ]);
+  } finally {
+    firstRead.resolve([]);
+    observer.dispose();
+    queryClientHook.unmount();
+  }
   expect(stop).toHaveBeenCalledTimes(1);
 });
 
+test("stops a cancelled startup observation when baseline recovery fails", async () => {
+  const queryClientHook = renderIsolatedQueryClient();
+  const queryClient = queryClientHook.result.current;
+  let readCount = 0;
+  const recoveryError = new Error("sessions unavailable");
+  const onFailure = mock(() => {});
+  const stop = mock(() => {});
+  const published: NotificationOccurrence[] = [];
+  let receive = (_envelope: AgentSessionLiveEnvelope) => {};
+  const taskObserver = createNotificationTaskObserver(
+    {
+      loadTasks: async () => {
+        readCount += 1;
+        if (readCount === 1) throw new CancelledError();
+        if (readCount === 2) throw recoveryError;
+        return [createTaskCardFixture({ id: "task-1" })];
+      },
+      loadSessionRecords: loadWorkflowSessionRecords,
+      publish: () => {},
+      onFailure,
+    },
+    queryClient,
+  );
+  const observer = createNotificationWorkspaceObserver({
+    observe: async (_input, listener) => {
+      receive = listener;
+      listener(liveSnapshot(["existing"]));
+      return stop;
+    },
+    taskObserver,
+    publish: (occurrence) => published.push(occurrence),
+    onFailure,
+  });
+
+  try {
+    await observer.syncWorkspaces([{ repoPath: "/repo-a", repositoryLabel: "Repo A" }]);
+    receive(liveUpsert(["existing", "new"]));
+
+    await taskObserver.sink.onSnapshot();
+
+    expect(onFailure).toHaveBeenCalledTimes(1);
+    expect(onFailure).toHaveBeenCalledWith({
+      repoPath: "/repo-a",
+      source: "task",
+      cause: recoveryError,
+    });
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(published).toEqual([]);
+
+    await taskObserver.sink.onSnapshot();
+    expect(published).toEqual([]);
+  } finally {
+    observer.dispose();
+    queryClientHook.unmount();
+  }
+});
+
+test("serializes a notification baseline with a manual task refresh", async () => {
+  const queryClientHook = renderIsolatedQueryClient();
+  const queryClient = queryClientHook.result.current;
+  const firstReadStarted = createDeferred<void>();
+  const firstRead = createDeferred<TaskCard[]>();
+  const tasks = [createTaskCardFixture({ id: "task-1" })];
+  let readCount = 0;
+  const taskViewSync = createTaskViewSync({
+    queryClient,
+    ports: {
+      listTasks: async () => {
+        readCount += 1;
+        if (readCount === 1) {
+          firstReadStarted.resolve();
+          return await firstRead.promise;
+        }
+        return tasks;
+      },
+      loadFreshDocument: async () => {
+        throw new Error("Unexpected document read.");
+      },
+    },
+  });
+  const onFailure = mock(() => {});
+  const published: NotificationOccurrence[] = [];
+  let receive = (_envelope: AgentSessionLiveEnvelope) => {};
+  const taskObserver = createNotificationTaskObserver(
+    {
+      loadTasks: async (repoPath) => {
+        await taskViewSync.loadWorkspace(repoPath, { forceFresh: true });
+        const taskData = queryClient.getQueryData<RepoTaskData>(taskQueryKeys.repoData(repoPath));
+        if (!taskData) throw new Error("Task notification data is unavailable.");
+        return taskData.tasks;
+      },
+      loadSessionRecords: loadWorkflowSessionRecords,
+      publish: () => {},
+      onFailure,
+    },
+    queryClient,
+  );
+  const observer = createNotificationWorkspaceObserver({
+    observe: async (_input, listener) => {
+      receive = listener;
+      listener(liveSnapshot(["existing"]));
+      return () => {};
+    },
+    taskObserver,
+    publish: (occurrence) => published.push(occurrence),
+    onFailure,
+  });
+
+  try {
+    const startup = observer.syncWorkspaces([{ repoPath: "/repo-a", repositoryLabel: "Repo A" }]);
+    await firstReadStarted.promise;
+    const manualRefresh = taskViewSync.refreshManually("/repo-a");
+    await flush();
+    expect(readCount).toBe(1);
+
+    firstRead.resolve(tasks);
+    await Promise.all([startup, manualRefresh]);
+
+    receive(liveUpsert(["existing", "new"]));
+    expect(onFailure).not.toHaveBeenCalled();
+    expect(published).toMatchObject([
+      {
+        kind: "agent.permission_requested",
+        task: { id: "task-1" },
+      },
+    ]);
+  } finally {
+    firstRead.resolve(tasks);
+    observer.dispose();
+    queryClientHook.unmount();
+  }
+});
+
 test("reads new ownership from Query before the queued task notification sink runs", async () => {
-  const queryClient = new QueryClient();
+  const queryClientHook = renderIsolatedQueryClient();
+  const queryClient = queryClientHook.result.current;
   const published: NotificationOccurrence[] = [];
   const taskObserver = createTaskObserver({
     loadTasks: async () => [createTaskCardFixture({ id: "task-1" })],
@@ -336,15 +483,19 @@ test("reads new ownership from Query before the queued task notification sink ru
     publish: (occurrence) => published.push(occurrence),
     onFailure: () => {},
   });
-  await observer.syncWorkspaces([{ repoPath: "/repo-a", repositoryLabel: "Repo" }]);
-  queryClient.setQueryData(agentSessionQueryKeys.list("/repo-a", "task-1"), [
-    workflowSessionRecord,
-  ]);
-  listener(liveSnapshot(["existing"]));
-  expect(published).toEqual([]);
-  listener(liveUpsert(["existing", "new"]));
-  expect(published.map((item) => item.kind)).toEqual(["agent.permission_requested"]);
-  observer.dispose();
+  try {
+    await observer.syncWorkspaces([{ repoPath: "/repo-a", repositoryLabel: "Repo" }]);
+    queryClient.setQueryData(agentSessionQueryKeys.list("/repo-a", "task-1"), [
+      workflowSessionRecord,
+    ]);
+    listener(liveSnapshot(["existing"]));
+    expect(published).toEqual([]);
+    listener(liveUpsert(["existing", "new"]));
+    expect(published.map((item) => item.kind)).toEqual(["agent.permission_requested"]);
+  } finally {
+    observer.dispose();
+    queryClientHook.unmount();
+  }
 });
 
 describe("all-workspace notification observation", () => {

--- a/packages/frontend/src/features/notifications/notification-workspace-observer.test.ts
+++ b/packages/frontend/src/features/notifications/notification-workspace-observer.test.ts
@@ -660,6 +660,68 @@ test("ignores a stale cancelled baseline after the current attempt fails", async
   });
 });
 
+test("joins a startup baseline before applying an external task event", async () => {
+  const existing = createTaskCardFixture({ id: "existing", title: "Existing" });
+  const created = createTaskCardFixture({ id: "created", title: "Created" });
+  const initialSessionReadStarted = createDeferred<void>();
+  const initialSessionRead = createDeferred<Record<string, AgentSessionRecord[]>>();
+  const secondTaskRead = createDeferred<TaskCard[]>();
+  let taskReads = 0;
+  let sessionReads = 0;
+  const loadTasks = mock(async () => {
+    taskReads += 1;
+    return taskReads === 1 ? [existing] : secondTaskRead.promise;
+  });
+  const loadSessionRecords = mock(async () => {
+    sessionReads += 1;
+    if (sessionReads === 1) {
+      initialSessionReadStarted.resolve();
+      return initialSessionRead.promise;
+    }
+    return {};
+  });
+  const taskObserver = createNotificationTaskObserver({
+    loadTasks,
+    loadSessionRecords,
+    publish: () => {},
+    onFailure: () => {},
+  });
+  const stop = mock(() => {});
+  const observer = createNotificationWorkspaceObserver({
+    observe: async () => stop,
+    taskObserver,
+    publish: () => {},
+    onFailure: () => {},
+  });
+  const workspaces = [{ repoPath: "/repo-a", repositoryLabel: "Repo A" }];
+  const startup = observer.syncWorkspaces(workspaces);
+  await initialSessionReadStarted.promise;
+
+  const creation = taskObserver.sink.onChange({
+    kind: "external_task_created",
+    eventId: "create",
+    repoPath: "/repo-a",
+    taskId: created.id,
+    taskSnapshot: { id: created.id, title: created.title, status: created.status },
+    emittedAt: "2026-09-09T00:00:00.000Z",
+  });
+  await flush();
+
+  initialSessionRead.resolve({});
+  await startup;
+  secondTaskRead.resolve([existing, created]);
+  await creation;
+
+  expect(loadTasks).toHaveBeenCalledTimes(1);
+  expect(loadSessionRecords).toHaveBeenLastCalledWith("/repo-a", [created.id]);
+  expect(taskObserver.resolveTask("/repo-a", created.id)).toEqual({
+    id: created.id,
+    title: created.title,
+  });
+  expect(stop).not.toHaveBeenCalled();
+  observer.dispose();
+});
+
 test("serializes a notification baseline with a manual task refresh", async () => {
   const queryClientHook = renderIsolatedQueryClient();
   const queryClient = queryClientHook.result.current;

--- a/packages/frontend/src/features/notifications/notification-workspace-observer.test.ts
+++ b/packages/frontend/src/features/notifications/notification-workspace-observer.test.ts
@@ -611,6 +611,55 @@ test("keeps a newer recovery observation when an older baseline fails", async ()
   }
 });
 
+test("ignores a stale cancelled baseline after the current attempt fails", async () => {
+  const staleBaseline = createDeferred<TaskCard[]>();
+  const staleBaselineStarted = createDeferred<void>();
+  const currentBaseline = createDeferred<TaskCard[]>();
+  const currentBaselineStarted = createDeferred<void>();
+  const currentFailure = new Error("current baseline failed");
+  let readCount = 0;
+  const onFailure = mock(() => {});
+  const taskObserver = createNotificationTaskObserver({
+    loadTasks: async () => {
+      readCount += 1;
+      if (readCount === 1) throw new CancelledError();
+      if (readCount === 2) {
+        staleBaselineStarted.resolve();
+        return staleBaseline.promise;
+      }
+      currentBaselineStarted.resolve();
+      return currentBaseline.promise;
+    },
+    loadSessionRecords: loadWorkflowSessionRecords,
+    publish: () => {},
+    onFailure,
+  });
+  const workspaces = [{ repoPath: "/repo-a", repositoryLabel: "Repo A" }];
+
+  await taskObserver.syncWorkspaces(workspaces);
+  expect(taskObserver.isBaselineInterrupted("/repo-a")).toBe(true);
+
+  const staleRefresh = taskObserver.sink.onSnapshot();
+  await staleBaselineStarted.promise;
+  const currentRefresh = taskObserver.syncWorkspaces(workspaces);
+  await currentBaselineStarted.promise;
+
+  currentBaseline.reject(currentFailure);
+  await currentRefresh;
+  expect(taskObserver.isBaselineInterrupted("/repo-a")).toBe(false);
+
+  staleBaseline.reject(new CancelledError());
+  await staleRefresh;
+
+  expect(taskObserver.isBaselineInterrupted("/repo-a")).toBe(false);
+  expect(onFailure).toHaveBeenCalledTimes(1);
+  expect(onFailure).toHaveBeenCalledWith({
+    repoPath: "/repo-a",
+    source: "task",
+    cause: currentFailure,
+  });
+});
+
 test("serializes a notification baseline with a manual task refresh", async () => {
   const queryClientHook = renderIsolatedQueryClient();
   const queryClient = queryClientHook.result.current;

--- a/packages/frontend/src/features/notifications/notification-workspace-observer.test.ts
+++ b/packages/frontend/src/features/notifications/notification-workspace-observer.test.ts
@@ -7,11 +7,17 @@ import type {
   TaskCard,
 } from "@openducktor/contracts";
 import { CancelledError, useQueryClient } from "@tanstack/react-query";
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { TaskStreamFrame } from "@/lib/shell-bridge";
+import { createAgentSessionViewSync } from "@/state/queries/agent-session-view-sync";
 import { createTaskViewSync } from "@/state/queries/task-view-sync";
-import { agentSessionQueryKeys } from "@/state/queries/agent-sessions";
+import {
+  agentSessionQueryKeys,
+  loadAgentSessionListsFromQuery,
+} from "@/state/queries/agent-sessions";
 import { readCachedAgentSessionAssociation } from "@/state/queries/agent-session-association";
 import { taskQueryKeys, type RepoTaskData } from "@/state/queries/tasks";
+import { createTaskStreamController } from "@/state/tasks/task-stream-controller";
 import { IsolatedQueryWrapper } from "@/test-utils/isolated-query-wrapper";
 import { createDeferred, createTaskCardFixture } from "@/test-utils/shared-test-fixtures";
 import { createNotificationTaskObserver as createTaskObserver } from "./notification-task-observer";
@@ -383,6 +389,156 @@ test("stops a cancelled startup observation when baseline recovery fails", async
   } finally {
     observer.dispose();
     queryClientHook.unmount();
+  }
+});
+
+test("stops a cancelled session baseline when snapshot recovery fails terminally", async () => {
+  const queryClientHook = renderIsolatedQueryClient();
+  const queryClient = queryClientHook.result.current;
+  const initialSessionReadStarted = createDeferred<void>();
+  const initialSessionRead =
+    createDeferred<Array<{ taskId: string; agentSessions: AgentSessionRecord[] }>>();
+  const firstSnapshotFailure = new Error("snapshot sessions unavailable");
+  const recoverySnapshotFailure = new Error("recovery sessions unavailable");
+  let sessionBatchReads = 0;
+  const readPort = {
+    agentSessionsList: async () => [],
+    agentSessionsListForTasks: async (_repoPath: string, _taskIds: string[]) => {
+      sessionBatchReads += 1;
+      if (sessionBatchReads === 1) {
+        initialSessionReadStarted.resolve();
+        return initialSessionRead.promise;
+      }
+      throw sessionBatchReads === 2 ? firstSnapshotFailure : recoverySnapshotFailure;
+    },
+  };
+  const taskFailures = mock(() => {});
+  const taskObserver = createTaskObserver({
+    loadTasks: async () => [createTaskCardFixture({ id: "task-1" })],
+    loadSessionRecords: (repoPath, taskIds) =>
+      loadAgentSessionListsFromQuery(queryClient, repoPath, taskIds, { readPort }),
+    resolveSessionAssociation: (ref) => readCachedAgentSessionAssociation(queryClient, ref),
+    publish: () => {},
+    onFailure: taskFailures,
+  });
+  const stop = mock(() => {});
+  const published: NotificationOccurrence[] = [];
+  let receive = (_envelope: AgentSessionLiveEnvelope) => {};
+  const workspaceObserver = createNotificationWorkspaceObserver({
+    observe: async (_input, listener) => {
+      receive = listener;
+      listener(liveSnapshot(["existing"]));
+      return stop;
+    },
+    taskObserver,
+    publish: (occurrence) => published.push(occurrence),
+    onFailure: taskFailures,
+  });
+  const streamListeners: Array<(frame: TaskStreamFrame) => void> = [];
+  const controller = createTaskStreamController({
+    transport: {
+      subscribeTaskStream: async (_input, onFrame) => {
+        streamListeners.push(onFrame);
+        return {
+          subscriptionId: `subscription-${streamListeners.length}`,
+          acknowledge: async () => {},
+          unsubscribe: async () => {},
+        };
+      },
+    },
+    metadata: {
+      reconcileExternalTaskSyncEvent: () => {},
+      invalidateAllTaskMetadata: () => {},
+    },
+    taskViewSync: {
+      loadWorkspace: async () => {},
+      refreshManually: async () => {},
+      refreshAfterTaskRetentionChange: async () => {},
+      refreshAfterLocalMutation: async () => {},
+      reconcileExternalEvent: async () => {},
+      reconcileStreamSnapshot: async () => ["task-1"],
+    },
+    agentSessionViewSync: createAgentSessionViewSync({
+      queryClient,
+      readPort,
+      removeTaskSessions: () => {},
+      refreshLiveSessions: async () => {},
+    }),
+    getActiveRepoPath: () => "/repo-a",
+    notificationSink: taskObserver.sink,
+    onDegraded: () => {},
+  });
+
+  try {
+    const startup = workspaceObserver.syncWorkspaces([
+      { repoPath: "/repo-a", repositoryLabel: "Repo A" },
+    ]);
+    await initialSessionReadStarted.promise;
+    receive(liveUpsert(["existing", "new"]));
+
+    await controller.start();
+    streamListeners[0]?.({
+      type: "snapshot_required",
+      cursor: { epoch: "11111111-1111-4111-8111-111111111111", sequence: 7 },
+      reason: "buffer_gap",
+    });
+    await startup;
+    await waitFor(() => expect(streamListeners).toHaveLength(2));
+
+    streamListeners[1]?.({
+      type: "snapshot_required",
+      cursor: { epoch: "11111111-1111-4111-8111-111111111111", sequence: 8 },
+      reason: "buffer_gap",
+    });
+    await waitFor(() => expect(stop).toHaveBeenCalledTimes(1));
+
+    receive(liveUpsert(["existing", "new", "later"]));
+    expect(published).toEqual([]);
+    expect(taskObserver.isBaselineInterrupted("/repo-a")).toBe(false);
+    expect(taskFailures).not.toHaveBeenCalled();
+  } finally {
+    initialSessionRead.resolve([{ taskId: "task-1", agentSessions: [workflowSessionRecord] }]);
+    await controller.stop();
+    workspaceObserver.dispose();
+    queryClientHook.unmount();
+  }
+});
+
+test("stops every workspace whose baseline remains interrupted", async () => {
+  const taskObserver = createNotificationTaskObserver({
+    loadTasks: async () => [createTaskCardFixture({ id: "task-1" })],
+    loadSessionRecords: async () => {
+      throw new CancelledError();
+    },
+    publish: () => {},
+    onFailure: () => {},
+  });
+  const stopped: string[] = [];
+  const workspaceObserver = createNotificationWorkspaceObserver({
+    observe:
+      async ({ repoPath }) =>
+      () =>
+        stopped.push(repoPath),
+    taskObserver,
+    publish: () => {},
+    onFailure: () => {},
+  });
+
+  try {
+    await workspaceObserver.syncWorkspaces([
+      { repoPath: "/repo-a", repositoryLabel: "Repo A" },
+      { repoPath: "/repo-b", repositoryLabel: "Repo B" },
+    ]);
+    expect(taskObserver.isBaselineInterrupted("/repo-a")).toBe(true);
+    expect(taskObserver.isBaselineInterrupted("/repo-b")).toBe(true);
+
+    taskObserver.sink.onSnapshotFailed(new Error("snapshot recovery stopped"));
+
+    expect(stopped.sort()).toEqual(["/repo-a", "/repo-b"]);
+    expect(taskObserver.isBaselineInterrupted("/repo-a")).toBe(false);
+    expect(taskObserver.isBaselineInterrupted("/repo-b")).toBe(false);
+  } finally {
+    workspaceObserver.dispose();
   }
 });
 

--- a/packages/frontend/src/features/notifications/notification-workspace-observer.test.ts
+++ b/packages/frontend/src/features/notifications/notification-workspace-observer.test.ts
@@ -15,6 +15,7 @@ type AgentSessionLiveSnapshotEnvelope = Extract<AgentSessionLiveEnvelope, { type
 import { QueryClient } from "@tanstack/react-query";
 import { agentSessionQueryKeys } from "@/state/queries/agent-sessions";
 import { readCachedAgentSessionAssociation } from "@/state/queries/agent-session-association";
+import { taskQueryKeys } from "@/state/queries/tasks";
 
 const createNotificationTaskObserver = (
   options: Omit<Parameters<typeof createTaskObserver>[0], "resolveSessionAssociation">,
@@ -243,6 +244,72 @@ test.each(["tasks", "sessions"])(
     observer.dispose();
   },
 );
+
+test("keeps startup observation quiet when the task stream cancels its baseline read", async () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const firstReadStarted = createDeferred<void>();
+  const firstRead = createDeferred<TaskCard[]>();
+  let readCount = 0;
+  const loadTasks = async (repoPath: string): Promise<TaskCard[]> => {
+    const result = await queryClient.fetchQuery({
+      queryKey: taskQueryKeys.repoData(repoPath),
+      queryFn: async () => {
+        readCount += 1;
+        if (readCount === 1) {
+          firstReadStarted.resolve();
+          return { tasks: await firstRead.promise };
+        }
+        return { tasks: [createTaskCardFixture({ id: "task-1" })] };
+      },
+      staleTime: 0,
+    });
+    return result.tasks;
+  };
+  const onFailure = mock(() => {});
+  const stop = mock(() => {});
+  const published: NotificationOccurrence[] = [];
+  let receive = (_envelope: AgentSessionLiveEnvelope) => {};
+  const taskObserver = createNotificationTaskObserver({
+    loadTasks,
+    loadSessionRecords: loadWorkflowSessionRecords,
+    publish: () => {},
+    onFailure,
+  });
+  const observer = createNotificationWorkspaceObserver({
+    observe: async (_input, listener) => {
+      receive = listener;
+      listener(liveSnapshot(["existing"]));
+      return stop;
+    },
+    taskObserver,
+    publish: (occurrence) => published.push(occurrence),
+    onFailure,
+  });
+
+  const startup = observer.syncWorkspaces([{ repoPath: "/repo-a", repositoryLabel: "Repo A" }]);
+  await firstReadStarted.promise;
+  await queryClient.cancelQueries(
+    { queryKey: taskQueryKeys.repoData("/repo-a"), exact: true },
+    { silent: true },
+  );
+  await startup;
+
+  expect(onFailure).not.toHaveBeenCalled();
+  expect(stop).not.toHaveBeenCalled();
+
+  await taskObserver.sink.onSnapshot();
+  receive(liveUpsert(["existing", "new"]));
+
+  expect(published).toMatchObject([
+    {
+      kind: "agent.permission_requested",
+      task: { id: "task-1" },
+    },
+  ]);
+  firstRead.resolve([]);
+  observer.dispose();
+  expect(stop).toHaveBeenCalledTimes(1);
+});
 
 test("reads new ownership from Query before the queued task notification sink runs", async () => {
   const queryClient = new QueryClient();

--- a/packages/frontend/src/features/notifications/notification-workspace-observer.test.ts
+++ b/packages/frontend/src/features/notifications/notification-workspace-observer.test.ts
@@ -386,6 +386,75 @@ test("stops a cancelled startup observation when baseline recovery fails", async
   }
 });
 
+test("keeps a newer recovery observation when an older baseline fails", async () => {
+  const olderRecovery = createDeferred<TaskCard[]>();
+  const olderRecoveryStarted = createDeferred<void>();
+  const newerRecovery = createDeferred<TaskCard[]>();
+  const newerRecoveryStarted = createDeferred<void>();
+  const staleFailure = new Error("stale recovery failed");
+  const tasks = [createTaskCardFixture({ id: "task-1" })];
+  let readCount = 0;
+  const taskFailure = mock(() => {});
+  const taskObserver = createNotificationTaskObserver({
+    loadTasks: async () => {
+      readCount += 1;
+      if (readCount === 1) throw new CancelledError();
+      if (readCount === 2) {
+        olderRecoveryStarted.resolve();
+        return olderRecovery.promise;
+      }
+      newerRecoveryStarted.resolve();
+      return newerRecovery.promise;
+    },
+    loadSessionRecords: loadWorkflowSessionRecords,
+    publish: () => {},
+    onFailure: taskFailure,
+  });
+  const stop = mock(() => {});
+  const onFailure = mock(() => {});
+  const published: NotificationOccurrence[] = [];
+  let receive = (_envelope: AgentSessionLiveEnvelope) => {};
+  const observer = createNotificationWorkspaceObserver({
+    observe: async (_input, listener) => {
+      receive = listener;
+      listener(liveSnapshot(["existing"]));
+      return stop;
+    },
+    taskObserver,
+    publish: (occurrence) => published.push(occurrence),
+    onFailure,
+  });
+  const workspaces = [{ repoPath: "/repo-a", repositoryLabel: "Repo A" }];
+
+  try {
+    await observer.syncWorkspaces(workspaces);
+    const staleRefresh = taskObserver.sink.onSnapshot();
+    await olderRecoveryStarted.promise;
+    const currentRefresh = observer.syncWorkspaces(workspaces);
+    await newerRecoveryStarted.promise;
+
+    olderRecovery.reject(staleFailure);
+    await staleRefresh;
+    expect(stop).not.toHaveBeenCalled();
+    expect(taskFailure).not.toHaveBeenCalled();
+    expect(onFailure).not.toHaveBeenCalled();
+
+    newerRecovery.resolve(tasks);
+    await currentRefresh;
+    receive(liveUpsert(["existing", "new"]));
+    expect(published).toMatchObject([
+      {
+        kind: "agent.permission_requested",
+        task: { id: "task-1" },
+      },
+    ]);
+  } finally {
+    olderRecovery.resolve(tasks);
+    newerRecovery.resolve(tasks);
+    observer.dispose();
+  }
+});
+
 test("serializes a notification baseline with a manual task refresh", async () => {
   const queryClientHook = renderIsolatedQueryClient();
   const queryClient = queryClientHook.result.current;

--- a/packages/frontend/src/features/notifications/notification-workspace-observer.test.ts
+++ b/packages/frontend/src/features/notifications/notification-workspace-observer.test.ts
@@ -245,7 +245,7 @@ test.each(["tasks", "sessions"])(
   },
 );
 
-test("keeps startup observation quiet when the task stream cancels its baseline read", async () => {
+test("publishes a buffered request when the task stream recovers a cancelled startup baseline", async () => {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const firstReadStarted = createDeferred<void>();
   const firstRead = createDeferred<TaskCard[]>();
@@ -297,8 +297,10 @@ test("keeps startup observation quiet when the task stream cancels its baseline 
   expect(onFailure).not.toHaveBeenCalled();
   expect(stop).not.toHaveBeenCalled();
 
-  await taskObserver.sink.onSnapshot();
   receive(liveUpsert(["existing", "new"]));
+  expect(published).toEqual([]);
+
+  await taskObserver.sink.onSnapshot();
 
   expect(published).toMatchObject([
     {

--- a/packages/frontend/src/features/notifications/notification-workspace-observer.ts
+++ b/packages/frontend/src/features/notifications/notification-workspace-observer.ts
@@ -29,10 +29,14 @@ export const createNotificationWorkspaceObserver = ({
   onFailure(failure: NotificationProducerFailure): void;
 }) => {
   const observations = new Map<string, Observation>();
-  const unsubscribeBaselineReady = taskObserver.subscribeBaselineReady((repoPath) => {
-    observations.get(repoPath)?.flush();
-  });
+  let unsubscribeBaselineReady: (() => void) | null = null;
   let syncVersion = 0;
+
+  const ensureBaselineReadySubscription = (): void => {
+    unsubscribeBaselineReady ??= taskObserver.subscribeBaselineReady((repoPath) => {
+      observations.get(repoPath)?.flush();
+    });
+  };
 
   const stopObservation = (repoPath: string): void => {
     const observation = observations.get(repoPath);
@@ -110,6 +114,7 @@ export const createNotificationWorkspaceObserver = ({
 
   return {
     async syncWorkspaces(workspaces: readonly NotificationWorkspace[]): Promise<void> {
+      ensureBaselineReadySubscription();
       const version = ++syncVersion;
       const nextRepoPaths = new Set(workspaces.map((workspace) => workspace.repoPath));
       for (const repoPath of observations.keys()) {
@@ -138,7 +143,8 @@ export const createNotificationWorkspaceObserver = ({
       }
     },
     dispose(): void {
-      unsubscribeBaselineReady();
+      unsubscribeBaselineReady?.();
+      unsubscribeBaselineReady = null;
       syncVersion += 1;
       for (const repoPath of observations.keys()) {
         stopObservation(repoPath);

--- a/packages/frontend/src/features/notifications/notification-workspace-observer.ts
+++ b/packages/frontend/src/features/notifications/notification-workspace-observer.ts
@@ -84,6 +84,9 @@ export const createNotificationWorkspaceObserver = ({
 
     void observe({ repoPath: workspace.repoPath }, (envelope) => {
       if (observation.cancelled) return;
+      if (observation.pending && taskObserver.hasBaseline(workspace.repoPath)) {
+        observation.flush();
+      }
       if (observation.pending && envelope.type !== "fault" && envelope.type !== "transcript_gap") {
         observation.pending.push(envelope);
         return;
@@ -129,7 +132,7 @@ export const createNotificationWorkspaceObserver = ({
       for (const workspace of workspaces) {
         if (taskObserver.hasBaseline(workspace.repoPath)) {
           observations.get(workspace.repoPath)?.flush();
-        } else {
+        } else if (!taskObserver.isBaselineInterrupted(workspace.repoPath)) {
           stopObservation(workspace.repoPath);
         }
       }

--- a/packages/frontend/src/features/notifications/notification-workspace-observer.ts
+++ b/packages/frontend/src/features/notifications/notification-workspace-observer.ts
@@ -29,6 +29,9 @@ export const createNotificationWorkspaceObserver = ({
   onFailure(failure: NotificationProducerFailure): void;
 }) => {
   const observations = new Map<string, Observation>();
+  const unsubscribeBaselineReady = taskObserver.subscribeBaselineReady((repoPath) => {
+    observations.get(repoPath)?.flush();
+  });
   let syncVersion = 0;
 
   const stopObservation = (repoPath: string): void => {
@@ -84,9 +87,6 @@ export const createNotificationWorkspaceObserver = ({
 
     void observe({ repoPath: workspace.repoPath }, (envelope) => {
       if (observation.cancelled) return;
-      if (observation.pending && taskObserver.hasBaseline(workspace.repoPath)) {
-        observation.flush();
-      }
       if (observation.pending && envelope.type !== "fault" && envelope.type !== "transcript_gap") {
         observation.pending.push(envelope);
         return;
@@ -138,6 +138,7 @@ export const createNotificationWorkspaceObserver = ({
       }
     },
     dispose(): void {
+      unsubscribeBaselineReady();
       syncVersion += 1;
       for (const repoPath of observations.keys()) {
         stopObservation(repoPath);

--- a/packages/frontend/src/features/notifications/notification-workspace-observer.ts
+++ b/packages/frontend/src/features/notifications/notification-workspace-observer.ts
@@ -29,12 +29,16 @@ export const createNotificationWorkspaceObserver = ({
   onFailure(failure: NotificationProducerFailure): void;
 }) => {
   const observations = new Map<string, Observation>();
-  let unsubscribeBaselineReady: (() => void) | null = null;
+  let unsubscribeBaselineOutcome: (() => void) | null = null;
   let syncVersion = 0;
 
-  const ensureBaselineReadySubscription = (): void => {
-    unsubscribeBaselineReady ??= taskObserver.subscribeBaselineReady((repoPath) => {
-      observations.get(repoPath)?.flush();
+  const ensureBaselineOutcomeSubscription = (): void => {
+    unsubscribeBaselineOutcome ??= taskObserver.subscribeBaselineOutcome((outcome) => {
+      if (outcome.status === "ready") {
+        observations.get(outcome.repoPath)?.flush();
+        return;
+      }
+      stopObservation(outcome.repoPath);
     });
   };
 
@@ -114,7 +118,7 @@ export const createNotificationWorkspaceObserver = ({
 
   return {
     async syncWorkspaces(workspaces: readonly NotificationWorkspace[]): Promise<void> {
-      ensureBaselineReadySubscription();
+      ensureBaselineOutcomeSubscription();
       const version = ++syncVersion;
       const nextRepoPaths = new Set(workspaces.map((workspace) => workspace.repoPath));
       for (const repoPath of observations.keys()) {
@@ -143,8 +147,8 @@ export const createNotificationWorkspaceObserver = ({
       }
     },
     dispose(): void {
-      unsubscribeBaselineReady?.();
-      unsubscribeBaselineReady = null;
+      unsubscribeBaselineOutcome?.();
+      unsubscribeBaselineOutcome = null;
       syncVersion += 1;
       for (const repoPath of observations.keys()) {
         stopObservation(repoPath);

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
@@ -558,6 +558,7 @@ const notificationContextValue: NotificationContextValue = {
   taskStreamSink: {
     onChange: async () => {},
     onSnapshot: async () => {},
+    onSnapshotFailed: () => {},
     onFailure: () => {},
   },
 };

--- a/packages/frontend/src/pages/kanban/kanban-page.test.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page.test.tsx
@@ -153,6 +153,7 @@ const notificationContextValue = {
   taskStreamSink: {
     onChange: async () => {},
     onSnapshot: async () => {},
+    onSnapshotFailed: () => {},
     onFailure: () => {},
   },
 } satisfies NotificationContextValue;

--- a/packages/frontend/src/pages/onboarding/onboarding-page.test-support.tsx
+++ b/packages/frontend/src/pages/onboarding/onboarding-page.test-support.tsx
@@ -49,6 +49,7 @@ const notificationContextValue = {
   taskStreamSink: {
     onChange: async () => {},
     onSnapshot: async () => {},
+    onSnapshotFailed: () => {},
     onFailure: () => {},
   },
 } satisfies NotificationContextValue;

--- a/packages/frontend/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/packages/frontend/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -49,6 +49,7 @@ const lifecycleArgs = {
 const taskViewSync: TaskViewSync = {
   loadWorkspace: async () => {},
   refreshManually: async () => {},
+  refreshAfterTaskRetentionChange: async () => {},
   refreshAfterLocalMutation: async () => {},
   reconcileExternalEvent: async () => {},
   reconcileStreamSnapshot: async () => [],

--- a/packages/frontend/src/state/notifications/use-notification-test-controls.test.ts
+++ b/packages/frontend/src/state/notifications/use-notification-test-controls.test.ts
@@ -77,6 +77,7 @@ test.each([
       taskStreamSink: {
         onChange: async () => {},
         onSnapshot: async () => {},
+        onSnapshotFailed: () => {},
         onFailure: () => {},
       },
     };

--- a/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.ts
+++ b/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.ts
@@ -15,7 +15,7 @@ import { normalizeRepoScripts } from "@/state/read-models/settings-read-model";
 import type { RepoAgentDefaultInput, RepoSettingsInput } from "@/types/state-slices";
 import { checksQueryKeys } from "../../queries/checks";
 import { repositoryGitProviderContextQueryKeys } from "../../queries/git-provider-context";
-import { repoTaskDataQueryOptions, taskQueryKeys } from "../../queries/tasks";
+import { getProductionTaskViewSync } from "../../queries/task-view-sync";
 import {
   loadRepoConfigFromQuery,
   loadSettingsSnapshotFromQuery,
@@ -189,21 +189,9 @@ export function useRepoSettingsOperations({
         previousSnapshot !== undefined &&
         previousSnapshot.kanban.doneVisibleDays !== normalizedSnapshot.kanban.doneVisibleDays;
       if (retentionChanged) {
-        await queryClient.cancelQueries({ queryKey: taskQueryKeys.all }, { silent: true });
-        await queryClient.invalidateQueries({
-          queryKey: taskQueryKeys.all,
-          refetchType: "none",
-        });
-        if (savedActiveWorkspace) {
-          try {
-            await queryClient.fetchQuery({
-              ...repoTaskDataQueryOptions(savedActiveWorkspace.repoPath),
-              staleTime: 0,
-            });
-          } catch {
-            // TanStack Query keeps the failure for the task-loading error path to report.
-          }
-        }
+        await getProductionTaskViewSync(queryClient).refreshAfterTaskRetentionChange(
+          savedActiveWorkspace?.repoPath ?? null,
+        );
       }
       void queryClient.invalidateQueries({ queryKey: checksQueryKeys.all });
       await queryClient.invalidateQueries({

--- a/packages/frontend/src/state/providers/autopilot-provider.test.tsx
+++ b/packages/frontend/src/state/providers/autopilot-provider.test.tsx
@@ -86,6 +86,7 @@ const createNotificationContext = (
   taskStreamSink: {
     onChange: async () => {},
     onSnapshot: async () => {},
+    onSnapshotFailed: () => {},
     onFailure: () => {},
   },
   ...overrides,

--- a/packages/frontend/src/state/providers/notification-provider.tsx
+++ b/packages/frontend/src/state/providers/notification-provider.tsx
@@ -43,7 +43,8 @@ import { hostBridge } from "@/lib/host-client";
 import { getShellBridge } from "@/lib/shell-bridge";
 import { loadAgentSessionListsFromQuery } from "@/state/queries/agent-sessions";
 import { readCachedAgentSessionAssociation } from "@/state/queries/agent-session-association";
-import { unfilteredRepoTaskDataQueryOptions } from "@/state/queries/tasks";
+import { getProductionTaskViewSync } from "@/state/queries/task-view-sync";
+import { type RepoTaskData, taskQueryKeys } from "@/state/queries/tasks";
 import { settingsSnapshotQueryOptions } from "@/state/queries/workspace";
 import { useWorkspaceStateContext } from "../app-state-contexts";
 import {
@@ -151,8 +152,14 @@ export function NotificationProvider({ children }: PropsWithChildren): ReactElem
     () =>
       createNotificationTaskObserver({
         loadTasks: async (repoPath) => {
-          const options = unfilteredRepoTaskDataQueryOptions(repoPath);
-          return (await queryClient.fetchQuery({ ...options, staleTime: 0 })).tasks;
+          await getProductionTaskViewSync(queryClient).loadWorkspace(repoPath, {
+            forceFresh: true,
+          });
+          const taskData = queryClient.getQueryData<RepoTaskData>(taskQueryKeys.repoData(repoPath));
+          if (!taskData) {
+            throw new Error("Task notification data is unavailable. Reload to reconnect.");
+          }
+          return taskData.tasks;
         },
         loadSessionRecords: (repoPath, taskIds) =>
           loadAgentSessionListsFromQuery(queryClient, repoPath, taskIds),

--- a/packages/frontend/src/state/queries/task-view-sync-races.test.ts
+++ b/packages/frontend/src/state/queries/task-view-sync-races.test.ts
@@ -4,7 +4,7 @@ import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import { createTaskCardFixture } from "@/test-utils/shared-test-fixtures";
 import { documentQueryKeys } from "./documents";
 import { createTaskViewSync, type TaskViewSyncPorts } from "./task-view-sync";
-import { taskQueryKeys } from "./tasks";
+import { taskQueryKeys, type RepoTaskData } from "./tasks";
 
 const createDeferred = <T>() => {
   let resolve: (value: T) => void = () => {};
@@ -52,6 +52,33 @@ describe("TaskViewSync races", () => {
       taskList.resolve([createTaskCardFixture({ id: "task-1" })]);
       await Promise.allSettled([snapshot, workspaceLoad]);
     }
+  });
+
+  test("queues a task-retention refresh after a workspace load", async () => {
+    const firstTaskList = createDeferred<TaskCard[]>();
+    const firstTaskListStarted = createDeferred<void>();
+    const tasks = [createTaskCardFixture({ id: "task-1" })];
+    const listTasks = mock(async () => {
+      if (listTasks.mock.calls.length === 1) {
+        firstTaskListStarted.resolve();
+        return firstTaskList.promise;
+      }
+      return tasks;
+    });
+    const { queryClient, sync } = createSync(createPorts({ listTasks }));
+
+    const workspaceLoad = sync.loadWorkspace("/repo", { forceFresh: true });
+    await firstTaskListStarted.promise;
+    const retentionRefresh = sync.refreshAfterTaskRetentionChange("/repo");
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(listTasks).toHaveBeenCalledTimes(1);
+    firstTaskList.resolve(tasks);
+    await Promise.all([workspaceLoad, retentionRefresh]);
+    expect(listTasks).toHaveBeenCalledTimes(2);
+    expect(queryClient.getQueryData<RepoTaskData>(taskQueryKeys.repoData("/repo"))).toEqual({
+      tasks,
+    });
   });
 
   test("runs external document refreshes in event order", async () => {

--- a/packages/frontend/src/state/queries/task-view-sync.ts
+++ b/packages/frontend/src/state/queries/task-view-sync.ts
@@ -21,7 +21,7 @@ export type LocalMutationImpact =
   | { kind: "remove-documents"; taskIds: string[] };
 
 export type TaskViewSync = {
-  loadWorkspace: (repoPath: string) => Promise<void>;
+  loadWorkspace: (repoPath: string, options?: { forceFresh?: boolean }) => Promise<void>;
   refreshManually: (repoPath: string) => Promise<void>;
   refreshAfterLocalMutation: (repoPath: string, impact: LocalMutationImpact) => Promise<void>;
   reconcileExternalEvent: (
@@ -215,10 +215,10 @@ export const createTaskViewSync = ({
     });
 
   return {
-    loadWorkspace: (repoPath) =>
+    loadWorkspace: (repoPath, options) =>
       runForRepo(repoPath, async () => {
         const state = queryClient.getQueryState(taskQueryKeys.repoData(repoPath));
-        if (state?.status !== "success") {
+        if (options?.forceFresh || state?.status !== "success") {
           await fetchTasks(repoPath);
         }
       }),

--- a/packages/frontend/src/state/queries/task-view-sync.ts
+++ b/packages/frontend/src/state/queries/task-view-sync.ts
@@ -23,6 +23,7 @@ export type LocalMutationImpact =
 export type TaskViewSync = {
   loadWorkspace: (repoPath: string, options?: { forceFresh?: boolean }) => Promise<void>;
   refreshManually: (repoPath: string) => Promise<void>;
+  refreshAfterTaskRetentionChange: (activeRepoPath: string | null) => Promise<void>;
   refreshAfterLocalMutation: (repoPath: string, impact: LocalMutationImpact) => Promise<void>;
   reconcileExternalEvent: (
     event: ExternalTaskSyncEvent,
@@ -226,6 +227,33 @@ export const createTaskViewSync = ({
       refreshActive(repoPath, {
         impact: { kind: "task-list-only" },
       }),
+    refreshAfterTaskRetentionChange: async (activeRepoPath) => {
+      const taskQueries = queryClient
+        .getQueryCache()
+        .findAll({ queryKey: taskQueryKeys.all, exact: false });
+      const repos = new Set<string>([
+        ...(activeRepoPath ? [activeRepoPath] : []),
+        ...taskQueries.flatMap((query) => {
+          const repoPathResult = z.string().safeParse(query.queryKey[2]);
+          return repoPathResult.success ? [repoPathResult.data] : [];
+        }),
+      ]);
+      await Promise.all(
+        [...repos].map((repoPath) =>
+          runForRepo(repoPath, async () => {
+            await cancelRepoTaskQueries(repoPath);
+            await invalidateRepoTaskQueries(queryClient, repoPath);
+            if (repoPath === activeRepoPath) {
+              try {
+                await fetchTasks(repoPath);
+              } catch {
+                // TanStack Query keeps the failure for the task-loading error path to report.
+              }
+            }
+          }),
+        ),
+      );
+    },
     refreshAfterLocalMutation: (repoPath, impact) => refreshActive(repoPath, { impact }),
     reconcileExternalEvent: async (event, activeRepoPath) => {
       const { taskIds, removedTaskIds } = toEventChanges(event);

--- a/packages/frontend/src/state/tasks/task-stream-controller.test.ts
+++ b/packages/frontend/src/state/tasks/task-stream-controller.test.ts
@@ -222,6 +222,7 @@ describe("task stream controller recovery", () => {
         throw notificationFailure;
       }),
       onSnapshot: mock(async () => {}),
+      onSnapshotFailed: mock(() => {}),
       onFailure: mock(() => {}),
     };
     const harness = createHarness({
@@ -257,6 +258,7 @@ describe("task stream controller recovery", () => {
         }
       }),
       onSnapshot: mock(async () => {}),
+      onSnapshotFailed: mock(() => {}),
       onFailure: mock(() => {}),
     };
     const harness = createHarness({ notificationSink });
@@ -282,6 +284,7 @@ describe("task stream controller recovery", () => {
     const notificationSink: TaskStreamNotificationSink = {
       onChange: mock(async () => {}),
       onSnapshot: mock(async () => snapshotNotification.promise),
+      onSnapshotFailed: mock(() => {}),
       onFailure: mock(() => {}),
     };
     const harness = createHarness({ notificationSink });
@@ -552,6 +555,67 @@ describe("task stream controller recovery", () => {
     expect(harness.records[1]?.unsubscribe).toHaveBeenCalledTimes(1);
     expect(harness.onDegraded).toHaveBeenCalledWith(changeFailure);
     expect(harness.onSnapshotFinished).toHaveBeenCalledWith("/repo", false);
+  });
+
+  test("does not report terminal snapshot failure when the recovery snapshot succeeds", async () => {
+    const firstFailure = new Error("first snapshot failed");
+    let snapshotApplications = 0;
+    const notificationSink: TaskStreamNotificationSink = {
+      onChange: mock(async () => {}),
+      onSnapshot: mock(async () => {}),
+      onSnapshotFailed: mock(() => {}),
+      onFailure: mock(() => {}),
+    };
+    const harness = createHarness({
+      notificationSink,
+      taskViewSync: {
+        reconcileStreamSnapshot: async () => {
+          snapshotApplications += 1;
+          if (snapshotApplications === 1) throw firstFailure;
+          return [];
+        },
+      },
+    });
+
+    await harness.controller.start();
+    harness.emit(0, { type: "snapshot_required", cursor: cursor(7), reason: "buffer_gap" });
+    await flush();
+    harness.emit(1, { type: "snapshot_required", cursor: cursor(8), reason: "buffer_gap" });
+    await flush();
+
+    expect(notificationSink.onSnapshot).toHaveBeenCalledTimes(1);
+    expect(notificationSink.onSnapshotFailed).not.toHaveBeenCalled();
+  });
+
+  test("reports terminal snapshot failure once when the recovery snapshot fails", async () => {
+    const firstFailure = new Error("first snapshot failed");
+    const recoveryFailure = new Error("recovery snapshot failed");
+    let snapshotApplications = 0;
+    const notificationSink: TaskStreamNotificationSink = {
+      onChange: mock(async () => {}),
+      onSnapshot: mock(async () => {}),
+      onSnapshotFailed: mock(() => {}),
+      onFailure: mock(() => {}),
+    };
+    const harness = createHarness({
+      notificationSink,
+      taskViewSync: {
+        reconcileStreamSnapshot: async () => {
+          snapshotApplications += 1;
+          throw snapshotApplications === 1 ? firstFailure : recoveryFailure;
+        },
+      },
+    });
+
+    await harness.controller.start();
+    harness.emit(0, { type: "snapshot_required", cursor: cursor(7), reason: "buffer_gap" });
+    await flush();
+    harness.emit(1, { type: "snapshot_required", cursor: cursor(8), reason: "buffer_gap" });
+    await flush();
+
+    expect(notificationSink.onSnapshot).not.toHaveBeenCalled();
+    expect(notificationSink.onSnapshotFailed).toHaveBeenCalledTimes(1);
+    expect(notificationSink.onSnapshotFailed).toHaveBeenCalledWith(recoveryFailure);
   });
 
   test("concurrent starts share acquisition and stop waits for acquisition and teardown", async () => {

--- a/packages/frontend/src/state/tasks/task-stream-controller.test.ts
+++ b/packages/frontend/src/state/tasks/task-stream-controller.test.ts
@@ -76,6 +76,7 @@ const createHarness = ({
   const taskViewSync: TaskViewSync = {
     loadWorkspace: async () => {},
     refreshManually: async () => {},
+    refreshAfterTaskRetentionChange: async () => {},
     refreshAfterLocalMutation: async () => {},
     reconcileExternalEvent: mock(async () => {}),
     reconcileStreamSnapshot: mock(async () => []),
@@ -568,6 +569,7 @@ describe("task stream controller recovery", () => {
       taskViewSync: {
         loadWorkspace: async () => {},
         refreshManually: async () => {},
+        refreshAfterTaskRetentionChange: async () => {},
         refreshAfterLocalMutation: async () => {},
         reconcileExternalEvent: async () => {},
         reconcileStreamSnapshot: async () => [],

--- a/packages/frontend/src/state/tasks/task-stream-controller.test.ts
+++ b/packages/frontend/src/state/tasks/task-stream-controller.test.ts
@@ -441,6 +441,39 @@ describe("task stream controller recovery", () => {
     expect(harness.records[1]?.unsubscribe).toHaveBeenCalledTimes(1);
   });
 
+  test("reports terminal snapshot failure when the recovery stream ends before a snapshot", async () => {
+    const snapshotFailure = new Error("snapshot failed");
+    const terminalFailure = new Error("recovery stream ended");
+    const notificationSink: TaskStreamNotificationSink = {
+      onChange: mock(async () => {}),
+      onSnapshot: mock(async () => {}),
+      onSnapshotFailed: mock(() => {}),
+      onFailure: mock(() => {}),
+    };
+    const harness = createHarness({
+      notificationSink,
+      taskViewSync: {
+        reconcileStreamSnapshot: async () => {
+          throw snapshotFailure;
+        },
+      },
+    });
+
+    await harness.controller.start();
+    harness.emit(0, { type: "snapshot_required", cursor: cursor(7), reason: "buffer_gap" });
+    await flush();
+
+    expect(harness.records).toHaveLength(2);
+    expect(notificationSink.onSnapshotFailed).not.toHaveBeenCalled();
+
+    harness.failTerminally(1, terminalFailure);
+    await flush();
+
+    expect(harness.records[1]?.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(notificationSink.onSnapshotFailed).toHaveBeenCalledTimes(1);
+    expect(notificationSink.onSnapshotFailed).toHaveBeenCalledWith(terminalFailure);
+  });
+
   test("keeps a terminal recovery acquisition failure in the degraded episode", async () => {
     const terminalFailure = new Error("stream ended");
     const recoveryFailure = new Error("replacement unavailable");

--- a/packages/frontend/src/state/tasks/task-stream-controller.ts
+++ b/packages/frontend/src/state/tasks/task-stream-controller.ts
@@ -32,6 +32,7 @@ export type TaskStreamController = {
 export type TaskStreamNotificationSink = {
   onChange(event: ExternalTaskSyncEvent): Promise<void>;
   onSnapshot(): Promise<void>;
+  onSnapshotFailed(cause: unknown): void;
   onFailure(cause: unknown): void;
 };
 
@@ -408,6 +409,12 @@ export const createTaskStreamController = ({
                   acknowledgementFailed,
                 ))
               ) {
+                if (!stopped && !acknowledgementFailed) {
+                  enqueueNotificationSink(() => {
+                    notificationSink?.onSnapshotFailed(error);
+                    return Promise.resolve();
+                  });
+                }
                 return;
               }
             }

--- a/packages/frontend/src/state/tasks/task-stream-controller.ts
+++ b/packages/frontend/src/state/tasks/task-stream-controller.ts
@@ -295,7 +295,14 @@ export const createTaskStreamController = ({
           (frame) => receive(owner, frame),
           (error) => {
             if (!isCurrentOwner(owner)) return;
-            void startRecovery(error, acknowledgedCursor, true).catch(reportDegraded);
+            void startRecovery(error, acknowledgedCursor, true).then((recovered) => {
+              if (!recovered && !stopped) {
+                enqueueNotificationSink(() => {
+                  notificationSink?.onSnapshotFailed(error);
+                  return Promise.resolve();
+                });
+              }
+            }, reportDegraded);
           },
         ),
       );


### PR DESCRIPTION
Opening OpenDucktor could show one Agent notification observation failure for each repository. The task stream cancels shared startup reads during its initial snapshot, and the notification observer treated that expected cancellation as a read failure.

## Summary

- Treat TanStack Query cancellation as an interrupted startup baseline while real read and stream failures remain visible.
- Keep live session requests buffered until the task snapshot restores task and session ownership.
- Restore the baseline-ready listener when React StrictMode replays effect cleanup and setup.
- Cover cancellation recovery with a real QueryClient and observer lifecycle replay.

## Scope

- No notification settings, copy, delivery, transport, or durable data changes.
- No polling, retry, or fallback path.

## Related issues

- OpenDucktor task openduckto-insc1

## Breaking changes

- None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification synchronization after interrupted or cancelled workspace startup.
  - Buffered notification updates now resume when a workspace baseline becomes available.
  - Notification observation remains active during temporary baseline interruptions and stops after unrecoverable failures.
  - Improved failure reporting when notification snapshots cannot be recovered.
  - Cleared interrupted synchronization state when workspaces are removed.
  - Improved task refresh behavior after retention settings change, including coordination with in-progress workspace loads.

- **Tests**
  - Added coverage for baseline recovery, snapshot failures, refresh serialization, and task-retention refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->