### PR TITLE
fix(resizable-panels): prevent setPointerCapture crash when a separator unmounts mid-drag

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -150,7 +150,7 @@
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-markdown": "^10.1.0",
-        "react-resizable-panels": "^4",
+        "react-resizable-panels": "^4.12.4",
         "react-router": "^8.3.1",
         "react-syntax-highlighter": "^16.1.1",
         "rehype-katex": "^7.0.1",
@@ -2014,7 +2014,7 @@
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
-    "react-resizable-panels": ["react-resizable-panels@4.12.3", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-GHMJWnDXui/3RX4bT+cgBP+N3N2nkwcoZATr/2xLFpqQQe7TlBrE0cGM0dUa9ceT7A90tUrSRsiqgRG+g0/2AA=="],
+    "react-resizable-panels": ["react-resizable-panels@4.12.4", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-SOsSj4e9U7vxL15MbgTfl35IO4vxSW4Xb0b1gtJVbRPWv7FOezcgOA00Mi0jP8XqC3y7jOQxpsGs/9zLKHPitA=="],
 
     "react-router": ["react-router@8.3.1", "", { "dependencies": { "cookie-es": "^3.1.1" }, "peerDependencies": { "react": ">=19.2.7", "react-dom": ">=19.2.7" }, "optionalPeers": ["react-dom"] }, "sha512-TEOpiO2g0TJHEOJeRVv4amUFun9v1npCKszvcquNvzETUtJ8udV86ah5eFoHT7g26bsBvT6EiIhqulR8eDF++A=="],
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -67,7 +67,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-markdown": "^10.1.0",
-    "react-resizable-panels": "^4",
+    "react-resizable-panels": "^4.12.4",
     "react-router": "^8.3.1",
     "react-syntax-highlighter": "^16.1.1",
     "rehype-katex": "^7.0.1",


### PR DESCRIPTION
## Problem

While using Agent Studio, a panel resize could crash the entire renderer with an uncaught runtime error: `InvalidStateError: Failed to execute 'setPointerCapture' on 'Element'`.

## Goal

We found that `react-resizable-panels` attaches pointer listeners to the document when a panel group mounts, and while a drag is active it calls `setPointerCapture` on the separator from the document `pointermove` handler.

Agent Studio conditionally unmounts separators (terminal panel and right panel) while the panel group stays mounted. When a separator unmounts mid-drag, the frozen drag state still references the detached element, so the next pointer move throws `InvalidStateError` and crashes the app.

Upstream identified this exact bug ([#743](https://github.com/bvaughn/react-resizable-panels/issues/743)) and fixed it in `react-resizable-panels@4.12.4` by skipping pointer capture when the separator is not connected. This PR upgrades the dependency to that version, so the drag never touches a detached element.