### PR TITLE
perf: reduce CPU use for live agent sessions

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -51,7 +51,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "vite": "^8.2.2",
-    "zod": "^4.4.3"
+    "zod": "^4.6.2"
   },
   "optionalDependencies": {
     "node-mac-permissions": "github:codebytere/node-mac-permissions#b2b0a18e4d21d6926fde1cd84d9124a0b8e6b755"

--- a/apps/electron/src/main/electron-host-event-forwarding.test.ts
+++ b/apps/electron/src/main/electron-host-event-forwarding.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { forwardElectronHostEvent } from "./electron-host-event-forwarding";
+import { electronHostEventChannel } from "../shared/electron-host-event-channel";
 
 describe("forwardElectronHostEvent", () => {
   test("reports one failed window send and continues forwarding to later windows", () => {
@@ -23,13 +24,12 @@ describe("forwardElectronHostEvent", () => {
           webContents: { isDestroyed: () => false, send: received },
         },
       ],
-      "openducktor:host-event",
       { channel: "openducktor://run-event", payload: { type: "run" } },
       report,
     );
 
     expect(report).toHaveBeenCalledWith({ channel: "openducktor://run-event", cause: failure });
-    expect(received).toHaveBeenCalledWith("openducktor:host-event", {
+    expect(received).toHaveBeenCalledWith(electronHostEventChannel("openducktor://run-event"), {
       channel: "openducktor://run-event",
       payload: { type: "run" },
     });

--- a/apps/electron/src/main/electron-host-event-forwarding.ts
+++ b/apps/electron/src/main/electron-host-event-forwarding.ts
@@ -1,5 +1,6 @@
 import type { HostEventChannel } from "@openducktor/contracts";
 import type { ElectronHostEventEnvelope } from "../shared/electron-bridge-contract";
+import { electronHostEventEnvelopeChannel } from "../shared/electron-host-event-channel";
 
 type ElectronHostEventWindow = {
   isDestroyed(): boolean;
@@ -11,10 +12,10 @@ type ElectronHostEventWindow = {
 
 export const forwardElectronHostEvent = (
   windows: readonly ElectronHostEventWindow[],
-  ipcChannel: string,
   envelope: ElectronHostEventEnvelope,
   reportDeliveryFailure: (failure: { channel: HostEventChannel; cause: unknown }) => void,
 ): void => {
+  const ipcChannel = electronHostEventEnvelopeChannel(envelope);
   for (const window of windows) {
     if (window.isDestroyed() || window.webContents.isDestroyed()) {
       continue;

--- a/apps/electron/src/main/electron-task-stream-ipc.ts
+++ b/apps/electron/src/main/electron-task-stream-ipc.ts
@@ -3,7 +3,6 @@ import {
   type TaskEventStreamFrame,
   type TaskEventStreamSubscribe,
   taskEventStreamAcknowledgeSchema,
-  taskEventStreamFrameSchema,
   taskEventStreamSubscribeSchema,
 } from "@openducktor/contracts";
 import type { EffectNodeHostCommandRouter } from "@openducktor/host";
@@ -269,14 +268,17 @@ export const registerElectronTaskStreamIpc = ({
         pendingFrames.push(frame);
         return;
       }
-      const parsedFrame = taskEventStreamFrameSchema.safeParse(frame);
-      if (!parsedFrame.success) {
+      const parsedEnvelope = electronTaskStreamFrameEnvelopeSchema.safeParse({
+        frame,
+        subscriptionId,
+      });
+      if (!parsedEnvelope.success) {
         reportDeliveryFailure({
           cause: validationError(
             "electron.task-stream.delivery.validate",
             "frame",
             "Task stream produced an invalid frame.",
-            { issues: jsonIssues(parsedFrame.error.issues) },
+            { issues: jsonIssues(parsedEnvelope.error.issues) },
           ),
           subscriptionId,
         });
@@ -302,13 +304,7 @@ export const registerElectronTaskStreamIpc = ({
         return;
       }
       try {
-        owner.senderFrame.send(
-          ELECTRON_TASK_STREAM_FRAME_CHANNEL,
-          electronTaskStreamFrameEnvelopeSchema.parse({
-            frame: parsedFrame.data,
-            subscriptionId,
-          }),
-        );
+        owner.senderFrame.send(ELECTRON_TASK_STREAM_FRAME_CHANNEL, parsedEnvelope.data);
       } catch (cause) {
         reportDeliveryFailure({ cause, subscriptionId });
         cleanup();

--- a/apps/electron/src/main/main.ts
+++ b/apps/electron/src/main/main.ts
@@ -45,7 +45,6 @@ import {
   ELECTRON_APP_UPDATE_GET_STATE_CHANNEL,
   ELECTRON_APP_UPDATE_INSTALL_CHANNEL,
   ELECTRON_APP_UPDATE_STATE_CHANGED_CHANNEL,
-  ELECTRON_HOST_EVENT_CHANNEL,
   ELECTRON_LOCAL_ATTACHMENT_PREVIEW_CHANNEL,
   ELECTRON_OPEN_EXTERNAL_URL_CHANNEL,
   type ElectronAppUpdateCheckInput,
@@ -531,7 +530,6 @@ const registerHostEventForwarding = (): void => {
     hostEventBus.subscribe(channel, (envelope) => {
       forwardElectronHostEvent(
         BrowserWindow.getAllWindows(),
-        ELECTRON_HOST_EVENT_CHANNEL,
         envelope,
         ({ channel: failedChannel, cause }) =>
           reportElectronNonFatalDeliveryFailure(

--- a/apps/electron/src/main/terminals/electron-terminal-ipc.ts
+++ b/apps/electron/src/main/terminals/electron-terminal-ipc.ts
@@ -2,6 +2,7 @@ import {
   decodeTerminalProtocolFrame,
   encodeTerminalProtocolFrame,
   isTerminalClientMessage,
+  withMaxUtf16Length,
 } from "@openducktor/contracts";
 import {
   createTerminalClientSession,
@@ -23,7 +24,7 @@ import type { IpcMain } from "electron";
 
 const MAX_CLIENT_ID_LENGTH = 128;
 
-const electronTerminalClientIdSchema = z.string().min(1).max(MAX_CLIENT_ID_LENGTH);
+const electronTerminalClientIdSchema = withMaxUtf16Length(z.string().min(1), MAX_CLIENT_ID_LENGTH);
 const electronTerminalFrameSchema = z.instanceof(Uint8Array);
 const electronTerminalSendRequestSchema = z.strictObject({
   clientId: electronTerminalClientIdSchema,

--- a/apps/electron/src/preload/electron-host-events.test.ts
+++ b/apps/electron/src/preload/electron-host-events.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, mock, spyOn, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import type { HostEventEnvelope, HostEventPayload } from "@openducktor/contracts";
 import type { IpcRendererEvent } from "electron";
-import { ELECTRON_HOST_EVENT_CHANNEL } from "../shared/electron-bridge-contract";
+import { electronHostEventChannel } from "../shared/electron-host-event-channel";
+import { forwardElectronHostEvent } from "../main/electron-host-event-forwarding";
 import { type ElectronHostEventListener, subscribeElectronHostEvent } from "./electron-host-events";
 
 describe("subscribeElectronHostEvent", () => {
@@ -39,9 +42,168 @@ describe("subscribeElectronHostEvent", () => {
       expect(listener).toHaveBeenCalledWith({ runId: "run-1" });
       expect(error).toHaveBeenCalledTimes(1);
       unsubscribe();
-      expect(ipcRenderer.off).toHaveBeenCalledWith(ELECTRON_HOST_EVENT_CHANNEL, receive);
+      expect(ipcRenderer.off).toHaveBeenCalledWith(
+        electronHostEventChannel("openducktor://run-event"),
+        receive,
+      );
     } finally {
       error.mockRestore();
     }
+  });
+
+  test("routes main-process events to the matching repository and ignores unobserved channels", () => {
+    const ipcRenderer = new EventEmitter();
+    const first = mock(() => {});
+    const second = mock(() => {});
+    const error = spyOn(console, "error").mockImplementation(() => {});
+    const report = mock(() => {});
+    const stopFirst = subscribeElectronHostEvent(
+      ipcRenderer,
+      "openducktor://agent-session-live-event",
+      first,
+      "/repo:a",
+    );
+    const stopSecond = subscribeElectronHostEvent(
+      ipcRenderer,
+      "openducktor://agent-session-live-event",
+      second,
+      "/repo:a/b",
+    );
+    const payload = { type: "snapshot", repoPath: "/repo:a", sessions: [] } as const;
+    try {
+      const envelope: HostEventEnvelope = {
+        channel: "openducktor://agent-session-live-event",
+        payload: { ...payload, sessions: [] },
+      };
+      forwardElectronHostEvent(
+        [
+          {
+            isDestroyed: () => false,
+            webContents: {
+              isDestroyed: () => false,
+              send: (channel, event) => {
+                ipcRenderer.emit(channel, {}, event);
+              },
+            },
+          },
+        ],
+        envelope,
+        report,
+      );
+      expect(first).toHaveBeenCalledWith(payload);
+      expect(second).not.toHaveBeenCalled();
+      expect(report).not.toHaveBeenCalled();
+      expect(
+        ipcRenderer.emit(
+          electronHostEventChannel("openducktor://run-event"),
+          {},
+          { invalid: true },
+        ),
+      ).toBe(false);
+      expect(
+        ipcRenderer.emit(
+          electronHostEventChannel("openducktor://agent-session-live-event", "/other"),
+          {},
+          { invalid: true },
+        ),
+      ).toBe(false);
+      expect(error).not.toHaveBeenCalled();
+      ipcRenderer.emit(
+        electronHostEventChannel("openducktor://agent-session-live-event", "/repo:a/b"),
+        {},
+        envelope,
+      );
+      expect(second).not.toHaveBeenCalled();
+      expect(error).toHaveBeenCalledTimes(1);
+    } finally {
+      stopFirst();
+      stopSecond();
+      error.mockRestore();
+    }
+    expect(ipcRenderer.eventNames()).toEqual([]);
+  });
+
+  test("shares validation across duplicate subscriptions and removes the route after the last unsubscribe", () => {
+    const ipcRenderer = new EventEmitter();
+    const channel = electronHostEventChannel("openducktor://run-event");
+    const received: unknown[] = [];
+    const listener = (payload: HostEventPayload<"openducktor://run-event">) =>
+      received.push(payload);
+    const stopFirst = subscribeElectronHostEvent(ipcRenderer, "openducktor://run-event", listener);
+    const stopSecond = subscribeElectronHostEvent(ipcRenderer, "openducktor://run-event", listener);
+    const error = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(ipcRenderer.listenerCount(channel)).toBe(1);
+      ipcRenderer.emit(
+        channel,
+        {},
+        { channel: "openducktor://run-event", payload: { runId: "first" } },
+      );
+      expect(received).toEqual([{ runId: "first" }, { runId: "first" }]);
+      ipcRenderer.emit(channel, {}, { channel: "openducktor://run-event", payload: null });
+      expect(error).toHaveBeenCalledTimes(1);
+      stopFirst();
+      stopFirst();
+      expect(ipcRenderer.listenerCount(channel)).toBe(1);
+      ipcRenderer.emit(
+        channel,
+        {},
+        { channel: "openducktor://run-event", payload: { runId: "second" } },
+      );
+      expect(received).toEqual([{ runId: "first" }, { runId: "first" }, { runId: "second" }]);
+      stopSecond();
+      expect(ipcRenderer.listenerCount(channel)).toBe(0);
+      const stopThird = subscribeElectronHostEvent(
+        ipcRenderer,
+        "openducktor://run-event",
+        listener,
+      );
+      expect(ipcRenderer.listenerCount(channel)).toBe(1);
+      stopSecond();
+      expect(ipcRenderer.listenerCount(channel)).toBe(1);
+      stopThird();
+    } finally {
+      stopFirst();
+      stopSecond();
+      error.mockRestore();
+    }
+    expect(ipcRenderer.eventNames()).toEqual([]);
+  });
+
+  test("keeps the current dispatch order when a callback replaces another subscription", () => {
+    const ipcRenderer = new EventEmitter();
+    const channel = electronHostEventChannel("openducktor://run-event");
+    const calls: string[] = [];
+    const stops: Array<() => void> = [];
+    let replaceSecond = () => {};
+    stops.push(
+      subscribeElectronHostEvent(ipcRenderer, "openducktor://run-event", () => {
+        calls.push("first");
+        replaceSecond();
+      }),
+    );
+    const stopSecond = subscribeElectronHostEvent(ipcRenderer, "openducktor://run-event", () =>
+      calls.push("second"),
+    );
+    stops.push(stopSecond);
+    replaceSecond = () => {
+      stopSecond();
+      stops.push(
+        subscribeElectronHostEvent(ipcRenderer, "openducktor://run-event", () =>
+          calls.push("third"),
+        ),
+      );
+      replaceSecond = () => {};
+    };
+    try {
+      const envelope = { channel: "openducktor://run-event", payload: {} };
+      ipcRenderer.emit(channel, {}, envelope);
+      expect(calls).toEqual(["first", "second"]);
+      ipcRenderer.emit(channel, {}, envelope);
+      expect(calls).toEqual(["first", "second", "first", "third"]);
+    } finally {
+      for (const stop of stops) stop();
+    }
+    expect(ipcRenderer.eventNames()).toEqual([]);
   });
 });

--- a/apps/electron/src/preload/electron-host-events.ts
+++ b/apps/electron/src/preload/electron-host-events.ts
@@ -1,11 +1,10 @@
-import {
-  type HostEventChannel,
-  type HostEventPayload,
-  type HostEventWireEnvelope,
-  hostEventEnvelopeSchema,
-} from "@openducktor/contracts";
+import { type HostEventWireEnvelope, hostEventEnvelopeSchema } from "@openducktor/contracts";
 import type { IpcRendererEvent } from "electron";
-import { ELECTRON_HOST_EVENT_CHANNEL } from "../shared/electron-bridge-contract";
+import type { ElectronHostEventSubscription } from "../shared/electron-bridge-contract";
+import {
+  electronHostEventChannel,
+  electronHostEventEnvelopeChannel,
+} from "../shared/electron-host-event-channel";
 
 export type ElectronHostEventWireEnvelope = HostEventWireEnvelope;
 export type ElectronHostEventListener = (
@@ -17,41 +16,65 @@ type ElectronHostEventIpcRenderer = {
   on(channel: string, listener: ElectronHostEventListener): void;
 };
 
-type ElectronHostEventSubscription = {
-  [Channel in HostEventChannel]: readonly [
-    channel: Channel,
-    listener: (payload: HostEventPayload<Channel>) => void,
-  ];
-}[HostEventChannel];
+type ElectronHostEventRoute = {
+  handleEvent: ElectronHostEventListener;
+  subscriptions: Set<ElectronHostEventSubscription>;
+};
+const routesByRenderer = new WeakMap<
+  ElectronHostEventIpcRenderer,
+  Map<string, ElectronHostEventRoute>
+>();
 
-export function subscribeElectronHostEvent<Channel extends HostEventChannel>(
-  ipcRenderer: ElectronHostEventIpcRenderer,
-  channel: Channel,
-  listener: (payload: HostEventPayload<Channel>) => void,
-): () => void;
 export function subscribeElectronHostEvent(
   ipcRenderer: ElectronHostEventIpcRenderer,
   ...subscription: ElectronHostEventSubscription
 ): () => void {
-  const handleEvent: ElectronHostEventListener = (_event, envelope) => {
-    const parsed = hostEventEnvelopeSchema.safeParse(envelope);
-    if (!parsed.success) {
-      console.error("Received invalid host event from Electron main process.", {
-        issues: parsed.error.issues,
-      });
-      return;
-    }
-    if (parsed.data.channel === "openducktor://run-event") {
-      if (subscription[0] === parsed.data.channel) subscription[1](parsed.data.payload);
-      return;
-    }
-    if (parsed.data.channel === "openducktor://dev-server-event") {
-      if (subscription[0] === parsed.data.channel) subscription[1](parsed.data.payload);
-      return;
-    }
-    if (subscription[0] === parsed.data.channel) subscription[1](parsed.data.payload);
-  };
+  const ipcChannel =
+    subscription[0] === "openducktor://agent-session-live-event"
+      ? electronHostEventChannel(subscription[0], subscription[2])
+      : electronHostEventChannel(subscription[0]);
+  let routes = routesByRenderer.get(ipcRenderer);
+  if (!routes) {
+    routes = new Map();
+    routesByRenderer.set(ipcRenderer, routes);
+  }
+  let route = routes.get(ipcChannel);
+  if (!route) {
+    const subscriptions = new Set<ElectronHostEventSubscription>();
+    const handleEvent: ElectronHostEventListener = (_event, envelope) => {
+      const parsed = hostEventEnvelopeSchema.safeParse(envelope);
+      if (!parsed.success) {
+        console.error("Received invalid host event from Electron main process.", {
+          issues: parsed.error.issues,
+        });
+        return;
+      }
+      const hostEvent = parsed.data;
+      if (electronHostEventEnvelopeChannel(hostEvent) !== ipcChannel) {
+        console.error("Received host event on the wrong Electron IPC channel.");
+        return;
+      }
+      // oxlint-disable-next-line unicorn/no-useless-spread -- preserve EventEmitter dispatch order when callbacks change subscriptions
+      for (const active of [...subscriptions]) {
+        if (hostEvent.channel === "openducktor://run-event") {
+          if (active[0] === hostEvent.channel) active[1](hostEvent.payload);
+        } else if (hostEvent.channel === "openducktor://dev-server-event") {
+          if (active[0] === hostEvent.channel) active[1](hostEvent.payload);
+        } else if (active[0] === hostEvent.channel) {
+          active[1](hostEvent.payload);
+        }
+      }
+    };
+    route = { handleEvent, subscriptions };
+    routes.set(ipcChannel, route);
+    ipcRenderer.on(ipcChannel, handleEvent);
+  }
+  route.subscriptions.add(subscription);
 
-  ipcRenderer.on(ELECTRON_HOST_EVENT_CHANNEL, handleEvent);
-  return () => ipcRenderer.off(ELECTRON_HOST_EVENT_CHANNEL, handleEvent);
+  return () => {
+    if (!route.subscriptions.delete(subscription) || route.subscriptions.size > 0) return;
+    ipcRenderer.off(ipcChannel, route.handleEvent);
+    routes.delete(ipcChannel);
+    if (routes.size === 0) routesByRenderer.delete(ipcRenderer);
+  };
 }

--- a/apps/electron/src/preload/preload.ts
+++ b/apps/electron/src/preload/preload.ts
@@ -152,8 +152,8 @@ const notifications: OpenDucktorElectronNotificationApi = {
 const electronApi: OpenDucktorElectronApi = {
   platform: appPlatformSchema.parse(process.platform),
   invoke: invokeHost,
-  subscribe(channel, listener) {
-    return subscribeElectronHostEvent(ipcRenderer, channel, listener);
+  subscribe(...subscription) {
+    return subscribeElectronHostEvent(ipcRenderer, ...subscription);
   },
   appUpdates,
   notifications,

--- a/apps/electron/src/renderer/electron-shell-bridge.test.ts
+++ b/apps/electron/src/renderer/electron-shell-bridge.test.ts
@@ -216,6 +216,7 @@ describe("electron shell bridge", () => {
     expect(electronApi.subscribe).toHaveBeenCalledWith(
       "openducktor://agent-session-live-event",
       expect.any(Function),
+      "/repo",
     );
     expect(electronApi.invoke).toHaveBeenCalledWith("agent_session_live_refresh", {
       repoPath: "/repo",

--- a/apps/electron/src/renderer/electron-shell-bridge.ts
+++ b/apps/electron/src/renderer/electron-shell-bridge.ts
@@ -82,9 +82,11 @@ export const createElectronShellBridge = (): ShellBridge => {
     },
     observeAgentSessionLive: async (input, listener) => {
       const attachment = createAgentSessionLiveAttachment(input.repoPath, listener);
-      const unsubscribe = electronApi.subscribe(AGENT_SESSION_LIVE_EVENT_CHANNEL, (payload) => {
-        attachment.accept(payload);
-      });
+      const unsubscribe = electronApi.subscribe(
+        AGENT_SESSION_LIVE_EVENT_CHANNEL,
+        attachment.accept,
+        input.repoPath,
+      );
       try {
         await client.agentSessionLiveRefresh(input);
       } catch (cause) {

--- a/apps/electron/src/shared/electron-bridge-contract.ts
+++ b/apps/electron/src/shared/electron-bridge-contract.ts
@@ -101,6 +101,16 @@ export type ElectronHostInvokeResponseEnvelope = z.output<typeof electronHostInv
 
 export type ElectronHostEventEnvelope = HostEventEnvelope;
 
+export type ElectronHostEventSubscription = {
+  [Channel in HostEventChannel]: Channel extends "openducktor://agent-session-live-event"
+    ? readonly [
+        channel: Channel,
+        listener: (payload: HostEventPayload<Channel>) => void,
+        repoPath: string,
+      ]
+    : readonly [channel: Channel, listener: (payload: HostEventPayload<Channel>) => void];
+}[HostEventChannel];
+
 export type ElectronTerminalEventEnvelope = {
   clientId: string;
   frame: Uint8Array;
@@ -187,10 +197,7 @@ export type OpenDucktorElectronApi = {
     command: HostCommandName,
     args?: ElectronHostInvokeRequest["args"],
   ): Promise<ElectronHostInvokeWireResult>;
-  subscribe<Channel extends HostEventChannel>(
-    channel: Channel,
-    listener: (payload: HostEventPayload<Channel>) => void,
-  ): () => void;
+  subscribe(...subscription: ElectronHostEventSubscription): () => void;
   appUpdates: OpenDucktorElectronAppUpdateApi;
   notifications: OpenDucktorElectronNotificationApi;
   openExternalUrl(url: string): Promise<void>;

--- a/apps/electron/src/shared/electron-host-event-channel.ts
+++ b/apps/electron/src/shared/electron-host-event-channel.ts
@@ -1,0 +1,15 @@
+import type { HostEventChannel, HostEventEnvelope } from "@openducktor/contracts";
+import { agentSessionLiveEnvelopeRepoPath } from "@openducktor/host-client";
+import { ELECTRON_HOST_EVENT_CHANNEL } from "./electron-bridge-contract";
+
+type ElectronHostEventScope =
+  | [channel: Exclude<HostEventChannel, "openducktor://agent-session-live-event">]
+  | [channel: "openducktor://agent-session-live-event", repoPath: string];
+
+export const electronHostEventChannel = (...scope: ElectronHostEventScope): string =>
+  `${ELECTRON_HOST_EVENT_CHANNEL}:${JSON.stringify(scope)}`;
+
+export const electronHostEventEnvelopeChannel = (envelope: HostEventEnvelope): string =>
+  envelope.channel === "openducktor://agent-session-live-event"
+    ? electronHostEventChannel(envelope.channel, agentSessionLiveEnvelopeRepoPath(envelope.payload))
+    : electronHostEventChannel(envelope.channel);

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "oxlint": "^1.80.0",
         "typescript": "^7.0.2",
         "yaml": "^2.9.0",
-        "zod": "^4.4.3",
+        "zod": "^4.6.2",
       },
     },
     "apps/electron": {
@@ -45,7 +45,7 @@
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "vite": "^8.2.2",
-        "zod": "^4.4.3",
+        "zod": "^4.6.2",
       },
       "optionalDependencies": {
         "node-mac-permissions": "github:codebytere/node-mac-permissions#b2b0a18e4d21d6926fde1cd84d9124a0b8e6b755",
@@ -59,7 +59,7 @@
         "@openducktor/contracts": "workspace:*",
         "@openducktor/core": "workspace:*",
         "@openducktor/path-support": "workspace:*",
-        "zod": "^4.4.3",
+        "zod": "^4.6.2",
       },
     },
     "packages/adapters-opencode-sdk": {
@@ -71,7 +71,7 @@
         "@openducktor/core": "workspace:*",
         "@openducktor/path-support": "workspace:*",
         "undici": "^8.10.2",
-        "zod": "^4.4.3",
+        "zod": "^4.6.2",
       },
     },
     "packages/build-tools": {
@@ -85,7 +85,7 @@
       "name": "@openducktor/contracts",
       "version": "0.6.3",
       "dependencies": {
-        "zod": "^4.4.3",
+        "zod": "^4.6.2",
       },
     },
     "packages/core": {
@@ -94,7 +94,7 @@
       "dependencies": {
         "@openducktor/contracts": "workspace:*",
         "@openducktor/path-support": "workspace:*",
-        "zod": "^4.4.3",
+        "zod": "^4.6.2",
       },
     },
     "packages/frontend": {
@@ -161,7 +161,7 @@
         "tailwind-merge": "^3.6.0",
         "unified": "^11.0.5",
         "unist-util-visit": "^5.0.0",
-        "zod": "^4.4.3",
+        "zod": "^4.6.2",
         "zustand": "^5.0.15",
       },
       "devDependencies": {
@@ -196,7 +196,7 @@
         "remark-parse": "^11.0.0",
         "unified": "^11.0.5",
         "unist-util-visit": "^5.0.0",
-        "zod": "^4.4.3",
+        "zod": "^4.6.2",
       },
       "devDependencies": {
         "@types/node": "^26.4.0",
@@ -210,7 +210,7 @@
       "dependencies": {
         "@openducktor/contracts": "workspace:*",
         "@openducktor/core": "workspace:*",
-        "zod": "^4.4.3",
+        "zod": "^4.6.2",
       },
     },
     "packages/openducktor-mcp": {
@@ -221,7 +221,7 @@
       },
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
-        "zod": "^4.4.3",
+        "zod": "^4.6.2",
       },
       "devDependencies": {
         "@openducktor/build-tools": "workspace:*",
@@ -240,7 +240,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.251",
         "undici": "^8.10.2",
-        "zod": "^4.4.3",
+        "zod": "^4.6.2",
       },
       "devDependencies": {
         "@openducktor/build-tools": "workspace:*",
@@ -2296,7 +2296,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+    "zod": ["zod@4.6.2", "", {}, "sha512-lh5RCAGFa1Cm2hjtNwLQhSs/AsqdWnTQaBER9fEwN/88pSh7KOtJavtBx/0VlkN/uFd61SwYmljLMDAsHlvzBQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,4 +32,5 @@ Use this index to find the document for your task.
 
 - [MCP runtime security](mcp-runtime-security.md) defines the allowed MCP transport and threat assumptions.
 - [Dependency hygiene](dependency-hygiene.md) defines dependency checks and update rules.
+- [Performance audits](performance-audits.md) explains how to diagnose CPU, memory, and response-time issues and verify fixes in Electron and the browser runner.
 - [Release process](release-process.md) defines desktop, web, MCP, and Homebrew releases.

--- a/docs/performance-audits.md
+++ b/docs/performance-audits.md
@@ -29,7 +29,7 @@ A replay isolates a cause. A live application check confirms that the optimized 
 | Schema constructors or allocation inside an event loop | Whether an immutable schema can live at module scope; whether a caller rebuilds the same schema | Fewer allocations with the same parsed output and errors |
 | Repeated recursive parsing of large payloads | Where data first crosses a trust boundary; whether a later consumer already receives a validated value | Full validation at the boundary, with no repeated traversal inside that boundary |
 | Session-array scans on every event | Whether lookup cost grows with all sessions; whether an index can use the event identity | Correct lookup after add, replace, remove, reconnect, and disposal |
-| Parsing events that no listener uses | Whether transport delivery can select a channel and repository before parsing the full payload | Unobserved routes do no parsing; observed routes still reject invalid or mismatched envelopes |
+| Parsing events that no listener uses | Whether transport delivery can select a channel and repository before parsing the full payload | Unobserved routes cause no parsing; observed routes still reject invalid or mismatched envelopes |
 | JSON formatting or tree traversal while a UI section is closed | Whether the UI computes hidden content or walks tool input more than once | Closed sections avoid the work; opening them preserves content and interaction |
 
 Check cumulative cost and call count together. A cheap function called for every session on every event can cost more than an expensive function called once. Test event mixes with no relevant events, some relevant events, and all relevant events. Vary session count and payload size independently to expose growth with input size.

--- a/docs/performance-audits.md
+++ b/docs/performance-audits.md
@@ -1,0 +1,66 @@
+# Audit performance issues
+
+Use this guide when OpenDucktor uses too much CPU, allocates too much memory, or responds slowly. The audit is complete when the affected workflow is faster, preserves its behavior, and passes the required checks in both Electron and the browser runner.
+
+Read the [architecture overview](architecture-overview.md) to find the process and package that own the work. Follow the [runtime integration guide](runtime-integration-guide.md) when the change affects runtime data. Use the [testing guide](testing.md) for test scope and [CONTRIBUTING.md](../CONTRIBUTING.md) for current commands.
+
+## Audit steps
+
+1. Define the slow action and record its starting state. Include the platform, runtime, session count, history size, event rate, and whether the app is idle or active. Repeat the action until the symptom is stable. Keep task-store reads read-only and use temporary data for writes.
+2. Find the process that spends the CPU time. Measure Electron main and renderer processes, the browser renderer and host process, and external runtime processes separately. Capture a profile during the slow action. A single process CPU percentage does not identify the cause.
+3. Trace the costly stack to its input and callers. Count how often it runs and how much data it visits. Test one cause at a time with the same input. Keep a hypothesis only if a measurement supports it.
+4. Change the owning code and compare it with the unchanged source. Replay identical inputs through the real functions, then repeat the user action in both applications. Check full ordered outputs and failure behavior as well as time.
+5. Run all required repository checks and resolve their failures. Report the before and after measurements, behavior checks, and actual platform coverage. A failed test or missing platform check leaves the work incomplete.
+
+## Measure work, not only elapsed time
+
+Record CPU time, elapsed time, input size, event count, and output count. CPU time can exceed elapsed time when several threads run at once. Include retained memory when the profile suggests a cache or subscription leak. Check memory again after cleanup.
+
+Run at least three measured samples per version. Warm up each version with the same input, alternate their run order, and keep background work stable. Report the median and range. Measure startup separately when moving work to module initialization or compiling a parser.
+
+Use the runtime that executes the production path. Bun test results do not predict V8 performance. Electron in Node mode can measure main-process JavaScript, but it does not exercise native IPC, the context bridge, Chromium rendering, or browser security policy. Confirm those paths in a running application.
+
+A replay isolates a cause. A live application check confirms that the optimized code receives the real workload. Keep these claims separate. Do not add savings from separate replays to predict whole-application CPU use.
+
+## Inspect repeated work
+
+| Profile evidence | What to inspect | What proves the change |
+| --- | --- | --- |
+| Schema constructors or allocation inside an event loop | Whether an immutable schema can live at module scope; whether a caller rebuilds the same schema | Fewer allocations with the same parsed output and errors |
+| Repeated recursive parsing of large payloads | Where data first crosses a trust boundary; whether a later consumer already receives a validated value | Full validation at the boundary, with no repeated traversal inside that boundary |
+| Session-array scans on every event | Whether lookup cost grows with all sessions; whether an index can use the event identity | Correct lookup after add, replace, remove, reconnect, and disposal |
+| Parsing events that no listener uses | Whether transport delivery can select a channel and repository before parsing the full payload | Unobserved routes do no parsing; observed routes still reject invalid or mismatched envelopes |
+| JSON formatting or tree traversal while a UI section is closed | Whether the UI computes hidden content or walks tool input more than once | Closed sections avoid the work; opening them preserves content and interaction |
+
+Check cumulative cost and call count together. A cheap function called for every session on every event can cost more than an expensive function called once. Test event mixes with no relevant events, some relevant events, and all relevant events. Vary session count and payload size independently to expose growth with input size.
+
+Preserve identity and ownership. An index must handle replacement and removal. A shared event listener must retain registration order, independent unsubscribe behavior, and cleanup after the last observer. Check initial snapshots, reconnects, buffered events, and errors during setup.
+
+## Preserve validation contracts
+
+Validate untrusted input at each process or network boundary. Within one boundary, pass the parsed value to typed consumers. Routing metadata can avoid work for unobserved events, but it does not make an observed payload valid. Validate that payload and confirm its route before delivery.
+
+Read the installed dependency source and its official contract before changing parser behavior. Use supported APIs. Measure schema compilation on the actual hot path, including its startup cost. Confirm that each target runtime and its security policy permit the compilation method.
+
+Compare accepted inputs, rejected inputs, and complete parsed outputs. Include defaults, transforms, unknown keys, recursive values, and error paths. For dependency upgrades, also check Unicode length limits, timestamp precision, public schema exports, and generated schemas used by external tools. These can change even when common valid inputs still pass.
+
+Use full output equality or a hash of the complete ordered output. Matching counts alone can hide dropped fields, wrong session routing, duplicate events, or changed defaults. Add regression tests for the cause and its meaningful failure cases. Keep machine-specific timing thresholds out of unit tests.
+
+## Verify both applications
+
+Shared code does not prove shared coverage. Trace each changed path from the Electron entry point and from the browser entry point. Record where their transports or lifecycle rules differ.
+
+| Path | Electron check | Browser check |
+| --- | --- | --- |
+| Host and runtime adapters | Exercise the desktop host and selected runtime route | Exercise the web host and selected runtime route |
+| Host events | Exercise main-process forwarding, preload validation, context-bridge delivery, and observer cleanup | Exercise server event names, EventSource delivery, validation, and observer cleanup |
+| Task stream | Exercise IPC envelope delivery, acknowledgement, and terminal failure | Exercise stream frames, acknowledgement, reconnect, and terminal failure |
+| Shared UI | Repeat the affected interaction in the Electron renderer | Repeat it in the supported browser |
+
+Verify malformed input, wrong repository scope, removal, and resubscription where they affect the change. Use temporary application state when a check creates records. Keep failures visible. If the test environment denies a required local socket or process operation, obtain that access and rerun the check; changing the assertion or skipping the test does not resolve the failure.
+
+## Keep useful evidence
+
+Keep temporary replay scripts, raw profiles, logs, process IDs, local ports, and dated measurements outside the source tree. Store the audit result with its task or review. Include the source revision, runtime versions, input shape, reproduction steps, sample results, output comparison, and remaining verification limits.
+
+Add lasting lessons to this guide only when they change how a future audit should proceed. Keep current file names, dependency versions, commands, and architecture details in their existing sources. This avoids a second copy that becomes stale.

--- a/docs/web-runner.md
+++ b/docs/web-runner.md
@@ -77,6 +77,8 @@ Without `--base-path`, the browser reaches the host on the backend port, so the 
 
 Shared frontend code cannot import shell internals. `bun run frontend:boundary-guard` checks this rule.
 
+The `/events` endpoint authenticates the host session and streams the shared event bus for all repositories. Repository names select browser listeners; they do not restrict access. The transport does not support sessions authorized for only one repository.
+
 The `/events` endpoint keeps one SSE connection and one replay cursor for non-task host events. Run and dev-server events use the `message` event name. Live-session events use `agent-session-live:` followed by the JSON-encoded repository path. The browser registers a named listener for each observed repository and validates each delivered envelope. Events for unobserved repositories still cross the connection and advance its cursor, but do not trigger JSON parsing or transcript validation in JavaScript. Replay gap warnings and reconnect refreshes apply to all active observers. Restart the host and reload the browser together when this event framing changes.
 
 ## Access control

--- a/docs/web-runner.md
+++ b/docs/web-runner.md
@@ -77,6 +77,8 @@ Without `--base-path`, the browser reaches the host on the backend port, so the 
 
 Shared frontend code cannot import shell internals. `bun run frontend:boundary-guard` checks this rule.
 
+The `/events` endpoint keeps one SSE connection and one replay cursor for non-task host events. Run and dev-server events use the `message` event name. Live-session events use `agent-session-live:` followed by the JSON-encoded repository path. The browser registers a named listener for each observed repository and validates each delivered envelope. Events for unobserved repositories still cross the connection and advance its cursor, but do not trigger JSON parsing or transcript validation in JavaScript. Replay gap warnings and reconnect refreshes apply to all active observers. Restart the host and reload the browser together when this event framing changes.
+
 ## Access control
 
 The launcher creates two tokens for each run:

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "oxlint": "^1.80.0",
     "typescript": "^7.0.2",
     "yaml": "^2.9.0",
-    "zod": "^4.4.3"
+    "zod": "^4.6.2"
   },
   "overrides": {
     "@hono/node-server": "^1.19.11",

--- a/packages/adapters-codex-app-server/package.json
+++ b/packages/adapters-codex-app-server/package.json
@@ -15,6 +15,6 @@
     "@openducktor/contracts": "workspace:*",
     "@openducktor/core": "workspace:*",
     "@openducktor/path-support": "workspace:*",
-    "zod": "^4.4.3"
+    "zod": "^4.6.2"
   }
 }

--- a/packages/adapters-codex-app-server/src/codex-app-server-shared.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-shared.ts
@@ -8,6 +8,7 @@ export const unsupported = (surface: string): never => {
 };
 
 const codexStringValueSchema = z.string();
+const codexJsonValueSchema = z.json();
 
 export const isPlainObject = (
   value: CodexAppServerJsonValue | undefined,
@@ -68,7 +69,7 @@ export const parseCodexJsonObjectString = (
   }
 
   try {
-    const parsed = z.json().safeParse(JSON.parse(text));
+    const parsed = codexJsonValueSchema.safeParse(JSON.parse(text));
     return parsed.success && isPlainObject(parsed.data) ? parsed.data : null;
   } catch {
     return null;

--- a/packages/adapters-opencode-sdk/package.json
+++ b/packages/adapters-opencode-sdk/package.json
@@ -16,6 +16,6 @@
     "@openducktor/core": "workspace:*",
     "@openducktor/path-support": "workspace:*",
     "undici": "^8.10.2",
-    "zod": "^4.4.3"
+    "zod": "^4.6.2"
   }
 }

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -7,11 +7,11 @@ import type {
 } from "@opencode-ai/sdk/v2/client";
 import type { OpenCodeProtocolObject } from "./guards";
 import type { AgentEvent, AgentModelSelection, AgentUserMessagePart } from "@openducktor/core";
+import { processOpencodeEvent, subscribeGlobalEvents } from "./event-stream";
 import {
   isRelevantSubscriberEvent,
-  processOpencodeEvent,
-  subscribeGlobalEvents,
-} from "./event-stream";
+  resolveOpencodeEventRecipients,
+} from "./opencode-event-recipients";
 import {
   type EventStreamRuntime,
   flushPendingSubagentInputEventsForSession,
@@ -2348,22 +2348,24 @@ describe("event-stream", () => {
       input: makeSessionInput(),
     };
 
-    expect(isRelevantSubscriberEvent(parentSubscriber, childPermissionEvent)).toBe(false);
+    const parentByChild = new Map([["external-child-session", parentSubscriber.externalSessionId]]);
     expect(
-      isRelevantSubscriberEvent(parentSubscriber, childPermissionEvent, {
-        resolveParentExternalSessionId: (externalSessionId) =>
-          externalSessionId === "external-child-session"
-            ? parentSubscriber.externalSessionId
-            : undefined,
-      }),
+      isRelevantSubscriberEvent(
+        parentSubscriber,
+        resolveOpencodeEventRecipients(childPermissionEvent, new Map()),
+      ),
+    ).toBe(false);
+    expect(
+      isRelevantSubscriberEvent(
+        parentSubscriber,
+        resolveOpencodeEventRecipients(childPermissionEvent, parentByChild),
+      ),
     ).toBe(true);
     expect(
-      isRelevantSubscriberEvent(parentSubscriber, childMessageEvent, {
-        resolveParentExternalSessionId: (externalSessionId) =>
-          externalSessionId === "external-child-session"
-            ? parentSubscriber.externalSessionId
-            : undefined,
-      }),
+      isRelevantSubscriberEvent(
+        parentSubscriber,
+        resolveOpencodeEventRecipients(childMessageEvent, parentByChild),
+      ),
     ).toBe(false);
   });
 
@@ -2376,10 +2378,9 @@ describe("event-stream", () => {
       externalSessionId: "external-explicit-parent",
       input: makeSessionInput(),
     };
-    const resolveConfirmedParent = (externalSessionId: string) =>
-      externalSessionId === "external-child-session"
-        ? confirmedParentSubscriber.externalSessionId
-        : undefined;
+    const parentByChild = new Map([
+      ["external-child-session", confirmedParentSubscriber.externalSessionId],
+    ]);
 
     for (const eventType of [
       "permission.asked",
@@ -2396,16 +2397,9 @@ describe("event-stream", () => {
         },
       } satisfies OpenCodeProtocolObject;
 
-      expect(
-        isRelevantSubscriberEvent(confirmedParentSubscriber, event, {
-          resolveParentExternalSessionId: resolveConfirmedParent,
-        }),
-      ).toBe(true);
-      expect(
-        isRelevantSubscriberEvent(explicitParentSubscriber, event, {
-          resolveParentExternalSessionId: resolveConfirmedParent,
-        }),
-      ).toBe(false);
+      const recipients = resolveOpencodeEventRecipients(event, parentByChild);
+      expect(isRelevantSubscriberEvent(confirmedParentSubscriber, recipients)).toBe(true);
+      expect(isRelevantSubscriberEvent(explicitParentSubscriber, recipients)).toBe(false);
     }
   });
 
@@ -2426,8 +2420,9 @@ describe("event-stream", () => {
       input: makeSessionInput(),
     };
 
-    expect(isRelevantSubscriberEvent(parentSubscriber, childSessionCreatedEvent)).toBe(false);
-    expect(isRelevantSubscriberEvent(otherSubscriber, childSessionCreatedEvent)).toBe(false);
+    const recipients = resolveOpencodeEventRecipients(childSessionCreatedEvent, new Map());
+    expect(isRelevantSubscriberEvent(parentSubscriber, recipients)).toBe(false);
+    expect(isRelevantSubscriberEvent(otherSubscriber, recipients)).toBe(false);
   });
 
   test("does not treat lifecycle parent aliases as authoritative", () => {
@@ -2443,7 +2438,12 @@ describe("event-stream", () => {
         parentSubscriber.externalSessionId,
       );
 
-      expect(isRelevantSubscriberEvent(parentSubscriber, lifecycleEvent)).toBe(false);
+      expect(
+        isRelevantSubscriberEvent(
+          parentSubscriber,
+          resolveOpencodeEventRecipients(lifecycleEvent, new Map()),
+        ),
+      ).toBe(false);
     }
   });
 
@@ -2487,7 +2487,12 @@ describe("event-stream", () => {
       properties: { directory: "/repo" },
     });
 
-    expect(isRelevantSubscriberEvent(parentSubscriber, childPermissionEvent)).toBe(false);
+    expect(
+      isRelevantSubscriberEvent(
+        parentSubscriber,
+        resolveOpencodeEventRecipients(childPermissionEvent, new Map()),
+      ),
+    ).toBe(false);
   });
 
   test("applies queued part delta with append semantics", async () => {

--- a/packages/adapters-opencode-sdk/src/event-stream.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.ts
@@ -1,14 +1,6 @@
 import type { GlobalEvent, OpencodeClient } from "@opencode-ai/sdk/v2/client";
 import {
-  isRelevantEvent,
-  readEventDirectory,
-  readEventParentExternalSessionId,
-  readEventSessionId,
-  readSessionLifecycleEvent,
-} from "./event-stream/shared";
-import {
   normalizeOpencodeGlobalEventPayload,
-  opencodeEventUsesParentSessionRouting,
   type ProjectOpencodeAgentSessionEventInput,
   projectOpencodeAgentSessionEvent,
 } from "./opencode-agent-session-projection";
@@ -39,10 +31,6 @@ type LogEventInput = {
   event: Event;
   relevant: boolean;
   logEvent?: OpencodeEventLogger;
-};
-
-type RelevantSubscriberEventOptions = {
-  resolveParentExternalSessionId?: (childExternalSessionId: string) => string | undefined;
 };
 
 type OpencodeGlobalEvent = GlobalEvent;
@@ -118,22 +106,6 @@ const readGlobalEventFailureScope = (
   return scope;
 };
 
-const normalizeDirectory = (directory: string): string => directory.trim();
-
-const isEventDirectoryScopedToSubscriber = (
-  subscriber: EventStreamSubscriber,
-  event: Event,
-): boolean => {
-  const eventDirectory = readEventDirectory(event);
-  if (!eventDirectory) {
-    return false;
-  }
-
-  return (
-    normalizeDirectory(eventDirectory) === normalizeDirectory(subscriber.input.workingDirectory)
-  );
-};
-
 export const processOpencodeEvent = (input: ProcessOpencodeEventInput): void => {
   projectOpencodeAgentSessionEvent(input);
 };
@@ -172,40 +144,4 @@ export const subscribeGlobalEvents = async (input: SubscribeGlobalEventsInput): 
       input.onReady?.();
     }
   }
-};
-
-export const isRelevantSubscriberEvent = (
-  subscriber: EventStreamSubscriber,
-  event: Event,
-  options?: RelevantSubscriberEventOptions,
-): boolean => {
-  if (isRelevantEvent(subscriber.externalSessionId, event)) {
-    return true;
-  }
-
-  const lifecycleEvent = readSessionLifecycleEvent(event);
-  const eventExternalSessionId = lifecycleEvent
-    ? lifecycleEvent.externalSessionId
-    : readEventSessionId(event);
-  if (eventExternalSessionId) {
-    const parentExternalSessionId = lifecycleEvent
-      ? lifecycleEvent.parentExternalSessionId
-      : readEventParentExternalSessionId(event);
-
-    if (parentExternalSessionId) {
-      return parentExternalSessionId === subscriber.externalSessionId;
-    }
-
-    if (
-      opencodeEventUsesParentSessionRouting(event) &&
-      options?.resolveParentExternalSessionId?.(eventExternalSessionId) ===
-        subscriber.externalSessionId
-    ) {
-      return true;
-    }
-
-    return false;
-  }
-
-  return isEventDirectoryScopedToSubscriber(subscriber, event);
 };

--- a/packages/adapters-opencode-sdk/src/event-stream/shared.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/shared.ts
@@ -13,6 +13,9 @@ import {
 import type { SessionInput, SessionRecord } from "../types";
 import { z } from "zod";
 
+const eventSessionIdSchema = z.string();
+const partDeltaTextSchema = z.string();
+
 export type PendingPartDelta = {
   field: string;
   delta: string;
@@ -247,7 +250,7 @@ export const applyDeltaToPart = (
 ): ParsedOpencodePart | null => {
   const normalizedField = normalizePartDeltaField(field);
   const existing = Object.getOwnPropertyDescriptor(part, normalizedField)?.value;
-  const existingText = z.string().safeParse(existing);
+  const existingText = partDeltaTextSchema.safeParse(existing);
   if (existing !== undefined && !existingText.success) {
     return null;
   }
@@ -263,7 +266,7 @@ export const readEventSessionId = (event: Event): string | undefined => {
   if (!("sessionID" in properties)) {
     return undefined;
   }
-  const sessionId = z.string().safeParse(properties.sessionID);
+  const sessionId = eventSessionIdSchema.safeParse(properties.sessionID);
   return sessionId.success ? sessionId.data : undefined;
 };
 
@@ -292,8 +295,4 @@ export const readSessionLifecycleEvent = (event: Event): SessionLifecycleEvent |
 
 export const readEventDirectory = (event: Event): string | undefined => {
   return event.properties.directory;
-};
-
-export const isRelevantEvent = (externalSessionId: string, event: Event): boolean => {
-  return readEventSessionId(event) === externalSessionId;
 };

--- a/packages/adapters-opencode-sdk/src/guards.ts
+++ b/packages/adapters-opencode-sdk/src/guards.ts
@@ -6,6 +6,10 @@ export type OpenCodeProtocolObject = Record<string, OpenCodeProtocolValue>;
 export const opencodeProtocolValueSchema = z.json();
 export const opencodeProtocolObjectSchema = z.record(z.string(), opencodeProtocolValueSchema);
 
+const stringSchema = z.string();
+const finiteNumberSchema = z.number().finite();
+const booleanSchema = z.boolean();
+
 export const asJsonObject = (
   value: OpenCodeProtocolValue | undefined,
 ): OpenCodeProtocolObject | undefined => {
@@ -23,7 +27,7 @@ export const readStringProp = (
   }
 
   for (const key of keys) {
-    const value = z.string().safeParse(record[key]);
+    const value = stringSchema.safeParse(record[key]);
     if (value.success && value.data.length > 0) {
       return value.data;
     }
@@ -41,7 +45,7 @@ export const readNumberProp = (
   }
 
   for (const key of keys) {
-    const value = z.number().finite().safeParse(record[key]);
+    const value = finiteNumberSchema.safeParse(record[key]);
     if (value.success) {
       return value.data;
     }
@@ -59,7 +63,7 @@ export const readBooleanProp = (
   }
 
   for (const key of keys) {
-    const value = z.boolean().safeParse(record[key]);
+    const value = booleanSchema.safeParse(record[key]);
     if (value.success) {
       return value.data;
     }

--- a/packages/adapters-opencode-sdk/src/opencode-event-policy.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-event-policy.ts
@@ -146,7 +146,7 @@ export type ConsumedOpencodeEventType = {
   ]: (typeof OPENCODE_EVENT_POLICY_BY_TYPE)[Type]["ingress"] extends "validate" ? Type : never;
 }[OpencodeEventType];
 
-export const isKnownOpencodeEventType = (value: string): value is OpencodeEventType =>
+const isKnownOpencodeEventType = (value: string): value is OpencodeEventType =>
   Object.hasOwn(OPENCODE_EVENT_POLICY_BY_TYPE, value);
 
 export const isConsumedOpencodeEventType = (value: string): value is ConsumedOpencodeEventType =>

--- a/packages/adapters-opencode-sdk/src/opencode-event-recipients.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-event-recipients.ts
@@ -1,0 +1,41 @@
+import { opencodeEventUsesParentSessionRouting } from "./opencode-agent-session-projection";
+import type { ParsedOpencodeEvent } from "./opencode-global-event-ingress";
+import {
+  readEventDirectory,
+  readEventSessionId,
+  readSessionLifecycleEvent,
+} from "./event-stream/shared";
+import type { EventStreamSubscriber } from "./types";
+
+export type OpencodeEventRecipients = {
+  sessionIds: readonly string[];
+  directory: string | undefined;
+};
+
+export const resolveOpencodeEventRecipients = (
+  event: ParsedOpencodeEvent,
+  parentByChild: ReadonlyMap<string, string>,
+): OpencodeEventRecipients => {
+  const externalSessionId = readEventSessionId(event);
+  const lifecycle = readSessionLifecycleEvent(event);
+  const eventSessionId = lifecycle ? lifecycle.externalSessionId : externalSessionId;
+  const sessionIds: string[] = [];
+  if (externalSessionId !== undefined) sessionIds.push(externalSessionId);
+  if (!eventSessionId) {
+    const directory = readEventDirectory(event);
+    return { sessionIds, directory: directory ? directory.trim() : undefined };
+  }
+  const parentId =
+    lifecycle?.parentExternalSessionId ??
+    (opencodeEventUsesParentSessionRouting(event) ? parentByChild.get(eventSessionId) : undefined);
+  if (parentId) sessionIds.push(parentId);
+  return { sessionIds, directory: undefined };
+};
+
+export const isRelevantSubscriberEvent = (
+  subscriber: EventStreamSubscriber,
+  recipients: OpencodeEventRecipients,
+): boolean =>
+  recipients.sessionIds.includes(subscriber.externalSessionId) ||
+  (recipients.directory !== undefined &&
+    subscriber.input.workingDirectory.trim() === recipients.directory);

--- a/packages/adapters-opencode-sdk/src/opencode-global-event-ingress.test.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-global-event-ingress.test.ts
@@ -76,6 +76,36 @@ describe("type-directed OpenCode ingress", () => {
     }
   });
 
+  test("compiled deltas strip unknown keys and retain the directory", () => {
+    expect(
+      opencodeDirectEventSchema.parse({
+        id: "delta",
+        type: "message.part.delta",
+        extra: true,
+        properties: {
+          sessionID: "s",
+          messageID: "m",
+          partID: "p",
+          field: "text",
+          delta: "hello",
+          directory: "/repo",
+          extra: true,
+        },
+      }),
+    ).toEqual({
+      id: "delta",
+      type: "message.part.delta",
+      properties: {
+        sessionID: "s",
+        messageID: "m",
+        partID: "p",
+        field: "text",
+        delta: "hello",
+        directory: "/repo",
+      },
+    });
+  });
+
   test("validates heartbeat and sync envelopes before normalization", () => {
     expect(
       normalizeOpencodeGlobalEventPayload({

--- a/packages/adapters-opencode-sdk/src/opencode-global-event-ingress.test.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-global-event-ingress.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { normalizeOpencodeGlobalEventPayload } from "./opencode-agent-session-projection";
+import {
+  OPENCODE_EVENT_POLICY_BY_TYPE,
+  isConsumedOpencodeEventType,
+} from "./opencode-event-policy";
+import {
+  opencodeDirectEventSchema,
+  parseOpencodeGlobalEventPayload,
+} from "./opencode-global-event-ingress";
+
+describe("type-directed OpenCode ingress", () => {
+  test("keeps every explicit ignored event policy", () => {
+    for (const type of Object.keys(OPENCODE_EVENT_POLICY_BY_TYPE)) {
+      if (isConsumedOpencodeEventType(type)) continue;
+      expect(
+        parseOpencodeGlobalEventPayload({
+          id: "ignored",
+          type,
+          properties: { future: [1, false] },
+        }),
+      ).toEqual({
+        id: "ignored",
+        type,
+        kind: "ignored",
+      });
+    }
+  });
+
+  test("rejects malformed consumed events instead of treating them as ignored", () => {
+    for (const schema of opencodeDirectEventSchema.options) {
+      const type = schema.shape.type.value;
+      expect(() => parseOpencodeGlobalEventPayload({ type, properties: {} })).toThrow(
+        `Invalid OpenCode global event payload (${type})`,
+      );
+    }
+    expect(() =>
+      parseOpencodeGlobalEventPayload({
+        id: "delta",
+        type: "message.part.delta",
+        properties: {
+          sessionID: "session",
+          messageID: "message",
+          partID: "part",
+          field: "text",
+          delta: 1,
+        },
+      }),
+    ).toThrow("properties.delta");
+  });
+
+  test("preserves direct outputs and stripping when selecting a variant", () => {
+    const previous = z.union(opencodeDirectEventSchema.options);
+    for (const event of [
+      {
+        id: "delta",
+        type: "message.part.delta",
+        properties: {
+          sessionID: "s",
+          messageID: "m",
+          partID: "p",
+          field: "text",
+          delta: "hello",
+          directory: "/repo",
+          extra: true,
+        },
+      },
+      {
+        id: "status",
+        type: "session.status",
+        properties: { sessionID: "s", status: { type: "busy" }, extra: true },
+      },
+    ]) {
+      expect(opencodeDirectEventSchema.parse(event)).toEqual(previous.parse(event));
+    }
+  });
+
+  test("validates heartbeat and sync envelopes before normalization", () => {
+    expect(
+      normalizeOpencodeGlobalEventPayload({
+        id: "heartbeat",
+        type: "server.heartbeat",
+        properties: {},
+      }),
+    ).toEqual({ kind: "heartbeat" });
+    expect(() =>
+      parseOpencodeGlobalEventPayload({
+        id: "heartbeat",
+        type: "server.heartbeat",
+        properties: null,
+      }),
+    ).toThrow("Invalid OpenCode global event payload");
+    expect(() =>
+      normalizeOpencodeGlobalEventPayload({
+        id: "sync",
+        type: "sync",
+        syncEvent: {
+          id: "event",
+          seq: 1,
+          type: "session.updated.99",
+          aggregateID: "s",
+          data: {},
+        },
+      }),
+    ).toThrow("has no normalization decision");
+    expect(() =>
+      parseOpencodeGlobalEventPayload({
+        id: "sync",
+        type: "sync",
+        syncEvent: {
+          id: "event",
+          seq: 1,
+          type: "session.updated.1",
+          aggregateID: "s",
+          data: null,
+        },
+      }),
+    ).toThrow("syncEvent.data");
+  });
+});

--- a/packages/adapters-opencode-sdk/src/opencode-global-event-ingress.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-global-event-ingress.ts
@@ -7,7 +7,10 @@ import {
   opencodePartPayloadSchema,
   opencodeSessionDetailPayloadSchema,
 } from "./opencode-ingress";
-import { isConsumedOpencodeEventType, isKnownOpencodeEventType } from "./opencode-event-policy";
+import {
+  isConsumedOpencodeEventType,
+  OPENCODE_EVENT_POLICY_BY_TYPE,
+} from "./opencode-event-policy";
 
 const eventSchema = <Type extends string, Properties extends z.ZodType>(
   type: Type,
@@ -39,15 +42,18 @@ const messagePartRemovedEventSchema = eventSchema(
   "message.part.removed",
   z.object({ sessionID: z.string(), messageID: z.string(), partID: z.string() }),
 );
-const messagePartDeltaEventSchema = eventSchema(
-  "message.part.delta",
-  z.object({
-    sessionID: z.string(),
-    messageID: z.string(),
-    partID: z.string(),
-    field: z.string(),
-    delta: z.string(),
-  }),
+const messagePartDeltaEventSchema = z.compile(
+  eventSchema(
+    "message.part.delta",
+    z.object({
+      sessionID: z.string(),
+      messageID: z.string(),
+      partID: z.string(),
+      field: z.string(),
+      delta: z.string(),
+    }),
+  ),
+  { strict: true },
 );
 
 const sessionEventSchema = <Type extends "session.created" | "session.updated" | "session.deleted">(
@@ -191,19 +197,18 @@ const todoUpdatedEventSchema = eventSchema(
   }),
 );
 
+const ignoredEventTypes = Object.keys(OPENCODE_EVENT_POLICY_BY_TYPE).filter(
+  (type) => !isConsumedOpencodeEventType(type),
+);
 const ignoredDirectEventSchema = z
   .object({
     id: z.string(),
-    type: z.string(),
+    type: z.enum(ignoredEventTypes),
     properties: z.unknown(),
-  })
-  .refine(({ type }) => isKnownOpencodeEventType(type) && !isConsumedOpencodeEventType(type), {
-    message: "OpenCode events must have an explicit ingress policy.",
-    path: ["type"],
   })
   .transform(({ id, type }) => ({ kind: "ignored" as const, id, type }));
 
-export const opencodeDirectEventSchema = z.union([
+export const opencodeDirectEventSchema = z.discriminatedUnion("type", [
   sessionCreatedEventSchema,
   sessionUpdatedEventSchema,
   sessionDeletedEventSchema,
@@ -229,7 +234,10 @@ export const opencodeDirectEventSchema = z.union([
   sessionCompactedEventSchema,
 ]);
 
-const opencodeIngressEventSchema = z.union([opencodeDirectEventSchema, ignoredDirectEventSchema]);
+const opencodeIngressEventSchema = z.discriminatedUnion("type", [
+  opencodeDirectEventSchema,
+  ignoredDirectEventSchema,
+]);
 
 const syncEventSchema = z.object({
   aggregateID: z.string(),
@@ -249,7 +257,7 @@ const ingressEventDescriptorSchema = z.object({
   syncEvent: z.object({ type: z.string() }).optional(),
 });
 
-const opencodeGlobalEventPayloadSchema = z.union([
+const opencodeGlobalEventPayloadSchema = z.discriminatedUnion("type", [
   opencodeIngressEventSchema,
   syncEnvelopeSchema,
   serverHeartbeatSchema,

--- a/packages/adapters-opencode-sdk/src/runtime-event-subscribers.test.ts
+++ b/packages/adapters-opencode-sdk/src/runtime-event-subscribers.test.ts
@@ -157,6 +157,23 @@ describe("runtime event subscriber index", () => {
     expect(directories).toEqual(["/repo", "/new"]);
   });
 
+  test("defers newly registered recipients until the next event", () => {
+    const recipients = { sessionIds: ["parent", "child"], directory: "/repo" };
+    for (const logging of [false, true]) {
+      const registry = new RuntimeEventSubscribers();
+      registry.set("parent", subscriber("parent"));
+      const delivered: string[] = [];
+      const selected = logging ? registry.values() : registry.forEvent(recipients);
+      for (const entry of selected) {
+        delivered.push(entry.externalSessionId);
+        registry.set("child", subscriber("child"));
+        registry.set("neighbor", subscriber("neighbor"));
+      }
+      expect(delivered).toEqual(["parent"]);
+      expect(ids(registry.forEvent(recipients))).toEqual(["parent", "child", "neighbor"]);
+    }
+  });
+
   test("checks directory relevance after a callback replaces the next subscriber", () => {
     const event = opencodeDirectEventSchema.parse({
       id: "error",

--- a/packages/adapters-opencode-sdk/src/runtime-event-subscribers.test.ts
+++ b/packages/adapters-opencode-sdk/src/runtime-event-subscribers.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isRelevantSubscriberEvent,
+  resolveOpencodeEventRecipients,
+} from "./opencode-event-recipients";
+import { makeSessionInput } from "./event-stream.test-support";
+import {
+  opencodeDirectEventSchema,
+  type ParsedOpencodeEvent,
+} from "./opencode-global-event-ingress";
+import { createOpencodeSessionFixture } from "./opencode-protocol-test-fixtures";
+import { RuntimeEventSubscribers } from "./runtime-event-subscribers";
+
+const subscriber = (externalSessionId: string, directory = "/repo") => ({
+  externalSessionId,
+  input: { ...makeSessionInput(), workingDirectory: directory },
+});
+
+const permission = (sessionID: string) =>
+  opencodeDirectEventSchema.parse({
+    id: "event",
+    type: "permission.v2.asked",
+    properties: { id: "request", sessionID, action: "bash", resources: ["ls"] },
+  });
+
+const ids = (subscribers: Iterable<{ externalSessionId: string }>) =>
+  [...subscribers].map(({ externalSessionId }) => externalSessionId);
+
+describe("runtime event subscriber index", () => {
+  test("selects expected recipients for indexed delivery and logging", () => {
+    const registry = new RuntimeEventSubscribers();
+    registry.set("parent", subscriber("parent"));
+    registry.set("child", subscriber("child", "/other"));
+    registry.set("neighbor", subscriber("neighbor", " /repo "));
+    for (let index = 0; index < 97; index += 1) {
+      const id = `unrelated-${index}`;
+      registry.set(id, subscriber(id, "/unrelated"));
+    }
+    const parentByChild = new Map([["child", "parent"]]);
+    const cases: Array<{ event: ParsedOpencodeEvent; expected: string[] }> = [
+      { event: permission("child"), expected: ["parent", "child"] },
+      { event: permission("unknown"), expected: [] },
+      {
+        event: opencodeDirectEventSchema.parse({
+          id: "delta",
+          type: "message.part.delta",
+          properties: {
+            sessionID: "child",
+            messageID: "message",
+            partID: "part",
+            field: "text",
+            delta: "text",
+          },
+        }),
+        expected: ["child"],
+      },
+    ];
+    for (const [sessionID, expected] of [
+      [undefined, ["parent", "neighbor"]],
+      ["child", ["child"]],
+      ["unknown", []],
+      ["", ["parent", "neighbor"]],
+    ] as const) {
+      cases.push({
+        event: opencodeDirectEventSchema.parse({
+          id: "error",
+          type: "session.error",
+          properties: { directory: " /repo ", sessionID },
+        }),
+        expected: [...expected],
+      });
+    }
+    for (const type of ["session.created", "session.updated", "session.deleted"] as const) {
+      for (const [id, parentID, expected] of [
+        ["child", "parent", ["parent", "child"]],
+        ["child", "neighbor", ["child", "neighbor"]],
+        ["child", undefined, ["child"]],
+        ["", "parent", ["parent", "child", "neighbor"]],
+      ] as const) {
+        const info = createOpencodeSessionFixture({ id });
+        if (parentID !== undefined) info.parentID = parentID;
+        cases.push({
+          event: opencodeDirectEventSchema.parse({
+            id: "lifecycle",
+            type,
+            properties: {
+              sessionID: "child",
+              directory: "/repo",
+              info,
+            },
+          }),
+          expected: [...expected],
+        });
+      }
+    }
+    for (const { event, expected } of cases) {
+      const recipients = resolveOpencodeEventRecipients(event, parentByChild);
+      for (const logging of [false, true]) {
+        const selected = logging ? registry.values() : registry.forEvent(recipients);
+        const actual = [...selected].filter((entry) =>
+          isRelevantSubscriberEvent(entry, recipients),
+        );
+        expect(ids(actual)).toEqual(expected);
+      }
+    }
+    expect(registry.size).toBe(100);
+  });
+
+  test("preserves direct delivery to a registered empty session id", () => {
+    const registry = new RuntimeEventSubscribers();
+    registry.set("", subscriber(""));
+    const event = opencodeDirectEventSchema.parse({
+      id: "idle",
+      type: "session.idle",
+      properties: { sessionID: "" },
+    });
+    expect(ids(registry.forEvent(resolveOpencodeEventRecipients(event, new Map())))).toEqual([""]);
+  });
+
+  test("updates directory membership and preserves registration order on replacement", () => {
+    const registry = new RuntimeEventSubscribers();
+    registry.set("first", subscriber("first", "/other"));
+    registry.set("second", subscriber("second"));
+    registry.set("first", subscriber("first"));
+    expect(ids(registry.forDirectory(" /repo "))).toEqual(["first", "second"]);
+    expect(ids(registry.forDirectory("/other"))).toEqual([]);
+    registry.delete("first");
+    registry.set("first", subscriber("first"));
+    expect(ids(registry.forDirectory("/repo"))).toEqual(["second", "first"]);
+    registry.delete("second");
+    registry.delete("first");
+    expect(registry.size).toBe(0);
+    expect(ids(registry.forDirectory("/repo"))).toEqual([]);
+  });
+
+  test("skips a recipient released during delivery and reads replacements live", () => {
+    const registry = new RuntimeEventSubscribers();
+    registry.set("parent", subscriber("parent"));
+    registry.set("child", subscriber("child"));
+    const parentByChild = new Map([["child", "parent"]]);
+    const delivered: string[] = [];
+    for (const entry of registry.forEvent(
+      resolveOpencodeEventRecipients(permission("child"), parentByChild),
+    )) {
+      delivered.push(entry.externalSessionId);
+      registry.delete("child");
+    }
+    expect(delivered).toEqual(["parent"]);
+    registry.set("child", subscriber("child"));
+    const directories: string[] = [];
+    for (const entry of registry.forEvent(
+      resolveOpencodeEventRecipients(permission("child"), parentByChild),
+    )) {
+      directories.push(entry.input.workingDirectory);
+      registry.set("child", subscriber("child", "/new"));
+    }
+    expect(directories).toEqual(["/repo", "/new"]);
+  });
+
+  test("checks directory relevance after a callback replaces the next subscriber", () => {
+    const event = opencodeDirectEventSchema.parse({
+      id: "error",
+      type: "session.error",
+      properties: { directory: "/repo" },
+    });
+    const recipients = resolveOpencodeEventRecipients(event, new Map());
+    for (const logging of [false, true]) {
+      const registry = new RuntimeEventSubscribers();
+      registry.set("first", subscriber("first"));
+      registry.set("second", subscriber("second"));
+      const selected = logging ? registry.values() : registry.forEvent(recipients);
+      const delivered: string[] = [];
+      for (const entry of selected) {
+        if (!isRelevantSubscriberEvent(entry, recipients)) continue;
+        delivered.push(entry.externalSessionId);
+        registry.set("second", subscriber("second", "/other"));
+      }
+      expect(delivered).toEqual(["first"]);
+    }
+  });
+});

--- a/packages/adapters-opencode-sdk/src/runtime-event-subscribers.ts
+++ b/packages/adapters-opencode-sdk/src/runtime-event-subscribers.ts
@@ -1,0 +1,76 @@
+import type { OpencodeEventRecipients } from "./opencode-event-recipients";
+import type { EventStreamSubscriber } from "./types";
+
+type SubscriberEntry = { subscriber: EventStreamSubscriber; order: number };
+
+export class RuntimeEventSubscribers {
+  private readonly byId = new Map<string, SubscriberEntry>();
+  private readonly idsByDirectory = new Map<string, Set<string>>();
+  private nextOrder = 0;
+
+  get size(): number {
+    return this.byId.size;
+  }
+
+  has(id: string): boolean {
+    return this.byId.has(id);
+  }
+
+  set(id: string, subscriber: EventStreamSubscriber): void {
+    const previous = this.byId.get(id);
+    if (previous) {
+      this.removeDirectoryEntry(id, previous.subscriber.input.workingDirectory);
+    }
+    this.byId.set(id, { subscriber, order: previous?.order ?? this.nextOrder++ });
+    const directory = subscriber.input.workingDirectory.trim();
+    let ids = this.idsByDirectory.get(directory);
+    if (!ids) {
+      ids = new Set();
+      this.idsByDirectory.set(directory, ids);
+    }
+    ids.add(id);
+  }
+
+  delete(id: string): void {
+    const entry = this.byId.get(id);
+    if (!entry) return;
+    this.removeDirectoryEntry(id, entry.subscriber.input.workingDirectory);
+    this.byId.delete(id);
+  }
+
+  *values(): IterableIterator<EventStreamSubscriber> {
+    for (const { subscriber } of this.byId.values()) yield subscriber;
+  }
+
+  forDirectory(directory: string): Iterable<EventStreamSubscriber> {
+    return this.ordered(this.idsByDirectory.get(directory.trim()) ?? []);
+  }
+
+  forEvent(recipients: OpencodeEventRecipients): Iterable<EventStreamSubscriber> {
+    const ids = [...recipients.sessionIds];
+    if (recipients.directory !== undefined) {
+      ids.push(...(this.idsByDirectory.get(recipients.directory) ?? []));
+    }
+    return this.ordered(ids);
+  }
+
+  private *ordered(ids: Iterable<string>): IterableIterator<EventStreamSubscriber> {
+    const orderedIds = [...new Set(ids)].sort(
+      (left, right) =>
+        (this.byId.get(left)?.order ?? Infinity) - (this.byId.get(right)?.order ?? Infinity),
+    );
+    for (const id of orderedIds) {
+      // A preceding recipient can release or replace the next subscription during delivery.
+      const entry = this.byId.get(id);
+      if (entry) yield entry.subscriber;
+    }
+  }
+
+  private removeDirectoryEntry(id: string, directory: string): void {
+    const key = directory.trim();
+    const ids = this.idsByDirectory.get(key);
+    if (!ids) return;
+    ids.delete(id);
+    if (ids.size === 0) this.idsByDirectory.delete(key);
+  }
+}

--- a/packages/adapters-opencode-sdk/src/runtime-event-subscribers.ts
+++ b/packages/adapters-opencode-sdk/src/runtime-event-subscribers.ts
@@ -39,7 +39,11 @@ export class RuntimeEventSubscribers {
   }
 
   *values(): IterableIterator<EventStreamSubscriber> {
-    for (const { subscriber } of this.byId.values()) yield subscriber;
+    const ids = Array.from(this.byId.keys());
+    for (const id of ids) {
+      const entry = this.byId.get(id);
+      if (entry) yield entry.subscriber;
+    }
   }
 
   forDirectory(directory: string): Iterable<EventStreamSubscriber> {
@@ -55,10 +59,12 @@ export class RuntimeEventSubscribers {
   }
 
   private *ordered(ids: Iterable<string>): IterableIterator<EventStreamSubscriber> {
-    const orderedIds = [...new Set(ids)].sort(
-      (left, right) =>
-        (this.byId.get(left)?.order ?? Infinity) - (this.byId.get(right)?.order ?? Infinity),
-    );
+    const orderedIds = [...new Set(ids)]
+      .filter((id) => this.byId.has(id))
+      .sort(
+        (left, right) =>
+          (this.byId.get(left)?.order ?? Infinity) - (this.byId.get(right)?.order ?? Infinity),
+      );
     for (const id of orderedIds) {
       // A preceding recipient can release or replace the next subscription during delivery.
       const entry = this.byId.get(id);

--- a/packages/adapters-opencode-sdk/src/session-registry.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.test.ts
@@ -365,6 +365,50 @@ const runRuntimeEventTransport = async (
 };
 
 describe("session registry runtime event transport", () => {
+  test("delivers the same events with logging enabled and disabled", async () => {
+    for (const logging of [false, true]) {
+      const logs: Array<{ externalSessionId: string; relevant: boolean }> = [];
+      const options: NonNullable<Parameters<typeof runRuntimeEventTransport>[1]> = {
+        externalSessionIds: ["external-session-1", "external-session-2"],
+      };
+      if (logging) {
+        options.logEvent = ({ externalSessionId, relevant }) => {
+          logs.push({ externalSessionId, relevant });
+        };
+      }
+      const emitted = await runRuntimeEventTransport(
+        ["external-session-1", "external-session-2"].map((sessionID) => ({
+          id: `status-${sessionID}`,
+          type: "session.status" as const,
+          properties: { sessionID, status: { type: "busy" as const } },
+        })),
+        options,
+      );
+
+      expect(emitted.filter((event) => event.type === "session_status")).toEqual([
+        expect.objectContaining({
+          externalSessionId: "external-session-1",
+          status: { type: "busy", message: null },
+        }),
+        expect.objectContaining({
+          externalSessionId: "external-session-2",
+          status: { type: "busy", message: null },
+        }),
+      ]);
+      expect(emitted.filter((event) => event.type === "session_error")).toEqual([]);
+      expect(logs).toEqual(
+        logging
+          ? [
+              { externalSessionId: "external-session-1", relevant: true },
+              { externalSessionId: "external-session-2", relevant: false },
+              { externalSessionId: "external-session-1", relevant: false },
+              { externalSessionId: "external-session-2", relevant: true },
+            ]
+          : [],
+      );
+    }
+  });
+
   test("rejects pending message admission when its session is released", async () => {
     const session = makeSessionRecord(makeClientWithEvents([]));
     const sessions = new Map<string, SessionRecord>([[session.externalSessionId, session]]);

--- a/packages/adapters-opencode-sdk/src/session-registry.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.test.ts
@@ -322,6 +322,7 @@ const runRuntimeEventTransport = async (
   events: TestGlobalEventPayload[],
   options?: {
     onTransport?: (transport: RuntimeEventTransportRecord) => void;
+    onEmit?: (event: AgentEvent) => void;
     externalSessionIds?: string[];
     logEvent?: OpencodeEventLogger;
   },
@@ -347,6 +348,7 @@ const runRuntimeEventTransport = async (
       now: () => "2026-02-22T12:00:00.000Z",
       emit: (_externalSessionId, event) => {
         emitted.push(event);
+        options?.onEmit?.(event);
       },
     };
     if (options?.logEvent) {
@@ -408,6 +410,46 @@ describe("session registry runtime event transport", () => {
       );
     }
   });
+
+  test.each([false, true])(
+    "keeps directory recipients fixed during delivery with logging=%s",
+    async (logging) => {
+      let subscribers: RuntimeEventTransportRecord["subscribers"] | undefined;
+      const options: NonNullable<Parameters<typeof runRuntimeEventTransport>[1]> = {
+        externalSessionIds: ["external-session-1", "external-session-2", "external-session-3"],
+        onTransport: (transport) => {
+          subscribers = transport.subscribers;
+          subscribers.set("external-session-2", {
+            externalSessionId: "external-session-2",
+            input: { ...makeSessionInput(), workingDirectory: "/other" },
+          });
+        },
+        onEmit: (event) => {
+          if (event.type !== "session_error" || event.externalSessionId !== "external-session-1")
+            return;
+          if (!subscribers) throw new Error("Expected subscribers before event delivery.");
+          subscribers.set("external-session-2", {
+            externalSessionId: "external-session-2",
+            input: makeSessionInput(),
+          });
+          subscribers.delete("external-session-3");
+        },
+      };
+      if (logging) options.logEvent = () => {};
+      const emitted = await runRuntimeEventTransport(
+        [
+          { id: "first-error", type: "session.error", properties: { directory: "/repo" } },
+          { id: "second-error", type: "session.error", properties: { directory: "/repo" } },
+        ],
+        options,
+      );
+      expect(
+        emitted
+          .filter((event) => event.type === "session_error")
+          .map((event) => event.externalSessionId),
+      ).toEqual(["external-session-1", "external-session-1", "external-session-2"]);
+    },
+  );
 
   test("rejects pending message admission when its session is released", async () => {
     const session = makeSessionRecord(makeClientWithEvents([]));

--- a/packages/adapters-opencode-sdk/src/session-registry.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.ts
@@ -2,7 +2,6 @@ import type { OpencodeClient } from "@opencode-ai/sdk/v2/client";
 import type { AgentEvent, AgentSessionSummary } from "@openducktor/core";
 import { formatAgentSessionTitle } from "@openducktor/core";
 import {
-  isRelevantSubscriberEvent,
   logStreamEvent,
   type OpencodeGlobalEventFailureScope,
   processOpencodeEvent,
@@ -24,6 +23,11 @@ import type {
   SessionRecord,
 } from "./types";
 import { cancelPendingUserMessageAdmissions } from "./user-message-admission";
+import { RuntimeEventSubscribers } from "./runtime-event-subscribers";
+import {
+  isRelevantSubscriberEvent,
+  resolveOpencodeEventRecipients,
+} from "./opencode-event-recipients";
 
 export const requireSession = (
   sessions: Map<string, SessionRecord>,
@@ -139,9 +143,7 @@ const reportRuntimeEventFailure = (input: {
 
   if (!subscriberId) {
     const directory = input.scope.directory.trim();
-    const directoryMatches = [...input.eventTransport.subscribers.values()].filter(
-      (subscriber) => subscriber.input.workingDirectory.trim() === directory,
-    );
+    const directoryMatches = [...input.eventTransport.subscribers.forDirectory(directory)];
     if (directoryMatches.length === 1 && directoryMatches[0]) {
       subscriberId = directoryMatches[0].externalSessionId;
     }
@@ -218,14 +220,16 @@ const ensureRuntimeEventTransport = (input: {
         return false;
       }
       let projectionFailed = false;
-      for (const subscriber of streamRecord.subscribers.values()) {
+      const recipients = resolveOpencodeEventRecipients(
+        event,
+        streamRecord.parentExternalSessionIdByChildExternalSessionId,
+      );
+      const subscribers = input.logEvent
+        ? streamRecord.subscribers.values()
+        : streamRecord.subscribers.forEvent(recipients);
+      for (const subscriber of subscribers) {
         try {
-          const relevant = isRelevantSubscriberEvent(subscriber, event, {
-            resolveParentExternalSessionId: (childExternalSessionId) =>
-              streamRecord.parentExternalSessionIdByChildExternalSessionId.get(
-                childExternalSessionId,
-              ),
-          });
+          const relevant = isRelevantSubscriberEvent(subscriber, recipients);
           const logInput: Parameters<typeof logStreamEvent>[0] = {
             subscriber,
             event,
@@ -263,7 +267,7 @@ const ensureRuntimeEventTransport = (input: {
     },
     ready,
     streamDone: Promise.resolve(),
-    subscribers: new Map(),
+    subscribers: new RuntimeEventSubscribers(),
     observers: new Set(),
     terminalObservers: new Set(),
     parentExternalSessionIdByChildExternalSessionId: new Map(),

--- a/packages/adapters-opencode-sdk/src/session-registry.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.ts
@@ -224,12 +224,24 @@ const ensureRuntimeEventTransport = (input: {
         event,
         streamRecord.parentExternalSessionIdByChildExternalSessionId,
       );
+      // Logging visits unrelated subscribers too. Fix eligibility before callbacks can move them.
+      const recipientIdsAtDispatch = input.logEvent
+        ? new Set(
+            Array.from(
+              streamRecord.subscribers.forEvent(recipients),
+              (subscriber) => subscriber.externalSessionId,
+            ),
+          )
+        : undefined;
       const subscribers = input.logEvent
         ? streamRecord.subscribers.values()
         : streamRecord.subscribers.forEvent(recipients);
       for (const subscriber of subscribers) {
         try {
-          const relevant = isRelevantSubscriberEvent(subscriber, recipients);
+          const relevant =
+            (recipientIdsAtDispatch === undefined ||
+              recipientIdsAtDispatch.has(subscriber.externalSessionId)) &&
+            isRelevantSubscriberEvent(subscriber, recipients);
           const logInput: Parameters<typeof logStreamEvent>[0] = {
             subscriber,
             event,

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
@@ -8,7 +8,6 @@ import {
   asJsonObject,
   type OpenCodeProtocolObject,
   type OpenCodeProtocolValue,
-  opencodeProtocolObjectSchema,
   opencodeProtocolValueSchema,
   readBooleanProp,
   readNumberProp,
@@ -20,8 +19,12 @@ import { resolveOpencodeToolStrategy } from "./tool-strategy-catalog";
 import type { ParsedOpencodePart } from "./opencode-ingress";
 import { z } from "zod";
 
+const stringSchema = z.string();
+const booleanSchema = z.boolean();
+const displayScalarSchema = z.union([z.number(), booleanSchema]);
+
 const toDisplayText = (value: OpenCodeProtocolValue | undefined): string | undefined => {
-  const stringValue = z.string().safeParse(value);
+  const stringValue = stringSchema.safeParse(value);
   if (stringValue.success) {
     const trimmed = stringValue.data.trim();
     return trimmed.length > 0 ? trimmed : undefined;
@@ -29,7 +32,7 @@ const toDisplayText = (value: OpenCodeProtocolValue | undefined): string | undef
   if (value === null || value === undefined) {
     return undefined;
   }
-  const scalarValue = z.union([z.number(), z.boolean()]).safeParse(value);
+  const scalarValue = displayScalarSchema.safeParse(value);
   if (scalarValue.success) {
     return String(scalarValue.data);
   }
@@ -77,7 +80,7 @@ const outputTextFromMcpPayload = (
       if (!entryRecord) {
         return null;
       }
-      const text = z.string().safeParse(entryRecord.text);
+      const text = stringSchema.safeParse(entryRecord.text);
       return text.success ? text.data.trim() : null;
     })
     .filter((entry): entry is string => entry !== null && entry.length > 0);
@@ -92,7 +95,7 @@ const readToolOutputText = (value: string | undefined): string | undefined => to
 const MCP_TRANSPORT_ERROR_PREFIX = /^MCP error\s+-?\d+:/i;
 
 const readErrorValueMessage = (value: OpenCodeProtocolValue | undefined): string | undefined => {
-  const stringValue = z.string().safeParse(value);
+  const stringValue = stringSchema.safeParse(value);
   if (stringValue.success) {
     const trimmed = stringValue.data.trim();
     return trimmed.length > 0 ? trimmed : undefined;
@@ -109,13 +112,10 @@ const readErrorValueMessage = (value: OpenCodeProtocolValue | undefined): string
 const readEnvelopeErrorMessage = (
   value: string | OpenCodeProtocolObject | undefined,
 ): string | undefined => {
-  const stringValue = z.string().safeParse(value);
-  const objectValue = opencodeProtocolObjectSchema.safeParse(value);
+  const stringValue = stringSchema.safeParse(value);
   const record = stringValue.success
     ? parseStructuredTextObject(stringValue.data)
-    : objectValue.success
-      ? objectValue.data
-      : undefined;
+    : asJsonObject(value);
   if (!record) {
     return undefined;
   }
@@ -154,13 +154,10 @@ const readMcpContentTextError = (value: OpenCodeProtocolObject | undefined): str
 const readStructuredToolError = (
   value: string | OpenCodeProtocolObject | undefined,
 ): string | undefined => {
-  const stringValue = z.string().safeParse(value);
-  const objectValue = opencodeProtocolObjectSchema.safeParse(value);
+  const stringValue = stringSchema.safeParse(value);
   const record = stringValue.success
     ? parseStructuredTextObject(stringValue.data)
-    : objectValue.success
-      ? objectValue.data
-      : undefined;
+    : asJsonObject(value);
   const contentTextError = readMcpContentTextError(record);
   const transportError = readMcpTransportError(stringValue.success ? stringValue.data : undefined);
   if (!record) {
@@ -210,7 +207,7 @@ const normalizeMetadata = (
 };
 
 const normalizeFileDiffType = (value: OpenCodeProtocolValue | undefined): FileDiff["type"] => {
-  const parsed = z.string().safeParse(value);
+  const parsed = stringSchema.safeParse(value);
   if (!parsed.success) {
     return "modified";
   }
@@ -454,7 +451,7 @@ const readTrimmedString = (
 const normalizeSubagentExecutionMode = (
   value: OpenCodeProtocolValue | undefined,
 ): SubagentStreamPart["executionMode"] => {
-  const stringValue = z.string().safeParse(value);
+  const stringValue = stringSchema.safeParse(value);
   if (stringValue.success) {
     const normalized = stringValue.data.trim().toLowerCase();
     if (normalized === "background" || normalized === "foreground") {
@@ -462,7 +459,7 @@ const normalizeSubagentExecutionMode = (
     }
   }
 
-  const booleanValue = z.boolean().safeParse(value);
+  const booleanValue = booleanSchema.safeParse(value);
   if (booleanValue.success) {
     return booleanValue.data ? "background" : "foreground";
   }

--- a/packages/adapters-opencode-sdk/src/tool-preview.ts
+++ b/packages/adapters-opencode-sdk/src/tool-preview.ts
@@ -1,8 +1,22 @@
-import type { OpenCodeProtocolObject, OpenCodeProtocolValue } from "./guards";
+import {
+  type OpenCodeProtocolObject,
+  type OpenCodeProtocolValue,
+  opencodeProtocolObjectSchema,
+  opencodeProtocolValueSchema,
+} from "./guards";
 import type { AgentToolType } from "@openducktor/core";
 import { basenameForPath } from "@openducktor/path-support";
 import { z } from "zod";
 import { resolveOpencodeToolStrategy } from "./tool-strategy-catalog";
+
+const stringSchema = z.string();
+const finiteNumberSchema = z.number().finite();
+const collectionItemsSchema = z.object({
+  items: z.array(opencodeProtocolValueSchema).optional(),
+  questions: z.array(opencodeProtocolValueSchema).optional(),
+  summary: z.array(opencodeProtocolValueSchema).optional(),
+  todos: z.array(opencodeProtocolValueSchema).optional(),
+});
 
 export const deriveToolType = (toolName: string): AgentToolType => {
   return resolveOpencodeToolStrategy(toolName).toolType;
@@ -24,7 +38,7 @@ const readTrimmedString = (
     return null;
   }
   for (const key of keys) {
-    const parsed = z.string().safeParse(source[key]);
+    const parsed = stringSchema.safeParse(source[key]);
     if (parsed.success && parsed.data.trim().length > 0) {
       return parsed.data.trim();
     }
@@ -79,14 +93,7 @@ const countCollectionItems = (value: OpenCodeProtocolValue | undefined): number 
   if (Array.isArray(value)) {
     return value.length;
   }
-  const parsed = z
-    .object({
-      items: z.array(z.json()).optional(),
-      questions: z.array(z.json()).optional(),
-      summary: z.array(z.json()).optional(),
-      todos: z.array(z.json()).optional(),
-    })
-    .safeParse(value);
+  const parsed = collectionItemsSchema.safeParse(value);
   if (!parsed.success) {
     return null;
   }
@@ -124,7 +131,7 @@ const summarizeQuestionTool = (
     if (!Array.isArray(questions) || questions.length === 0) {
       continue;
     }
-    const firstQuestion = z.record(z.string(), z.json()).safeParse(questions[0]);
+    const firstQuestion = opencodeProtocolObjectSchema.safeParse(questions[0]);
     const prompt = readTrimmedString(firstQuestion.success ? firstQuestion.data : undefined, [
       "question",
       "prompt",
@@ -176,7 +183,7 @@ const summarizeOdtMutation = (
   }
   if (tool === "odt_set_pull_request") {
     const providerId = readTrimmedString(input, ["providerId"]);
-    const parsedNumber = z.number().finite().safeParse(input?.number);
+    const parsedNumber = finiteNumberSchema.safeParse(input?.number);
     const number = parsedNumber.success ? `#${parsedNumber.data}` : null;
     const taskId = readTrimmedString(input, ["taskId"]);
     return [taskId, providerId, number].filter((value) => value && value.length > 0).join(" · ");
@@ -196,7 +203,7 @@ const summarizeOdtMutation = (
 const summarizeSkillTool = (input: OpenCodeProtocolObject | undefined): string | null => {
   const direct =
     readTrimmedString(input, ["name", "skillName", "skill", "id"]) ??
-    readTrimmedString(z.record(z.string(), z.json()).safeParse(input?.skill).data, ["name", "id"]);
+    readTrimmedString(opencodeProtocolObjectSchema.safeParse(input?.skill).data, ["name", "id"]);
   if (direct) {
     return direct;
   }

--- a/packages/adapters-opencode-sdk/src/types.ts
+++ b/packages/adapters-opencode-sdk/src/types.ts
@@ -18,6 +18,7 @@ import type {
 } from "./event-stream/shared";
 import type { ParsedOpencodeEvent as Event } from "./opencode-global-event-ingress";
 import type { ParsedOpencodePart } from "./opencode-ingress";
+import type { RuntimeEventSubscribers } from "./runtime-event-subscribers";
 
 /**
  * Cache TTL for workflow tool selection (5 minutes).
@@ -105,7 +106,7 @@ export type RuntimeEventTransportRecord = {
   dispatch: (event: Event) => Promise<boolean>;
   ready: Promise<void>;
   streamDone: Promise<void>;
-  subscribers: Map<string, EventStreamSubscriber>;
+  subscribers: RuntimeEventSubscribers;
   observers: Set<(event: Event) => void | Promise<void>>;
   terminalObservers: Set<(error: Error) => void | Promise<void>>;
   parentExternalSessionIdByChildExternalSessionId: Map<string, string>;

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -14,6 +14,6 @@
     "lint": "oxlint -c ../../.oxlintrc.json src"
   },
   "dependencies": {
-    "zod": "^4.4.3"
+    "zod": "^4.6.2"
   }
 }

--- a/packages/contracts/src/agent-image-generation-schemas.ts
+++ b/packages/contracts/src/agent-image-generation-schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { withMaxUtf16Length } from "./string-schemas";
 import { agentSessionLiveRefSchema } from "./agent-session-schemas";
 import {
   LOCAL_ATTACHMENT_BASE64_CHARACTER_LIMIT,
@@ -92,7 +93,7 @@ export const agentGeneratedImageReadResultSchema = agentGeneratedImageReadInputS
   .extend({
     mime: z.literal("image/png"),
     byteLength: z.number().int().positive().max(LOCAL_ATTACHMENT_BYTE_LIMIT),
-    base64: z.string().min(1).max(LOCAL_ATTACHMENT_BASE64_CHARACTER_LIMIT),
+    base64: withMaxUtf16Length(z.string().min(1), LOCAL_ATTACHMENT_BASE64_CHARACTER_LIMIT),
   })
   .strict();
 export type AgentGeneratedImageReadResult = z.infer<typeof agentGeneratedImageReadResultSchema>;

--- a/packages/contracts/src/agent-session-control-schemas.ts
+++ b/packages/contracts/src/agent-session-control-schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isoTimestampSchema } from "./string-schemas";
 import { runtimeKindSchema } from "./agent-runtime-schemas";
 import { agentUserMessageEventSchema } from "./agent-session-event-schemas";
 import {
@@ -185,7 +186,7 @@ export const agentSessionControlSummarySchema = z
     runtimeKind: runtimeKindSchema,
     workingDirectory: nonEmptyStringSchema,
     title: z.string().optional(),
-    startedAt: z.string().datetime({ offset: true }),
+    startedAt: isoTimestampSchema,
     status: z.enum(["starting", "running", "idle", "error", "stopped"]),
   })
   .strict();

--- a/packages/contracts/src/agent-session-event-schemas.ts
+++ b/packages/contracts/src/agent-session-event-schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isoTimestampSchema } from "./string-schemas";
 import { agentImageGenerationPartSchema } from "./agent-image-generation-schemas";
 import {
   runtimeApprovalReplyOutcomeSchema,
@@ -18,7 +19,6 @@ import { skillDescriptorSchema } from "./skill-schemas";
 import { slashCommandCatalogSchema } from "./slash-command-schemas";
 import { subagentDescriptorSchema } from "./subagent-schemas";
 
-const isoTimestampSchema = z.string().datetime({ offset: true });
 const finiteNonNegativeNumberSchema = z.number().finite().nonnegative();
 export const agentToolDataSchema = z.record(z.string(), z.json());
 export type AgentToolData = z.output<typeof agentToolDataSchema>;

--- a/packages/contracts/src/agent-session-live-schemas.ts
+++ b/packages/contracts/src/agent-session-live-schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isoTimestampSchema } from "./string-schemas";
 import {
   runtimeApprovalReplyOutcomeSchema,
   runtimeApprovalRequestTypeSchema,
@@ -19,7 +20,6 @@ import { slashCommandCatalogSchema } from "./slash-command-schemas";
 import { fileDiffSchema } from "./git-schemas";
 
 const nonEmptyStringSchema = z.string().trim().min(1);
-const isoTimestampSchema = z.string().datetime({ offset: true });
 const finiteNonNegativeNumberSchema = z.number().finite().nonnegative();
 
 export const agentSessionContextUsageSchema = z

--- a/packages/contracts/src/app-update-schemas.ts
+++ b/packages/contracts/src/app-update-schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isoTimestampSchema as appUpdateCheckedAtSchema } from "./string-schemas";
 
 const appUpdateErrorDetailsSchema = z.record(z.string(), z.json());
 
@@ -58,7 +59,6 @@ export const appUpdateErrorSchema = z
 export type AppUpdateError = z.infer<typeof appUpdateErrorSchema>;
 
 const appUpdateVersionSchema = z.string().trim().min(1);
-const appUpdateCheckedAtSchema = z.string().datetime({ offset: true });
 const appUpdateProgressPercentSchema = z.number().min(0).max(100);
 
 export const appUpdateStateSchema = z.discriminatedUnion("status", [

--- a/packages/contracts/src/config-schemas.test.ts
+++ b/packages/contracts/src/config-schemas.test.ts
@@ -589,7 +589,11 @@ describe("config-schemas", () => {
     });
     expect(invalidRoleOverride.success).toBe(false);
     if (invalidRoleOverride.success) throw new Error("unsupported Codex role must fail");
-    expect(invalidRoleOverride.error.issues[0]?.path).toEqual(["roleOverrides", "review"]);
+    expect(invalidRoleOverride.error.issues[0]).toMatchObject({
+      code: "unrecognized_keys",
+      path: ["roleOverrides"],
+      keys: ["review"],
+    });
     expect(() =>
       codexRuntimeConfigSchema.parse({
         ...baseConfig,

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -614,6 +614,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "pullRequestSchema",
   "validatePromptTemplatePlaceholders",
   "validateSpecMarkdown",
+  "withMaxUtf16Length",
   "WORKSPACE_ID_PATTERN",
   "workspaceFileGitStatusSchema",
   "workspaceFileTreeEntrySchema",

--- a/packages/contracts/src/external-task-sync-schemas.ts
+++ b/packages/contracts/src/external-task-sync-schemas.ts
@@ -154,10 +154,10 @@ export const taskEventSnapshotRequiredFrameSchema = z
   .strict();
 export type TaskEventSnapshotRequiredFrame = z.infer<typeof taskEventSnapshotRequiredFrameSchema>;
 
-export const taskEventStreamFrameSchema = z.discriminatedUnion("type", [
-  taskEventChangeFrameSchema,
-  taskEventSnapshotRequiredFrameSchema,
-]);
+export const taskEventStreamFrameSchema = z.compile(
+  z.discriminatedUnion("type", [taskEventChangeFrameSchema, taskEventSnapshotRequiredFrameSchema]),
+  { strict: true },
+);
 export type TaskEventStreamFrame = z.infer<typeof taskEventStreamFrameSchema>;
 
 export const taskEventStreamSubscribeSchema = z

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -65,6 +65,7 @@ export * from "./session-todo-parsing";
 export * from "./skill-schemas";
 export * from "./slash-command-schemas";
 export * from "./spec-template";
+export { withMaxUtf16Length } from "./string-schemas";
 export * from "./subagent-schemas";
 export * from "./system-open-schemas";
 export * from "./task-asset-schemas";

--- a/packages/contracts/src/notification-schemas.ts
+++ b/packages/contracts/src/notification-schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { withMaxUtf16Length } from "./string-schemas";
 import { agentSessionLiveRefSchema } from "./agent-session-schemas";
 import { agentRoleSchema } from "./agent-workflow-schemas";
 import { agentSessionRecordSchema } from "./session-schemas";
@@ -121,12 +122,12 @@ const notificationRepoTargetFields = {
 
 const notificationTaskTargetFields = {
   ...notificationRepoTargetFields,
-  taskId: z.string().trim().min(1).max(128),
+  taskId: withMaxUtf16Length(z.string().trim().min(1), 128),
 } as const;
 
 const notificationSessionTargetFields = {
   ...notificationRepoTargetFields,
-  taskId: z.string().trim().min(1).max(128).optional(),
+  taskId: withMaxUtf16Length(z.string().trim().min(1), 128).optional(),
 } as const;
 
 export const notificationSessionIdentitySchema = agentSessionRecordSchema
@@ -157,7 +158,7 @@ export const notificationNavigationTargetSchema = z.discriminatedUnion("type", [
     type: z.literal("session_error"),
     ...notificationSessionTargetFields,
     session: notificationSessionIdentitySchema,
-    errorId: z.string().trim().min(1).max(512),
+    errorId: withMaxUtf16Length(z.string().trim().min(1), 512),
   }),
   z.strictObject({
     type: z.literal("kanban_task"),
@@ -167,19 +168,19 @@ export const notificationNavigationTargetSchema = z.discriminatedUnion("type", [
 export type NotificationNavigationTarget = z.infer<typeof notificationNavigationTargetSchema>;
 
 export const notificationOccurrenceSchema = z.strictObject({
-  occurrenceId: z.string().trim().min(1).max(1024),
+  occurrenceId: withMaxUtf16Length(z.string().trim().min(1), 1024),
   kind: notificationKindSchema,
   repoPath: agentSessionLiveRefSchema.shape.repoPath,
-  repositoryLabel: z.string().trim().min(1).max(120),
+  repositoryLabel: withMaxUtf16Length(z.string().trim().min(1), 120),
   task: z
     .strictObject({
-      id: z.string().trim().min(1).max(128),
-      title: z.string().trim().min(1).max(240).optional(),
+      id: withMaxUtf16Length(z.string().trim().min(1), 128),
+      title: withMaxUtf16Length(z.string().trim().min(1), 240).optional(),
     })
     .optional(),
   role: agentRoleSchema.optional(),
-  sessionLabel: z.string().trim().min(1).max(120).optional(),
-  status: z.string().trim().min(1).max(240),
+  sessionLabel: withMaxUtf16Length(z.string().trim().min(1), 120).optional(),
+  status: withMaxUtf16Length(z.string().trim().min(1), 240),
   navigationTarget: notificationNavigationTargetSchema,
 });
 export type NotificationOccurrence = z.infer<typeof notificationOccurrenceSchema>;
@@ -198,15 +199,15 @@ export const notificationOsCapabilitySchema = z.strictObject({
   permission: z.enum(NOTIFICATION_OS_PERMISSION_VALUES),
   canGuaranteeSilent: z.boolean(),
   canOpenSystemSettings: z.boolean(),
-  failureMessage: z.string().trim().min(1).max(500).optional(),
+  failureMessage: withMaxUtf16Length(z.string().trim().min(1), 500).optional(),
 });
 export type NotificationOsCapability = z.infer<typeof notificationOsCapabilitySchema>;
 
 export const notificationOsDeliveryRequestSchema = z.strictObject({
   purpose: z.enum(["notification", "test"]).optional(),
-  occurrenceId: z.string().trim().min(1).max(1024),
-  title: z.string().trim().min(1).max(180),
-  body: z.string().trim().min(1).max(500),
+  occurrenceId: withMaxUtf16Length(z.string().trim().min(1), 1024),
+  title: withMaxUtf16Length(z.string().trim().min(1), 180),
+  body: withMaxUtf16Length(z.string().trim().min(1), 500),
   silent: z.literal(true),
   navigationTarget: notificationNavigationTargetSchema,
 });
@@ -214,9 +215,18 @@ export type NotificationOsDeliveryRequest = z.infer<typeof notificationOsDeliver
 
 export const notificationDeliveryResultSchema = z.discriminatedUnion("status", [
   z.strictObject({ status: z.literal("shown") }),
-  z.strictObject({ status: z.literal("unsupported"), message: z.string().trim().min(1).max(500) }),
-  z.strictObject({ status: z.literal("denied"), message: z.string().trim().min(1).max(500) }),
-  z.strictObject({ status: z.literal("failed"), message: z.string().trim().min(1).max(500) }),
+  z.strictObject({
+    status: z.literal("unsupported"),
+    message: withMaxUtf16Length(z.string().trim().min(1), 500),
+  }),
+  z.strictObject({
+    status: z.literal("denied"),
+    message: withMaxUtf16Length(z.string().trim().min(1), 500),
+  }),
+  z.strictObject({
+    status: z.literal("failed"),
+    message: withMaxUtf16Length(z.string().trim().min(1), 500),
+  }),
 ]);
 export type NotificationDeliveryResult = z.infer<typeof notificationDeliveryResultSchema>;
 

--- a/packages/contracts/src/pull-request-review-schemas.ts
+++ b/packages/contracts/src/pull-request-review-schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isoTimestampSchema as dateTimeSchema } from "./string-schemas";
 import { gitProviderIdSchema } from "./git-schemas";
 
 export const pullRequestReviewProviderIdSchema = gitProviderIdSchema;
@@ -42,7 +43,6 @@ export type PullRequestReviewCheckConclusion = z.infer<
 
 const urlSchema = z.string().url();
 const nullableUrlSchema = urlSchema.nullable();
-const dateTimeSchema = z.string().datetime({ offset: true });
 const nullableDateTimeSchema = dateTimeSchema.nullable();
 
 export const pullRequestReviewPullRequestSchema = z.object({

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -1078,8 +1078,9 @@ describe("runtime schemas", () => {
     expect(result.error.issues).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          code: "invalid_key",
-          path: ["workflowToolAliasesByCanonical", "odt_set_specc"],
+          code: "unrecognized_keys",
+          path: ["workflowToolAliasesByCanonical"],
+          keys: ["odt_set_specc"],
         }),
       ]),
     );

--- a/packages/contracts/src/string-schemas.test.ts
+++ b/packages/contracts/src/string-schemas.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { agentSessionControlSummarySchema } from "./agent-session-control-schemas";
+import { agentUserMessageEventSchema } from "./agent-session-event-schemas";
+import { agentSessionLiveSnapshotSchema } from "./agent-session-live-schemas";
+import { appUpdateStateSchema } from "./app-update-schemas";
+import { notificationOsDeliveryRequestSchema } from "./notification-schemas";
+import { pullRequestReviewCheckSchema } from "./pull-request-review-schemas";
+import { withMaxUtf16Length } from "./string-schemas";
+import { taskAssetStageInputSchema, taskAssetStageResultSchema } from "./task-asset-schemas";
+import {
+  terminalIdSchema,
+  terminalPreparePathInputRequestSchema,
+  terminalPreparePathInputResponseSchema,
+} from "./terminal-schemas";
+
+describe("string length compatibility", () => {
+  test.each([
+    ["task asset input name", taskAssetStageInputSchema.shape.originalName, 255],
+    ["task asset result name", taskAssetStageResultSchema.shape.originalName, 255],
+    ["terminal ID", terminalIdSchema, 128],
+    ["terminal path", terminalPreparePathInputRequestSchema.shape.paths.element, 32_768],
+    ["terminal path text", terminalPreparePathInputResponseSchema.shape.text, 262_144],
+    ["notification title", notificationOsDeliveryRequestSchema.shape.title, 180],
+    ["notification body", notificationOsDeliveryRequestSchema.shape.body, 500],
+  ] as const)("keeps the UTF-16 limit for %s", (_name, schema, maximum) => {
+    const atLimit = "😀".repeat(Math.floor(maximum / 2)) + (maximum % 2 ? "a" : "");
+    expect(schema.parse(atLimit)).toBe(atLimit);
+    for (const value of [`${atLimit}a`, "a".repeat(maximum + 1)]) {
+      const result = schema.safeParse(value);
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error("over-limit input must fail");
+      expect(result.error.issues).toHaveLength(1);
+      expect(result.error.issues[0]).toMatchObject({
+        code: "too_big",
+        origin: "string",
+        maximum,
+        inclusive: true,
+      });
+    }
+  });
+
+  test("keeps trimming, field paths, and JSON-schema limits", () => {
+    const name = withMaxUtf16Length(z.string().trim().min(1), 2);
+    const schema = z.object({ name });
+    expect(schema.parse({ name: "  😀  " })).toEqual({ name: "😀" });
+    const result = schema.safeParse({ name: "😀a" });
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("over-limit input must fail");
+    expect(result.error.issues[0]?.path).toEqual(["name"]);
+    expect(z.toJSONSchema(name)).toMatchObject({ type: "string", minLength: 1, maxLength: 2 });
+    expect(name.safeParse(42).success).toBe(false);
+    expect(name.safeParse(" ").success).toBe(false);
+  });
+});
+
+describe("runtime timestamp compatibility", () => {
+  test.each([
+    ["session events", agentUserMessageEventSchema.shape.timestamp],
+    ["live sessions", agentSessionLiveSnapshotSchema.shape.startedAt],
+    ["session control", agentSessionControlSummarySchema.shape.startedAt],
+    ["pull request checks", pullRequestReviewCheckSchema.shape.startedAt.unwrap()],
+    ["app update checks", appUpdateStateSchema.options[0].shape.checkedAt.unwrap()],
+  ] as const)("accepts existing timestamp precision in %s", (_name, schema) => {
+    for (const value of [
+      "2026-09-11T12:34Z",
+      "2026-09-11T12:34+02:00",
+      "2026-09-11T12:34:56Z",
+      "2026-09-11T12:34:56.123456-05:00",
+      "2024-02-29T12:34Z",
+    ]) {
+      expect(schema.parse(value)).toBe(value);
+    }
+    for (const value of [
+      "2025-02-29T12:34Z",
+      "2026-09-11T24:34Z",
+      "2026-09-11T12:60Z",
+      "2026-09-11T12:34:60Z",
+      "2026-09-11T12:34",
+      "2026-09-11",
+      "not a timestamp",
+    ]) {
+      expect(schema.safeParse(value).success).toBe(false);
+    }
+  });
+});

--- a/packages/contracts/src/string-schemas.test.ts
+++ b/packages/contracts/src/string-schemas.test.ts
@@ -40,7 +40,7 @@ describe("string length compatibility", () => {
     }
   });
 
-  test("keeps trimming, field paths, and JSON-schema limits", () => {
+  test("keeps trimming and field paths", () => {
     const name = withMaxUtf16Length(z.string().trim().min(1), 2);
     const schema = z.object({ name });
     expect(schema.parse({ name: "  😀  " })).toEqual({ name: "😀" });
@@ -48,9 +48,18 @@ describe("string length compatibility", () => {
     expect(result.success).toBe(false);
     if (result.success) throw new Error("over-limit input must fail");
     expect(result.error.issues[0]?.path).toEqual(["name"]);
-    expect(z.toJSONSchema(name)).toMatchObject({ type: "string", minLength: 1, maxLength: 2 });
     expect(name.safeParse(42).success).toBe(false);
     expect(name.safeParse(" ").success).toBe(false);
+  });
+
+  test("requires Zod validation for the UTF-16 limit beyond JSON Schema maxLength", () => {
+    const name = withMaxUtf16Length(z.string(), 2);
+    expect(z.toJSONSchema(name)).toMatchObject({ type: "string", maxLength: 2 });
+    const twoCodePoints = "😀😀";
+    expect(Array.from(twoCodePoints)).toHaveLength(2);
+    expect(twoCodePoints).toHaveLength(4);
+    expect(name.safeParse(twoCodePoints).success).toBe(false);
+    expect(name.parse("😀")).toBe("😀");
   });
 });
 

--- a/packages/contracts/src/string-schemas.ts
+++ b/packages/contracts/src/string-schemas.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+// Zod 4.5 counts code points. These limits retain their existing UTF-16 length rule.
+export const withMaxUtf16Length = (schema: z.ZodString, maximum: number): z.ZodString =>
+  schema.max(maximum).superRefine((value, context) => {
+    if (value.length > maximum && !context.issues.some((issue) => issue.code === "too_big")) {
+      context.addIssue({ code: "too_big", origin: "string", maximum, inclusive: true });
+    }
+  });
+
+// Existing runtime timestamps can omit seconds.
+export const isoTimestampSchema = z.compile(
+  z.union([
+    z.string().datetime({ offset: true }),
+    z.string().datetime({ offset: true, precision: -1 }),
+  ]),
+  { strict: true },
+);

--- a/packages/contracts/src/string-schemas.ts
+++ b/packages/contracts/src/string-schemas.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 
-// Zod 4.5 counts code points. These limits retain their existing UTF-16 length rule.
+/**
+ * Retains the UTF-16 length limit used before Zod 4.5.
+ * Validate inputs with Zod to enforce this rule. Generated JSON Schema exposes only
+ * the code-point maxLength bound and cannot express the stricter UTF-16 refinement.
+ */
 export const withMaxUtf16Length = (schema: z.ZodString, maximum: number): z.ZodString =>
   schema.max(maximum).superRefine((value, context) => {
     if (value.length > maximum && !context.issues.some((issue) => issue.code === "too_big")) {

--- a/packages/contracts/src/task-asset-schemas.ts
+++ b/packages/contracts/src/task-asset-schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { withMaxUtf16Length } from "./string-schemas";
 import { workspaceIdSchema } from "./config-schemas";
 
 export const TASK_ASSET_MAX_FILE_BYTES = 10 * 1024 * 1024;
@@ -52,7 +53,7 @@ export const taskAssetStageInputSchema = z
   .object({
     workspaceId: workspaceIdSchema,
     scope: taskAssetScopeSchema,
-    originalName: z.string().trim().min(1).max(255),
+    originalName: withMaxUtf16Length(z.string().trim().min(1), 255),
     declaredMediaType: taskAssetMediaTypeSchema,
     bytesBase64: z
       .base64()
@@ -66,7 +67,7 @@ export const taskAssetStageResultSchema = z
   .object({
     assetId: taskAssetIdSchema,
     scope: taskAssetScopeSchema,
-    originalName: z.string().min(1).max(255),
+    originalName: withMaxUtf16Length(z.string().min(1), 255),
     verifiedMediaType: taskAssetMediaTypeSchema,
     byteSize: z.number().int().nonnegative().max(TASK_ASSET_MAX_FILE_BYTES),
   })

--- a/packages/contracts/src/terminal-protocol.test.ts
+++ b/packages/contracts/src/terminal-protocol.test.ts
@@ -8,6 +8,7 @@ import {
   TERMINAL_PROTOCOL_MAX_ROWS,
   TERMINAL_PROTOCOL_VERSION,
   terminalClientMessageSchema,
+  terminalServerMessageSchema,
 } from "./terminal-protocol";
 
 const inputMessage = { version: 1 as const, type: "input" as const, terminalId: "terminal-1" };
@@ -47,6 +48,26 @@ describe("terminal protocol", () => {
         rows: TERMINAL_PROTOCOL_MAX_ROWS,
       }),
     ).toThrow();
+  });
+
+  test("compiled output retains the sequence validation message and field path", () => {
+    const result = terminalServerMessageSchema.safeParse({
+      version: 1,
+      type: "output",
+      terminalId: "terminal-1",
+      sequenceStart: 2,
+      sequenceEnd: 2,
+      replay: false,
+    });
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("Expected output sequence validation to fail.");
+    expect(result.error.issues).toEqual([
+      {
+        code: "custom",
+        message: "sequenceEnd must be greater than sequenceStart",
+        path: ["sequenceEnd"],
+      },
+    ]);
   });
 
   test("rejects malformed discriminants and wrong versions", () => {

--- a/packages/contracts/src/terminal-protocol.ts
+++ b/packages/contracts/src/terminal-protocol.ts
@@ -56,24 +56,27 @@ export const terminalServerMessageSchema = z.discriminatedUnion("type", [
       complete: z.boolean(),
     })
     .strict(),
-  protocolBaseSchema
-    .extend({
-      type: z.literal("output"),
-      terminalId: terminalIdSchema,
-      sequenceStart: sequenceSchema,
-      sequenceEnd: sequenceSchema,
-      replay: z.boolean(),
-    })
-    .strict()
-    .superRefine((message, context) => {
-      if (message.sequenceEnd <= message.sequenceStart) {
-        context.addIssue({
-          code: "custom",
-          message: "sequenceEnd must be greater than sequenceStart",
-          path: ["sequenceEnd"],
-        });
-      }
-    }),
+  z.compile(
+    protocolBaseSchema
+      .extend({
+        type: z.literal("output"),
+        terminalId: terminalIdSchema,
+        sequenceStart: sequenceSchema,
+        sequenceEnd: sequenceSchema,
+        replay: z.boolean(),
+      })
+      .strict()
+      .superRefine((message, context) => {
+        if (message.sequenceEnd <= message.sequenceStart) {
+          context.addIssue({
+            code: "custom",
+            message: "sequenceEnd must be greater than sequenceStart",
+            path: ["sequenceEnd"],
+          });
+        }
+      }),
+    { strict: true },
+  ),
   protocolBaseSchema
     .extend({
       type: z.literal("replay_gap"),
@@ -121,13 +124,18 @@ export const terminalServerMessageSchema = z.discriminatedUnion("type", [
 export type TerminalServerMessage = z.infer<typeof terminalServerMessageSchema>;
 export type TerminalProtocolMessage = TerminalClientMessage | TerminalServerMessage;
 
+const terminalProtocolMessageSchema = z.union([
+  terminalClientMessageSchema,
+  terminalServerMessageSchema,
+]);
+
 export const isTerminalClientMessage = (
   message: TerminalProtocolMessage,
 ): message is TerminalClientMessage => terminalClientMessageSchema.safeParse(message).success;
 
 const terminalProtocolHeaderSchema = z
   .object({
-    message: z.union([terminalClientMessageSchema, terminalServerMessageSchema]),
+    message: terminalProtocolMessageSchema,
     payloadLength: z.number().int().nonnegative(),
   })
   .strict();
@@ -157,9 +165,7 @@ export const encodeTerminalProtocolFrame = ({
   message,
   payload,
 }: TerminalProtocolFrame): Uint8Array => {
-  const parsedMessage = z
-    .union([terminalClientMessageSchema, terminalServerMessageSchema])
-    .parse(message);
+  const parsedMessage = terminalProtocolMessageSchema.parse(message);
   assertPayloadContract(parsedMessage, payload.byteLength);
   const headerBytes = new TextEncoder().encode(
     JSON.stringify({ message: parsedMessage, payloadLength: payload.byteLength }),

--- a/packages/contracts/src/terminal-schemas.ts
+++ b/packages/contracts/src/terminal-schemas.ts
@@ -1,9 +1,13 @@
 import { z } from "zod";
+import { withMaxUtf16Length } from "./string-schemas";
 
 const terminalCommandFailureDetailsSchema = z.record(z.string(), z.json());
 
 export const TERMINAL_ID_MAX_LENGTH = 128;
-export const terminalIdSchema = z.string().trim().min(1).max(TERMINAL_ID_MAX_LENGTH);
+export const terminalIdSchema = withMaxUtf16Length(
+  z.string().trim().min(1),
+  TERMINAL_ID_MAX_LENGTH,
+);
 export const terminalTaskIdSchema = z.string().trim().min(1);
 const terminalRepoPathSchema = z.string().trim().min(1);
 
@@ -138,13 +142,16 @@ export type TerminalListResponse = z.infer<typeof terminalListResponseSchema>;
 export const terminalPreparePathInputRequestSchema = z
   .object({
     terminalId: terminalIdSchema,
-    paths: z.array(z.string().min(1).max(32_768)).min(1).max(8),
+    paths: z
+      .array(withMaxUtf16Length(z.string().min(1), 32_768))
+      .min(1)
+      .max(8),
   })
   .strict();
 export type TerminalPreparePathInputRequest = z.infer<typeof terminalPreparePathInputRequestSchema>;
 
 export const terminalPreparePathInputResponseSchema = z
-  .object({ text: z.string().min(1).max(262_144) })
+  .object({ text: withMaxUtf16Length(z.string().min(1), 262_144) })
   .strict();
 export type TerminalPreparePathInputResponse = z.infer<
   typeof terminalPreparePathInputResponseSchema

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "@openducktor/contracts": "workspace:*",
     "@openducktor/path-support": "workspace:*",
-    "zod": "^4.4.3"
+    "zod": "^4.6.2"
   }
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -78,7 +78,7 @@
     "tailwind-merge": "^3.6.0",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",
-    "zod": "^4.4.3",
+    "zod": "^4.6.2",
     "zustand": "^5.0.15"
   },
   "devDependencies": {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-tool-presenters.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-tool-presenters.tsx
@@ -8,7 +8,7 @@ import {
   Terminal,
   Wrench,
 } from "lucide-react";
-import type { ReactElement } from "react";
+import { type ReactElement, useMemo, useState } from "react";
 import type { AgentToolData } from "@openducktor/contracts";
 import { cn } from "@/lib/utils";
 import { AgentChatFileEditCard } from "./agent-chat-file-edit-card";
@@ -95,6 +95,42 @@ const ToolJsonDetails = ({
 
 const formatToolInput = (input: AgentToolData, workingDirectory?: string | null): string => {
   return JSON.stringify(relativizeDisplayPathsInValue(input, workingDirectory), null, 2);
+};
+
+type ToolInputDetailsProps = {
+  input: AgentToolData;
+  workingDirectory?: string | null | undefined;
+  className: string;
+  textClassName: string;
+  visible?: boolean;
+};
+
+const ToolInputDetails = ({
+  input,
+  workingDirectory,
+  className,
+  textClassName,
+  visible = true,
+}: ToolInputDetailsProps): ReactElement => {
+  const [isOpen, setIsOpen] = useState(false);
+  const formatted = useMemo(
+    () => (isOpen && visible ? formatToolInput(input, workingDirectory) : null),
+    [input, workingDirectory, isOpen, visible],
+  );
+  return (
+    <details className={className} onToggle={(event) => setIsOpen(event.currentTarget.open)}>
+      <summary className={cn("cursor-pointer px-2 py-1 text-xs font-medium", textClassName)}>
+        Input
+      </summary>
+      {formatted !== null ? (
+        <pre
+          className={cn("overflow-x-auto whitespace-pre-wrap px-2 pb-2 text-[11px]", textClassName)}
+        >
+          {formatted}
+        </pre>
+      ) : null}
+    </details>
+  );
 };
 
 const workflowToolForegroundClassName = ({
@@ -204,14 +240,12 @@ export const WorkflowToolMessage = ({
       {(hasInput || hasOutput || hasError) && (
         <div className="space-y-2">
           {hasInput && meta.input ? (
-            <details className="rounded border border-current/20 bg-card">
-              <summary className="cursor-pointer px-2 py-1 text-xs font-medium text-current">
-                Input
-              </summary>
-              <pre className="overflow-x-auto whitespace-pre-wrap px-2 pb-2 text-[11px] text-current">
-                {formatToolInput(meta.input, sessionWorkingDirectory)}
-              </pre>
-            </details>
+            <ToolInputDetails
+              input={meta.input}
+              workingDirectory={sessionWorkingDirectory}
+              className="rounded border border-current/20 bg-card"
+              textClassName="text-current"
+            />
           ) : null}
           {hasOutput && meta.output ? (
             <ToolJsonDetails
@@ -253,6 +287,7 @@ export const RegularToolMessage = ({
   sessionWorkingDirectory,
   displayName,
 }: RegularToolMessageProps): ReactElement => {
+  const [detailsOpen, setDetailsOpen] = useState(false);
   const lifecyclePhase = getToolLifecyclePhase(meta);
   const summary = buildToolSummary(meta, messageContent, sessionWorkingDirectory);
   const summaryText =
@@ -313,18 +348,22 @@ export const RegularToolMessage = ({
   return (
     <div className="space-y-1 px-1 py-0.5">
       {hasExpandableDetails ? (
-        <details className="group">
+        <details
+          className="group"
+          onToggle={(event) => {
+            if (event.target === event.currentTarget) setDetailsOpen(event.currentTarget.open);
+          }}
+        >
           <summary className="list-none [&::-webkit-details-marker]:hidden">{summaryRow}</summary>
           <div className="ml-5 mt-1 space-y-2">
             {hasInput && meta.input ? (
-              <details className="rounded border border-border bg-card">
-                <summary className="cursor-pointer px-2 py-1 text-xs font-medium text-foreground">
-                  Input
-                </summary>
-                <pre className="overflow-x-auto whitespace-pre-wrap px-2 pb-2 text-[11px] text-foreground">
-                  {formatToolInput(meta.input, sessionWorkingDirectory)}
-                </pre>
-              </details>
+              <ToolInputDetails
+                input={meta.input}
+                workingDirectory={sessionWorkingDirectory}
+                className="rounded border border-border bg-card"
+                textClassName="text-foreground"
+                visible={detailsOpen}
+              />
             ) : null}
             {hasOutput && meta.output ? (
               <details className="rounded border border-border bg-card">

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-tool-presenters.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-tool-presenters.tsx
@@ -133,31 +133,60 @@ const ToolInputDetails = ({
   );
 };
 
-const workflowToolForegroundClassName = ({
-  isFailure,
-  isCancelled,
-  isSuccessfulCompletion,
-  isExecuting,
+const ToolMessageTiming = ({
+  showSpinner,
+  durationMs,
+  timeLabel,
+  className,
 }: {
-  isFailure: boolean;
-  isCancelled: boolean;
-  isSuccessfulCompletion: boolean;
-  isExecuting: boolean;
-}): string => {
-  if (isFailure) {
-    return "text-destructive-surface-foreground";
+  showSpinner: boolean;
+  durationMs: number | null;
+  timeLabel: string;
+  className: string;
+}): ReactElement => (
+  <span className={cn("ml-auto inline-flex shrink-0 items-center gap-2 text-[11px]", className)}>
+    {showSpinner ? <LoaderCircle className="size-3 animate-spin" /> : null}
+    {durationMs !== null ? <span>{formatAgentDuration(durationMs)}</span> : null}
+    {timeLabel ? <span>{timeLabel}</span> : null}
+  </span>
+);
+
+const WORKFLOW_TOOL_APPEARANCE = {
+  queued: {
+    label: "QUEUED",
+    statusClassName: "border-pending-border bg-pending-surface text-pending-surface-foreground",
+    foregroundClassName: "text-pending-surface-foreground",
+  },
+  executing: {
+    label: "RUNNING",
+    statusClassName: "border-info-border bg-info-surface text-info-surface-foreground",
+    foregroundClassName: "text-info-surface-foreground",
+  },
+  failed: {
+    label: "FAILED",
+    statusClassName:
+      "border-destructive-border bg-destructive-surface text-destructive-surface-foreground",
+    foregroundClassName: "text-destructive-surface-foreground",
+  },
+  cancelled: {
+    label: "CANCELLED",
+    statusClassName:
+      "border-cancelled-border bg-cancelled-surface text-cancelled-surface-foreground",
+    foregroundClassName: "text-cancelled-surface-foreground",
+  },
+  completed: {
+    label: null,
+    statusClassName: "border-pending-border bg-pending-surface text-pending-surface-foreground",
+    foregroundClassName: "text-success-surface-foreground",
+  },
+} satisfies Record<
+  ReturnType<typeof getToolLifecyclePhase>,
+  {
+    label: string | null;
+    statusClassName: string;
+    foregroundClassName: string;
   }
-  if (isCancelled) {
-    return "text-cancelled-surface-foreground";
-  }
-  if (isSuccessfulCompletion) {
-    return "text-success-surface-foreground";
-  }
-  if (isExecuting) {
-    return "text-info-surface-foreground";
-  }
-  return "text-pending-surface-foreground";
-};
+>;
 
 type WorkflowToolMessageProps = {
   meta: ToolMeta;
@@ -179,42 +208,13 @@ export const WorkflowToolMessage = ({
   const hasOutput = hasNonEmptyText(meta.output);
   const hasError = hasNonEmptyText(meta.error);
   const lifecyclePhase = getToolLifecyclePhase(meta);
-  const isActive = lifecyclePhase === "queued" || lifecyclePhase === "executing";
   const isFailure = lifecyclePhase === "failed";
-  const isCancelled = lifecyclePhase === "cancelled";
-  const isSuccessfulCompletion = lifecyclePhase === "completed";
   const isExecuting = lifecyclePhase === "executing";
-  const statusLabel = (() => {
-    if (lifecyclePhase === "queued") {
-      return "QUEUED";
-    }
-    if (lifecyclePhase === "executing") {
-      return "RUNNING";
-    }
-    if (lifecyclePhase === "failed") {
-      return "FAILED";
-    }
-    if (lifecyclePhase === "cancelled") {
-      return "CANCELLED";
-    }
-    return null;
-  })();
-  let statusClassName = "border-pending-border bg-pending-surface text-pending-surface-foreground";
-  if (isExecuting) {
-    statusClassName = "border-info-border bg-info-surface text-info-surface-foreground";
-  } else if (isFailure) {
-    statusClassName =
-      "border-destructive-border bg-destructive-surface text-destructive-surface-foreground";
-  } else if (isCancelled) {
-    statusClassName =
-      "border-cancelled-border bg-cancelled-surface text-cancelled-surface-foreground";
-  }
-  const foregroundClassName = workflowToolForegroundClassName({
-    isFailure,
-    isCancelled,
-    isSuccessfulCompletion,
-    isExecuting,
-  });
+  const {
+    label: statusLabel,
+    statusClassName,
+    foregroundClassName,
+  } = WORKFLOW_TOOL_APPEARANCE[lifecyclePhase];
 
   return (
     <div className="space-y-2">
@@ -231,11 +231,12 @@ export const WorkflowToolMessage = ({
             {statusLabel}
           </span>
         ) : null}
-        <span className="ml-auto inline-flex shrink-0 items-center gap-2 text-[11px] text-current/75 font-normal normal-case">
-          {isExecuting ? <LoaderCircle className="size-3 animate-spin" /> : null}
-          {!isActive && durationMs !== null ? <span>{formatAgentDuration(durationMs)}</span> : null}
-          {timeLabel ? <span>{timeLabel}</span> : null}
-        </span>
+        <ToolMessageTiming
+          showSpinner={isExecuting}
+          durationMs={durationMs}
+          timeLabel={timeLabel}
+          className="text-current/75 font-normal normal-case"
+        />
       </div>
       {(hasInput || hasOutput || hasError) && (
         <div className="space-y-2">
@@ -279,16 +280,17 @@ type RegularToolMessageProps = {
   displayName: string;
 };
 
-export const RegularToolMessage = ({
+const RegularToolSummary = ({
   meta,
   messageContent,
   messageTimestamp,
   timeLabel,
   sessionWorkingDirectory,
   displayName,
-}: RegularToolMessageProps): ReactElement => {
-  const [detailsOpen, setDetailsOpen] = useState(false);
+  hasExpandableDetails,
+}: RegularToolMessageProps & { hasExpandableDetails: boolean }): ReactElement => {
   const lifecyclePhase = getToolLifecyclePhase(meta);
+  const isActive = lifecyclePhase === "queued" || lifecyclePhase === "executing";
   const summary = buildToolSummary(meta, messageContent, sessionWorkingDirectory);
   const summaryText =
     summary.length > 0
@@ -299,18 +301,7 @@ export const RegularToolMessage = ({
           ? "Tool cancelled"
           : "";
   const durationMs = getToolDuration(meta, messageTimestamp);
-  const hasInput = hasNonEmptyInput(meta.input);
-  const hasOutput = hasNonEmptyText(meta.output);
-  const hasError = hasNonEmptyText(meta.error);
-  const hasExpandableDetails = hasInput || hasOutput || hasError;
-  const isActive = lifecyclePhase === "queued" || lifecyclePhase === "executing";
-  const questionDetails = questionToolDetails(meta);
-  const questionDetailRenderEntries = buildQuestionDetailRenderEntries(
-    meta.callId,
-    questionDetails,
-  );
-
-  const summaryRow = (
+  return (
     <div
       className={cn(
         "flex min-h-6 items-center gap-2 text-xs",
@@ -337,12 +328,45 @@ export const RegularToolMessage = ({
       {summaryText.length > 0 ? (
         <p className="truncate text-muted-foreground">{summaryText}</p>
       ) : null}
-      <span className="ml-auto inline-flex shrink-0 items-center gap-2 text-[11px] text-muted-foreground">
-        {isActive ? <LoaderCircle className="size-3 animate-spin" /> : null}
-        {!isActive && durationMs !== null ? <span>{formatAgentDuration(durationMs)}</span> : null}
-        {timeLabel ? <span>{timeLabel}</span> : null}
-      </span>
+      <ToolMessageTiming
+        showSpinner={isActive}
+        durationMs={durationMs}
+        timeLabel={timeLabel}
+        className="text-muted-foreground"
+      />
     </div>
+  );
+};
+
+export const RegularToolMessage = ({
+  meta,
+  messageContent,
+  messageTimestamp,
+  timeLabel,
+  sessionWorkingDirectory,
+  displayName,
+}: RegularToolMessageProps): ReactElement => {
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const hasInput = hasNonEmptyInput(meta.input);
+  const hasOutput = hasNonEmptyText(meta.output);
+  const hasError = hasNonEmptyText(meta.error);
+  const hasExpandableDetails = hasInput || hasOutput || hasError;
+  const questionDetails = questionToolDetails(meta);
+  const questionDetailRenderEntries = buildQuestionDetailRenderEntries(
+    meta.callId,
+    questionDetails,
+  );
+
+  const summaryRow = (
+    <RegularToolSummary
+      meta={meta}
+      messageContent={messageContent}
+      messageTimestamp={messageTimestamp}
+      timeLabel={timeLabel}
+      sessionWorkingDirectory={sessionWorkingDirectory}
+      displayName={displayName}
+      hasExpandableDetails={hasExpandableDetails}
+    />
   );
 
   return (

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-tool-input-details.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-tool-input-details.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { act, fireEvent, render } from "@testing-library/react";
+import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
+import { RegularToolMessage, WorkflowToolMessage } from "./agent-chat-message-card-tool-presenters";
+import type { ToolMeta } from "./agent-chat-message-card-model.types";
+
+enableReactActEnvironment();
+
+const meta: ToolMeta = {
+  kind: "tool",
+  partId: "part",
+  callId: "call",
+  tool: "inspect",
+  toolType: "generic",
+  status: "running",
+  input: { content: "first input", path: "/repo/src/file.ts" },
+};
+const props = {
+  meta,
+  messageTimestamp: "2026-09-11T12:00:00.000Z",
+  timeLabel: "",
+  sessionWorkingDirectory: "/repo",
+  displayName: "inspect",
+};
+
+const toggle = (element: HTMLDetailsElement, open: boolean) => {
+  act(() => {
+    element.open = open;
+    fireEvent(element, new Event("toggle"));
+  });
+};
+
+describe("tool input details", () => {
+  test("formats regular input only while both details are open and shows current input", () => {
+    const view = render(<RegularToolMessage {...props} messageContent="Inspect data" />);
+    try {
+      const inputDetails = view.getByText("Input").closest("details");
+      const outerDetails = view.container.querySelector("details");
+      if (!inputDetails || !outerDetails) throw new Error("Expected tool details.");
+      expect(view.container.querySelector("pre")).toBeNull();
+      toggle(outerDetails, true);
+      expect(view.container.querySelector("pre")).toBeNull();
+      toggle(inputDetails, true);
+      expect(view.container.querySelector("pre")?.textContent).toContain("first input");
+      expect(view.container.querySelector("pre")?.textContent).toContain('"path": "src/file.ts"');
+      view.rerender(
+        <RegularToolMessage
+          {...props}
+          meta={{ ...meta, input: { content: "new input" } }}
+          messageContent="Inspect data"
+        />,
+      );
+      expect(view.container.querySelector("pre")?.textContent).toContain("new input");
+      toggle(outerDetails, false);
+      expect(view.container.querySelector("pre")).toBeNull();
+      toggle(outerDetails, true);
+      expect(view.container.querySelector("pre")?.textContent).toContain("new input");
+      toggle(inputDetails, false);
+      expect(view.container.querySelector("pre")).toBeNull();
+    } finally {
+      view.unmount();
+    }
+  });
+
+  test("defers workflow input and preserves it on reopen", () => {
+    const view = render(<WorkflowToolMessage {...props} />);
+    try {
+      const inputDetails = view.getByText("Input").closest("details");
+      if (!inputDetails) throw new Error("Expected input details.");
+      expect(view.container.querySelector("pre")).toBeNull();
+      toggle(inputDetails, true);
+      expect(view.container.querySelector("pre")?.textContent).toContain("first input");
+      toggle(inputDetails, false);
+      expect(view.container.querySelector("pre")).toBeNull();
+      toggle(inputDetails, true);
+      expect(view.container.querySelector("pre")?.textContent).toContain("first input");
+    } finally {
+      view.unmount();
+    }
+  });
+});

--- a/packages/frontend/src/components/features/agents/agent-chat/question-tool-parser.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/question-tool-parser.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ToolMeta } from "./agent-chat-message-card-model.types";
 import { hasNonEmptyText } from "./tool-lifecycle";
 
+const questionJsonValueSchema = z.json();
+
 export type QuestionToolDetail = {
   prompt: string;
   answers: string[];
@@ -22,7 +24,7 @@ const parseJsonIfPossible = (value: string | undefined): AgentToolValue | undefi
     return undefined;
   }
   try {
-    return z.json().parse(JSON.parse(trimmed));
+    return questionJsonValueSchema.parse(JSON.parse(trimmed));
   } catch {
     return undefined;
   }
@@ -134,8 +136,8 @@ export const questionToolDetails = (meta: ToolMeta): QuestionToolDetail[] => {
     return [];
   }
 
-  const parsedInput = z.json().safeParse(meta.input);
-  const parsedMetadata = z.json().safeParse(meta.metadata);
+  const parsedInput = questionJsonValueSchema.safeParse(meta.input);
+  const parsedMetadata = questionJsonValueSchema.safeParse(meta.metadata);
   const inputRecord =
     parsedInput.success && isAgentToolData(parsedInput.data) ? parsedInput.data : undefined;
   const metadataRecord =

--- a/packages/frontend/src/components/features/agents/agent-chat/tool-input-semantics.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/tool-input-semantics.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { agentToolDataSchema, type AgentToolData } from "@openducktor/contracts";
+import { hasMeaningfulToolInput } from "@/state/operations/agent-orchestrator/events/session-helpers";
+import { extractPathFromInput, readInputString } from "./tool-input-utils";
+import { hasNonEmptyInput, hasNonEmptyText } from "./tool-lifecycle";
+
+describe("validated tool input semantics", () => {
+  const cases: Array<[AgentToolData | undefined, boolean]> = [
+    [undefined, false],
+    [{}, false],
+    [{ value: "  " }, false],
+    [{ value: null }, false],
+    [{ value: { nested: [null, " ", {}, []] } }, false],
+    [{ value: { nested: [null, " text "] } }, true],
+    [{ value: 0 }, true],
+    [{ value: false }, true],
+    [{ value: { nested: [false] } }, true],
+  ];
+  test.each(cases)("preserves meaningful input for %j", (input, expected) => {
+    expect(hasNonEmptyInput(input)).toBe(expected);
+    expect(hasMeaningfulToolInput(input)).toBe(expected);
+  });
+
+  test("rejects invalid JSON values at the tool boundary", () => {
+    for (const value of [NaN, Infinity, undefined, new Date(), new Map(), () => 0]) {
+      expect(agentToolDataSchema.safeParse({ value }).success).toBe(false);
+    }
+  });
+
+  test("reads the first nonblank string in key order", () => {
+    const input = { first: false, second: " ", third: " value ", fourth: "other" };
+    expect(readInputString(input, ["missing", "first", "second", "third", "fourth"])).toBe("value");
+    expect(readInputString(input, ["missing", "first", "second"])).toBeNull();
+    expect(readInputString(undefined, ["missing"])).toBeNull();
+    expect(hasNonEmptyText(false)).toBe(false);
+    expect(hasNonEmptyText(undefined)).toBe(false);
+    expect(hasNonEmptyText(" ")).toBe(false);
+    expect(hasNonEmptyText(" value ")).toBe(true);
+  });
+
+  test("keeps path alias precedence and dot handling", () => {
+    expect(extractPathFromInput({ filePath: false, path: "/repo/file" })).toBeNull();
+    expect(extractPathFromInput({ filePath: null, path: " /repo/file " })).toBe("/repo/file");
+    expect(extractPathFromInput({ path: "." })).toBeNull();
+  });
+});

--- a/packages/frontend/src/components/features/agents/agent-chat/tool-input-utils.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/tool-input-utils.ts
@@ -1,9 +1,8 @@
 import type { AgentToolData } from "@openducktor/contracts";
-import { z } from "zod";
 
-const stringValueSchema = z.string();
 const isStringValue = (value: AgentToolData[string] | undefined): value is string =>
-  stringValueSchema.safeParse(value).success;
+  // oxlint-disable-next-line anti-slop/no-runtime-typeof -- Tool fields have already passed boundary validation.
+  typeof value === "string";
 
 export const readInputString = (
   input: AgentToolData | undefined,

--- a/packages/frontend/src/components/features/agents/agent-chat/tool-lifecycle.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/tool-lifecycle.ts
@@ -1,18 +1,17 @@
-import { agentToolDataSchema, type AgentToolData } from "@openducktor/contracts";
-import { z } from "zod";
+import type { AgentToolData } from "@openducktor/contracts";
 import type { ToolMeta } from "./agent-chat-message-card-model.types";
 
 const TOOL_CANCELLED_PATTERN = /\b(cancel(?:ed|led)|aborted|stopped|interrupted|terminated)\b/i;
 
-const stringValueSchema = z.string();
-const numberOrBooleanValueSchema = z.union([z.number(), z.boolean()]);
 type AgentToolValue = AgentToolData[string];
 
 const isStringValue = (value: AgentToolValue): value is string =>
-  stringValueSchema.safeParse(value).success;
+  // oxlint-disable-next-line anti-slop/no-runtime-typeof -- AgentToolData has already passed boundary validation.
+  typeof value === "string";
 
 const isNumberOrBooleanValue = (value: AgentToolValue): value is number | boolean =>
-  numberOrBooleanValueSchema.safeParse(value).success;
+  // oxlint-disable-next-line anti-slop/no-runtime-typeof -- Preserve the finite-number rule without allocating parse errors.
+  (typeof value === "number" && Number.isFinite(value)) || typeof value === "boolean";
 
 const hasMeaningfulInputValue = (value: AgentToolValue): boolean => {
   if (isStringValue(value)) {
@@ -24,11 +23,10 @@ const hasMeaningfulInputValue = (value: AgentToolValue): boolean => {
   if (Array.isArray(value)) {
     return value.some((entry) => hasMeaningfulInputValue(entry));
   }
-  const objectValue = agentToolDataSchema.safeParse(value);
-  if (!objectValue.success) {
+  if (value === null) {
     return false;
   }
-  return Object.values(objectValue.data).some((entry) => hasMeaningfulInputValue(entry));
+  return Object.values(value).some((entry) => hasMeaningfulInputValue(entry));
 };
 
 export const hasNonEmptyInput = (input: AgentToolData | undefined): boolean => {
@@ -36,8 +34,8 @@ export const hasNonEmptyInput = (input: AgentToolData | undefined): boolean => {
 };
 
 export const hasNonEmptyText = (value: AgentToolValue | undefined): value is string => {
-  const result = stringValueSchema.safeParse(value);
-  return result.success && result.data.trim().length > 0;
+  // oxlint-disable-next-line anti-slop/no-runtime-typeof -- Tool fields have already passed boundary validation.
+  return typeof value === "string" && value.trim().length > 0;
 };
 
 export const isToolMessageFailure = (meta: ToolMeta): boolean => {

--- a/packages/frontend/src/components/features/agents/agent-chat/tool-path-utils.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/tool-path-utils.test.ts
@@ -2,6 +2,36 @@ import { describe, expect, test } from "bun:test";
 import { relativizeDisplayPath, relativizeDisplayPathsInValue } from "./tool-path-utils";
 
 describe("tool-path-utils", () => {
+  test("relativizes nested tool input while preserving non-path values", () => {
+    const input = {
+      entries: [
+        {
+          details: {
+            path: "/repo/src/a.ts",
+            description: "/repo/leave-this-text",
+            enabled: false,
+            count: 0,
+            missing: null,
+          },
+        },
+      ],
+    };
+
+    expect(relativizeDisplayPathsInValue(input, "/repo")).toEqual({
+      entries: [
+        {
+          details: {
+            path: "src/a.ts",
+            description: "/repo/leave-this-text",
+            enabled: false,
+            count: 0,
+            missing: null,
+          },
+        },
+      ],
+    });
+  });
+
   test("relativizes string arrays for plural path keys", () => {
     expect(
       relativizeDisplayPathsInValue(

--- a/packages/frontend/src/components/features/agents/agent-chat/tool-path-utils.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/tool-path-utils.ts
@@ -1,6 +1,5 @@
-import { agentToolDataSchema, type AgentToolData } from "@openducktor/contracts";
+import type { AgentToolData } from "@openducktor/contracts";
 import { toDisplayRelativePath } from "@openducktor/path-support";
-import { z } from "zod";
 
 const DISPLAY_PATH_KEYS = new Set([
   "filePath",
@@ -18,11 +17,11 @@ const DISPLAY_PATH_KEYS = new Set([
   "workingDirectory",
 ]);
 
-const stringValueSchema = z.string();
 type AgentToolValue = AgentToolData[string];
 
 const isStringValue = (value: AgentToolValue): value is string =>
-  stringValueSchema.safeParse(value).success;
+  // oxlint-disable-next-line anti-slop/no-runtime-typeof -- AgentToolData has already passed boundary validation.
+  typeof value === "string";
 
 export const relativizeDisplayPath = (filePath: string, workingDirectory?: string | null): string =>
   toDisplayRelativePath(filePath, workingDirectory);
@@ -55,13 +54,13 @@ export const relativizeDisplayPathsInValue = (
   if (Array.isArray(value)) {
     return value.map((entry) => relativizeDisplayPathsInValue(entry, workingDirectory, key));
   }
-  const objectValue = agentToolDataSchema.safeParse(value);
-  if (!objectValue.success) {
+  // oxlint-disable-next-line anti-slop/no-runtime-typeof -- Traverse the validated JSON value without parsing its subtree again.
+  if (value === null || typeof value !== "object") {
     return value;
   }
 
   return Object.fromEntries(
-    Object.entries(objectValue.data).map(([entryKey, entryValue]) => [
+    Object.entries(value).map(([entryKey, entryValue]) => [
       entryKey,
       relativizeDisplayPathsInValue(entryValue, workingDirectory, entryKey),
     ]),

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-helpers.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-helpers.ts
@@ -1,6 +1,5 @@
 import { recordImageGenerationEnd } from "../support/image-generation-settlement";
-import { agentToolDataSchema, type AgentToolData } from "@openducktor/contracts";
-import { z } from "zod";
+import type { AgentToolData } from "@openducktor/contracts";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { settleDanglingTodoToolMessages } from "../agent-tool-messages";
 import type { SessionLifecycleEventContext, SessionPart } from "./session-event-types";
@@ -10,25 +9,26 @@ export const eventTimestampMs = (timestamp: string): number => {
   return Number.isNaN(parsed) ? Date.now() : parsed;
 };
 
-const stringValueSchema = z.string();
-const numberOrBooleanValueSchema = z.union([z.number(), z.boolean()]);
-
 const hasMeaningfulToolInputValue = (value: AgentToolData[string]): boolean => {
-  const stringResult = stringValueSchema.safeParse(value);
-  if (stringResult.success) {
-    return stringResult.data.trim().length > 0;
+  // oxlint-disable-next-line anti-slop/no-runtime-typeof -- Transcript tool input has already passed boundary validation.
+  if (typeof value === "string") {
+    return value.trim().length > 0;
   }
-  if (numberOrBooleanValueSchema.safeParse(value).success) {
+  // oxlint-disable-next-line anti-slop/no-runtime-typeof -- Keep the same finite-number acceptance as the boundary schema.
+  if (typeof value === "number") {
+    return Number.isFinite(value);
+  }
+  // oxlint-disable-next-line anti-slop/no-runtime-typeof -- Boolean false is meaningful tool input too.
+  if (typeof value === "boolean") {
     return true;
   }
   if (Array.isArray(value)) {
     return value.some((entry) => hasMeaningfulToolInputValue(entry));
   }
-  const objectValue = agentToolDataSchema.safeParse(value);
-  if (!objectValue.success) {
+  if (value === null) {
     return false;
   }
-  return Object.values(objectValue.data).some((entry) => hasMeaningfulToolInputValue(entry));
+  return Object.values(value).some((entry) => hasMeaningfulToolInputValue(entry));
 };
 
 export const hasMeaningfulToolInput = (input: AgentToolData | undefined): boolean => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/todos.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/todos.ts
@@ -6,6 +6,10 @@ import {
 import { z } from "zod";
 import { type AgentSessionTodoItem, normalizeAgentSessionTodoList } from "@openducktor/core";
 
+const todoJsonValueSchema = z.json();
+const todoOutputListSchema = agentSessionTodoPayloadListSchema();
+const todoInputListSchema = agentSessionTodoPayloadListSchema({ allowStringEntries: true });
+
 export const parseTodosFromToolOutput = (
   output: string | undefined,
 ): AgentSessionTodoItem[] | null => {
@@ -13,17 +17,13 @@ export const parseTodosFromToolOutput = (
     return null;
   }
   try {
-    const parsed = z.json().parse(JSON.parse(output));
+    const parsed = todoJsonValueSchema.parse(JSON.parse(output));
     if (Array.isArray(parsed)) {
-      return normalizeAgentSessionTodoList(agentSessionTodoPayloadListSchema().parse(parsed));
+      return normalizeAgentSessionTodoList(todoOutputListSchema.parse(parsed));
     }
     const record = agentToolDataSchema.safeParse(parsed);
-    if (record.success) {
-      if (Array.isArray(record.data.todos)) {
-        return normalizeAgentSessionTodoList(
-          agentSessionTodoPayloadListSchema().parse(record.data.todos),
-        );
-      }
+    if (record.success && Array.isArray(record.data.todos)) {
+      return normalizeAgentSessionTodoList(todoOutputListSchema.parse(record.data.todos));
     }
     return null;
   } catch {
@@ -37,18 +37,15 @@ export const parseTodosFromToolInput = (
   if (!input) {
     return null;
   }
-  const rawTodos = Array.isArray(input.todos)
-    ? input.todos
-    : Array.isArray(input.items)
-      ? input.items
-      : null;
-  if (!rawTodos) {
+  let rawTodos = input.todos;
+  if (!Array.isArray(rawTodos)) {
+    rawTodos = input.items;
+  }
+  if (!Array.isArray(rawTodos)) {
     return null;
   }
 
-  const parsed = agentSessionTodoPayloadListSchema({
-    allowStringEntries: true,
-  }).parse(rawTodos);
+  const parsed = todoInputListSchema.parse(rawTodos);
   const normalized = normalizeAgentSessionTodoList(parsed);
 
   return normalized.length > 0 ? normalized : null;

--- a/packages/frontend/src/state/queries/agent-session-view-sync.ts
+++ b/packages/frontend/src/state/queries/agent-session-view-sync.ts
@@ -9,6 +9,8 @@ import {
   refreshAgentSessionLists,
 } from "./agent-sessions";
 
+const queryKeyStringSchema = z.string();
+
 export type AgentSessionViewSync = {
   reconcileExternalEvent: (event: ExternalTaskSyncEvent) => Promise<void>;
   reconcileStreamSnapshot: (activeRepoPath: string | null, taskIds: string[]) => Promise<void>;
@@ -68,7 +70,7 @@ function cachedAgentSessionTaskIds(queryClient: QueryClient, repoPath: string): 
     .findAll({ queryKey: agentSessionQueryKeys.all, exact: false })
     .flatMap((query) => {
       const [, kind, cachedRepoPath, taskId] = query.queryKey;
-      const taskIdResult = z.string().safeParse(taskId);
+      const taskIdResult = queryKeyStringSchema.safeParse(taskId);
       return kind === "list" && cachedRepoPath === repoPath && taskIdResult.success
         ? [taskIdResult.data]
         : [];

--- a/packages/frontend/src/state/queries/documents.ts
+++ b/packages/frontend/src/state/queries/documents.ts
@@ -6,6 +6,8 @@ import { resolveLatestDocumentPayload } from "./document-utils";
 
 export const TASK_DOCUMENT_STALE_TIME_MS = 60_000;
 
+const queryKeyStringSchema = z.string();
+
 export type TaskDocument = {
   markdown: string;
   updatedAt: string | null;
@@ -128,7 +130,7 @@ export const removeCachedTaskDocumentQueries = (
     exact: false,
   })) {
     const [scope, _section, cachedRepoPath, cachedTaskId] = query.queryKey;
-    const cachedTaskIdResult = z.string().safeParse(cachedTaskId);
+    const cachedTaskIdResult = queryKeyStringSchema.safeParse(cachedTaskId);
     if (
       scope !== documentQueryKeys.all[0] ||
       cachedRepoPath !== repoPath ||
@@ -156,7 +158,7 @@ export const invalidateCachedTaskDocumentQueries = async (
     exact: false,
     predicate: (query) => {
       const [scope, _section, cachedRepoPath, cachedTaskId] = query.queryKey;
-      const cachedTaskIdResult = z.string().safeParse(cachedTaskId);
+      const cachedTaskIdResult = queryKeyStringSchema.safeParse(cachedTaskId);
       return (
         scope === documentQueryKeys.all[0] &&
         cachedRepoPath === repoPath &&

--- a/packages/frontend/src/state/queries/task-view-sync.ts
+++ b/packages/frontend/src/state/queries/task-view-sync.ts
@@ -6,6 +6,8 @@ import { resolveLatestDocumentPayload } from "./document-utils";
 import { documentQueryKeys, type TaskDocument, type TaskDocumentSection } from "./documents";
 import { invalidateRepoTaskQueries, taskQueryKeys } from "./tasks";
 
+const queryKeyStringSchema = z.string();
+
 export type TaskViewSyncPorts = {
   listTasks: (repoPath: string) => Promise<TaskCard[]>;
   loadFreshDocument: (
@@ -49,7 +51,7 @@ const cachedDocumentEntries = (queryClient: QueryClient, repoPath: string): Cach
     .findAll({ queryKey: documentQueryKeys.all, exact: false })
     .flatMap<CachedDocumentEntry>((query) => {
       const [scope, section, cachedRepoPath, taskId] = query.queryKey;
-      const taskIdResult = z.string().safeParse(taskId);
+      const taskIdResult = queryKeyStringSchema.safeParse(taskId);
       if (
         scope !== documentQueryKeys.all[0] ||
         cachedRepoPath !== repoPath ||
@@ -234,7 +236,7 @@ export const createTaskViewSync = ({
       const repos = new Set<string>([
         ...(activeRepoPath ? [activeRepoPath] : []),
         ...taskQueries.flatMap((query) => {
-          const repoPathResult = z.string().safeParse(query.queryKey[2]);
+          const repoPathResult = queryKeyStringSchema.safeParse(query.queryKey[2]);
           return repoPathResult.success ? [repoPathResult.data] : [];
         }),
       ]);
@@ -311,11 +313,11 @@ export const createTaskViewSync = ({
       const repos = new Set<string>([
         ...(activeRepoPath ? [activeRepoPath] : []),
         ...taskQueries.flatMap((query) => {
-          const repoPathResult = z.string().safeParse(query.queryKey[2]);
+          const repoPathResult = queryKeyStringSchema.safeParse(query.queryKey[2]);
           return repoPathResult.success ? [repoPathResult.data] : [];
         }),
         ...documentQueries.flatMap((query) => {
-          const repoPathResult = z.string().safeParse(query.queryKey[2]);
+          const repoPathResult = queryKeyStringSchema.safeParse(query.queryKey[2]);
           return repoPathResult.success ? [repoPathResult.data] : [];
         }),
       ]);

--- a/packages/host-client/package.json
+++ b/packages/host-client/package.json
@@ -16,6 +16,6 @@
   "dependencies": {
     "@openducktor/contracts": "workspace:*",
     "@openducktor/core": "workspace:*",
-    "zod": "^4.4.3"
+    "zod": "^4.6.2"
   }
 }

--- a/packages/host-client/src/agent-session-live-attachment.ts
+++ b/packages/host-client/src/agent-session-live-attachment.ts
@@ -5,7 +5,7 @@ type AgentSessionLiveAttachment = {
   restart: () => void;
 };
 
-const envelopeRepoPath = (envelope: AgentSessionLiveEnvelope): string => {
+export const envelopeRepoPath = (envelope: AgentSessionLiveEnvelope): string => {
   switch (envelope.type) {
     case "snapshot":
     case "transcript_gap":

--- a/packages/host-client/src/index.ts
+++ b/packages/host-client/src/index.ts
@@ -1,6 +1,9 @@
 import type { PlannerTools } from "@openducktor/core";
 
-export { createAgentSessionLiveAttachment } from "./agent-session-live-attachment";
+export {
+  createAgentSessionLiveAttachment,
+  envelopeRepoPath as agentSessionLiveEnvelopeRepoPath,
+} from "./agent-session-live-attachment";
 
 import { HostAgentSessionLiveClient } from "./agent-session-live-client";
 import { HostAgentClient } from "./build-runtime-client";

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -30,7 +30,7 @@
     "remark-parse": "^11.0.0",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",
-    "zod": "^4.4.3"
+    "zod": "^4.6.2"
   },
   "devDependencies": {
     "@types/node": "^26.4.0",

--- a/packages/host/src/adapters/agent-sessions/opencode-live-session-ref-index.ts
+++ b/packages/host/src/adapters/agent-sessions/opencode-live-session-ref-index.ts
@@ -1,0 +1,41 @@
+import type { AgentSessionLiveRef } from "@openducktor/contracts";
+import { HostValidationError } from "../../effect/host-errors";
+import { refKey, toSessionRef } from "./opencode-live-session-normalization";
+
+export class OpenCodeSessionRefIndex {
+  private readonly byExternalId = new Map<string, Map<string, AgentSessionLiveRef>>();
+
+  constructor(private readonly runtimeId: string) {}
+
+  set(ref: AgentSessionLiveRef): void {
+    let refs = this.byExternalId.get(ref.externalSessionId);
+    if (!refs) {
+      refs = new Map();
+      this.byExternalId.set(ref.externalSessionId, refs);
+    }
+    refs.set(refKey(ref), ref);
+  }
+
+  delete(ref: AgentSessionLiveRef): void {
+    const refs = this.byExternalId.get(ref.externalSessionId);
+    refs?.delete(refKey(ref));
+    if (refs?.size === 0) this.byExternalId.delete(ref.externalSessionId);
+  }
+
+  find(externalSessionId: string): AgentSessionLiveRef | null {
+    const matches = this.byExternalId.get(externalSessionId);
+    if (matches && matches.size > 1) {
+      throw new HostValidationError({
+        field: "externalSessionId",
+        message: `OpenCode runtime '${this.runtimeId}' cannot route ambiguous session id '${externalSessionId}'.`,
+        details: { runtimeId: this.runtimeId, externalSessionId },
+      });
+    }
+    const ref = matches?.values().next().value;
+    return ref ? toSessionRef(ref) : null;
+  }
+
+  clear(): void {
+    this.byExternalId.clear();
+  }
+}

--- a/packages/host/src/adapters/agent-sessions/opencode-live-session-state.test.ts
+++ b/packages/host/src/adapters/agent-sessions/opencode-live-session-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { RUNTIME_DESCRIPTORS_BY_KIND } from "@openducktor/contracts";
 import type { AgentSessionSummary } from "@openducktor/core";
+import { HostValidationError } from "../../effect/host-errors";
 import type { OpenCodeRuntimeInstance } from "./opencode-live-session-normalization";
 import { createOpenCodeLiveSessionState } from "./opencode-live-session-state";
 
@@ -217,6 +218,57 @@ describe("OpenCode host live-session state", () => {
     });
     expect(state.removeSession(ref)).toEqual([{ type: "session_removed", ref }]);
     expect(state.listSnapshots()).toEqual([]);
+  });
+
+  test("retains early context and updates only the matching session", () => {
+    const state = createState();
+    expect(state.setContext("session-1", { totalTokens: 42 })).toEqual([]);
+    expect(state.listSnapshots()).toEqual([]);
+    state.applyControlSummary(summary());
+    state.applyControlSummary(summary("session-2"));
+    const ref = state.refForExternalSession("session-1");
+    if (!ref) throw new Error("Expected a live session reference.");
+    expect(state.contextUsage(ref)).toEqual({ totalTokens: 42 });
+
+    expect(state.setContext("session-1", { totalTokens: 84 })).toEqual([
+      {
+        type: "session_upsert",
+        snapshot: expect.objectContaining({ ref, contextUsage: { totalTokens: 84 } }),
+      },
+    ]);
+    expect(state.contextUsage(ref)).toEqual({ totalTokens: 84 });
+    expect(state.listSnapshots()).toContainEqual(
+      expect.objectContaining({
+        ref: expect.objectContaining({ externalSessionId: "session-2" }),
+        contextUsage: null,
+      }),
+    );
+    expect(state.setContext("session-1", { totalTokens: 84 })).toEqual([]);
+  });
+
+  test("rejects ambiguous context updates without changing state and resumes after removal", () => {
+    const state = createState();
+    state.applyControlSummary(summary());
+    const first = state.refForExternalSession("session-1");
+    if (!first) throw new Error("Expected a live session reference.");
+    state.setContext("session-1", { totalTokens: 42 });
+    state.applyControlSummary({ ...summary(), workingDirectory: "/other" });
+    const before = state.listSnapshots();
+
+    expect(() => state.setContext("session-1", { totalTokens: 84 })).toThrow(HostValidationError);
+    state.applyControlSummary(summary());
+    expect(state.listSnapshots()).toEqual(before);
+
+    state.removeSession(first);
+    expect(state.setContext("session-1", { totalTokens: 84 })).toEqual([
+      {
+        type: "session_upsert",
+        snapshot: expect.objectContaining({
+          ref: { ...first, workingDirectory: "/other" },
+          contextUsage: { totalTokens: 84 },
+        }),
+      },
+    ]);
   });
 
   test("removes a vanished descendant when the runtime list omits it", () => {

--- a/packages/host/src/adapters/agent-sessions/opencode-live-session-state.test.ts
+++ b/packages/host/src/adapters/agent-sessions/opencode-live-session-state.test.ts
@@ -56,6 +56,25 @@ describe("OpenCode host live-session state", () => {
     ]);
   });
 
+  test("indexes external ids through replacement, ambiguity, removal, and release", () => {
+    const state = createState();
+    expect(state.refForExternalSession("session-1")).toBeNull();
+    state.applyControlSummary(summary());
+    const first = state.refForExternalSession("session-1");
+    if (!first) throw new Error("Expected a live session reference.");
+    state.applyControlSummary({ ...summary(), title: "Updated title" });
+    expect(state.refForExternalSession("session-1")).toEqual(first);
+    state.applyControlSummary({ ...summary(), workingDirectory: "/other" });
+    expect(() => state.refForExternalSession("session-1")).toThrow("ambiguous session id");
+    state.removeSession(first);
+    const remaining = state.refForExternalSession("session-1");
+    expect(remaining?.workingDirectory).toBe("/other");
+    state.release();
+    expect(state.refForExternalSession("session-1")).toBeNull();
+    state.applyControlSummary(summary());
+    expect(state.refForExternalSession("session-1")).toEqual(first);
+  });
+
   test("retains and resolves pending input from runtime events", () => {
     const state = createState();
     state.applyControlSummary(summary());
@@ -143,6 +162,8 @@ describe("OpenCode host live-session state", () => {
       childExternalSessionId: "grandchild",
     });
 
+    expect(state.refForExternalSession("child")?.externalSessionId).toBe("child");
+    expect(state.refForExternalSession("grandchild")?.externalSessionId).toBe("grandchild");
     expect(state.listSnapshots()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ ref: expect.objectContaining({ externalSessionId: "parent" }) }),

--- a/packages/host/src/adapters/agent-sessions/opencode-live-session-state.ts
+++ b/packages/host/src/adapters/agent-sessions/opencode-live-session-state.ts
@@ -136,21 +136,12 @@ export const createOpenCodeLiveSessionState = ({
     usage: OpencodeSessionContextUsage,
   ): AgentSessionLiveAdapterChange[] => {
     const contextUsage = toContextUsage(usage);
-    const matches = [...sessionsByRef.values()].filter(
-      ({ snapshot }) => snapshot.ref.externalSessionId === externalSessionId,
-    );
-    if (matches.length > 1) {
-      throw new HostValidationError({
-        field: "externalSessionId",
-        message: `OpenCode runtime '${runtime.runtimeId}' has multiple live sessions with id '${externalSessionId}'.`,
-        details: { runtimeId: runtime.runtimeId, externalSessionId },
-      });
-    }
-    const session = matches[0];
-    if (!session) {
+    const ref = refsByExternalSessionId.find(externalSessionId);
+    if (!ref) {
       contextUsageBySessionId.set(externalSessionId, contextUsage);
       return [];
     }
+    const session = requireSession(ref);
     if (openCodeLiveSnapshotsEqual(session.snapshot, { ...session.snapshot, contextUsage })) {
       contextUsageBySessionId.set(externalSessionId, contextUsage);
       return [];

--- a/packages/host/src/adapters/agent-sessions/opencode-live-session-state.ts
+++ b/packages/host/src/adapters/agent-sessions/opencode-live-session-state.ts
@@ -1,3 +1,4 @@
+import { OpenCodeSessionRefIndex } from "./opencode-live-session-ref-index";
 import type {
   OpencodeRuntimeSnapshotRead,
   OpencodeSessionContextUsage,
@@ -43,6 +44,7 @@ export const createOpenCodeLiveSessionState = ({
   readonly nextOccurrenceId: () => string;
 }) => {
   const sessionsByRef = new Map<string, OpenCodeLiveSession>();
+  const refsByExternalSessionId = new OpenCodeSessionRefIndex(runtime.runtimeId);
   const contextUsageBySessionId = new Map<string, AgentSessionContextUsage>();
   const versionsByRef = new Map<string, number>();
   const pendingRequests = createOpenCodePendingRequestRouter({
@@ -57,6 +59,7 @@ export const createOpenCodeLiveSessionState = ({
     const key = refKey(session.snapshot.ref);
     const previous = sessionsByRef.get(key)?.snapshot;
     sessionsByRef.set(key, session);
+    refsByExternalSessionId.set(session.snapshot.ref);
     if (previous && openCodeLiveSnapshotsEqual(previous, session.snapshot)) {
       return [];
     }
@@ -394,6 +397,7 @@ export const createOpenCodeLiveSessionState = ({
       return [];
     }
     sessionsByRef.delete(key);
+    refsByExternalSessionId.delete(ref);
     versionsByRef.set(key, (versionsByRef.get(key) ?? 0) + 1);
     contextUsageBySessionId.delete(ref.externalSessionId);
     pendingRequests.removeSession(ref);
@@ -464,19 +468,8 @@ export const createOpenCodeLiveSessionState = ({
     requirePendingRoute,
     completePendingReply,
     removeSession,
-    refForExternalSession: (externalSessionId: string): AgentSessionLiveRef | null => {
-      const matches = [...sessionsByRef.values()].filter(
-        ({ snapshot }) => snapshot.ref.externalSessionId === externalSessionId,
-      );
-      if (matches.length > 1) {
-        throw new HostValidationError({
-          field: "externalSessionId",
-          message: `OpenCode runtime '${runtime.runtimeId}' cannot route ambiguous session id '${externalSessionId}'.`,
-          details: { runtimeId: runtime.runtimeId, externalSessionId },
-        });
-      }
-      return matches[0] ? toSessionRef(matches[0].snapshot.ref) : null;
-    },
+    refForExternalSession: (externalSessionId: string): AgentSessionLiveRef | null =>
+      refsByExternalSessionId.find(externalSessionId),
     release: (): AgentSessionLiveRef[] => {
       const refs = [...sessionsByRef.values()].map(({ snapshot }) => toSessionRef(snapshot.ref));
       for (const ref of refs) {
@@ -484,6 +477,7 @@ export const createOpenCodeLiveSessionState = ({
         versionsByRef.set(key, (versionsByRef.get(key) ?? 0) + 1);
       }
       sessionsByRef.clear();
+      refsByExternalSessionId.clear();
       pendingRequests.clear();
       contextUsageBySessionId.clear();
       return refs;

--- a/packages/host/src/adapters/claude/claude-agent-sdk-file-edits.ts
+++ b/packages/host/src/adapters/claude/claude-agent-sdk-file-edits.ts
@@ -9,6 +9,9 @@ import {
 } from "./claude-agent-sdk-ingress-schemas";
 import { readStringProp } from "./claude-agent-sdk-utils";
 
+const stringSchema = z.string();
+const finiteNumberSchema = z.number().finite();
+
 type ClaudeFileEditPayload = {
   fileDiffs?: FileDiff[];
 };
@@ -32,12 +35,12 @@ const readRecordProp = (record: ClaudeProtocolObject, key: string): ClaudeProtoc
 };
 
 const readNumberProp = (record: ClaudeProtocolObject, key: string): number | undefined => {
-  const parsed = z.number().finite().safeParse(record[key]);
+  const parsed = finiteNumberSchema.safeParse(record[key]);
   return parsed.success ? parsed.data : undefined;
 };
 
 const readStringValue = (record: ClaudeProtocolObject, key: string): string | undefined => {
-  const parsed = z.string().safeParse(record[key]);
+  const parsed = stringSchema.safeParse(record[key]);
   return parsed.success ? parsed.data : undefined;
 };
 
@@ -53,7 +56,7 @@ const readStructuredPatchHunk = (value: ClaudeProtocolObject[string]): string | 
   }
   const { oldStart, oldLines, newStart, newLines, lines } = parsed.data;
   const hunkLines = lines.flatMap((line) => {
-    const text = z.string().safeParse(line);
+    const text = stringSchema.safeParse(line);
     return text.success && text.data.length > 0 ? [text.data] : [];
   });
   return [
@@ -124,7 +127,7 @@ const readPatchFromRecord = (
 
   for (const key of ["gitDiff", "structuredPatch", "fileDiff", "filediff"] as const) {
     const nested = record[key];
-    const nestedText = z.string().safeParse(nested);
+    const nestedText = stringSchema.safeParse(nested);
     if (nestedText.success && nestedText.data.trim().length > 0) {
       return nestedText.data;
     }
@@ -234,7 +237,7 @@ const changeTypeFromToolInput = (
     return readStringProp(record, "type")?.toLowerCase() === "create" ? "added" : "modified";
   }
   const oldString = input?.old_string ?? input?.oldString;
-  const parsedOldString = z.string().safeParse(oldString);
+  const parsedOldString = stringSchema.safeParse(oldString);
   return parsedOldString.success && parsedOldString.data.length === 0 ? "added" : "modified";
 };
 

--- a/packages/host/src/adapters/claude/claude-agent-sdk-history-support.ts
+++ b/packages/host/src/adapters/claude/claude-agent-sdk-history-support.ts
@@ -36,7 +36,8 @@ const claudeHistoryContentBlockSchema = z.looseObject({
 });
 const claudeHistoryMessageContentSchema = z.looseObject({ content: z.unknown() });
 const claudeHistorySourceSchema = z.looseObject({ media_type: z.string().optional() });
-const claudeHistoryStringArraySchema = z.array(z.string().min(1));
+const claudeHistoryStringSchema = z.string().min(1);
+const claudeHistoryStringArraySchema = z.array(claudeHistoryStringSchema);
 
 export const appendUnmatchedLiveUserMessages = (
   history: AgentSessionHistoryMessage[],
@@ -170,7 +171,7 @@ export const readClaudeHistoryDisplayParts = (
     return [];
   }
   const content = parsedMessage.data.content;
-  const textContent = z.string().min(1).safeParse(content);
+  const textContent = claudeHistoryStringSchema.safeParse(content);
   if (textContent.success) {
     return readClaudeHistoryTextDisplayParts(textContent.data);
   }

--- a/packages/host/src/adapters/claude/claude-agent-sdk-tool-shapes.ts
+++ b/packages/host/src/adapters/claude/claude-agent-sdk-tool-shapes.ts
@@ -12,6 +12,9 @@ import {
 import type { ClaudeToolInput } from "./claude-agent-sdk-types";
 import { previewInput, readStringProp, toolPartPresentation } from "./claude-agent-sdk-utils";
 
+const toolContentStringSchema = z.string();
+const toolContentScalarSchema = z.union([z.number(), z.boolean()]);
+
 type ClaudeToolUseMetadata =
   | {
       blockType: ClaudeToolUseBlockType;
@@ -190,7 +193,7 @@ const stringifyToolResultContent = (value: ClaudeProtocolValue): string => {
   if (value === null) {
     return "";
   }
-  const primitive = z.union([z.number(), z.boolean()]).safeParse(value);
+  const primitive = toolContentScalarSchema.safeParse(value);
   if (primitive.success) {
     return String(primitive.data);
   }
@@ -198,7 +201,7 @@ const stringifyToolResultContent = (value: ClaudeProtocolValue): string => {
 };
 
 const toolResultBlockText = (block: ClaudeProtocolValue): string => {
-  const text = z.string().safeParse(block);
+  const text = toolContentStringSchema.safeParse(block);
   if (text.success) {
     return text.data;
   }

--- a/packages/host/src/adapters/codex/codex-app-server-transport-messages.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport-messages.ts
@@ -22,6 +22,21 @@ import {
 
 const MAX_CAPTURED_STDERR_BYTES = 64 * 1024;
 
+const responseIdSchema = z.number();
+const methodSchema = z.string();
+const serverRequestIdSchema = z.union([z.number(), z.string()]);
+
+export const readCodexMessageRouting = (message: CodexAppServerJsonObject) => {
+  const parsedResponseId = responseIdSchema.safeParse(message.id);
+  const parsedServerRequestId = serverRequestIdSchema.safeParse(message.id);
+  return {
+    responseId: parsedResponseId.success ? parsedResponseId.data : null,
+    serverRequestId: parsedServerRequestId.success ? parsedServerRequestId.data : null,
+    hasMethod: methodSchema.safeParse(message.method).success,
+    hasResponse: "result" in message || "error" in message,
+  };
+};
+
 const isCodexServerRequestMethod = (method: string): method is CodexAppServerServerRequestMethod =>
   CODEX_APP_SERVER_SERVER_REQUEST_METHODS.some((candidate) => candidate === method);
 
@@ -81,7 +96,7 @@ export function parseStreamMessage(
   message: CodexAppServerJsonObject,
   kind: "notification" | "server_request",
 ): CodexAppServerProtocolMessage {
-  const parsedMethod = z.string().safeParse(message.method);
+  const parsedMethod = methodSchema.safeParse(message.method);
   if (!parsedMethod.success || parsedMethod.data.trim().length === 0) {
     throw new HostValidationError({
       message: `Codex app-server ${kind} for ${runtimeId} is missing a method`,
@@ -98,7 +113,7 @@ export function parseStreamMessage(
     });
   }
   if (kind === "server_request") {
-    if (!z.union([z.number(), z.string()]).safeParse(message.id).success) {
+    if (!serverRequestIdSchema.safeParse(message.id).success) {
       throw new HostValidationError({
         message: `Codex app-server server request for ${runtimeId} is missing an id`,
         field: "id",

--- a/packages/host/src/adapters/codex/codex-app-server-transport.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport.ts
@@ -24,6 +24,7 @@ import {
 import {
   appendCapturedStderr,
   parseStreamMessage,
+  readCodexMessageRouting,
   respondToAutomaticServerRequest,
 } from "./codex-app-server-transport-messages";
 import type {
@@ -256,12 +257,8 @@ export const createCodexAppServerTransport = (
   };
 
   const handleMessage = (messageRecord: CodexAppServerJsonObject): void => {
-    const parsedResponseId = z.number().safeParse(messageRecord.id);
-    const responseId = parsedResponseId.success ? parsedResponseId.data : null;
-    const parsedServerRequestId = z.union([z.number(), z.string()]).safeParse(messageRecord.id);
-    const serverRequestId = parsedServerRequestId.success ? parsedServerRequestId.data : null;
-    const hasMethod = z.string().safeParse(messageRecord.method).success;
-    const hasResponse = "result" in messageRecord || "error" in messageRecord;
+    const { responseId, serverRequestId, hasMethod, hasResponse } =
+      readCodexMessageRouting(messageRecord);
 
     if (hasResponse) {
       if (responseId === null) {

--- a/packages/host/src/adapters/sqlite/sqlite-json-codecs.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-json-codecs.ts
@@ -17,6 +17,8 @@ type SafeParser<Input, Output> = {
 };
 
 const labelsSchema = z.array(z.string());
+const jsonValueSchema = z.json();
+const agentSessionListSchema = agentSessionRecordSchema.array();
 
 export const normalizeLabels = (labels: string[]): string[] =>
   Array.from(new Set(labels.map((label) => label.trim()).filter(Boolean))).sort();
@@ -75,7 +77,7 @@ export const parseJsonColumnValue = (
     return Effect.succeed(fallback);
   }
   return Effect.try({
-    try: () => z.json().parse(JSON.parse(value)),
+    try: () => jsonValueSchema.parse(JSON.parse(value)),
     catch: (cause) =>
       new SqliteTaskStoreDataError({
         message: `Invalid SQLite task ${taskId} ${field} JSON: ${errorMessage(cause)}`,
@@ -126,7 +128,7 @@ export const agentSessionsFromRow = (
     row.agentSessionsJson,
     [],
     (value) =>
-      decodeWithSchema(agentSessionRecordSchema.array(), value, "agent_sessions_json", {
+      decodeWithSchema(agentSessionListSchema, value, "agent_sessions_json", {
         taskId: row.id,
       }),
     "agent_sessions_json",

--- a/packages/host/src/effect/json.ts
+++ b/packages/host/src/effect/json.ts
@@ -1,3 +1,5 @@
 import { z, type JSONType } from "zod";
 
-export const parseJson = (payload: string): JSONType => z.json().parse(JSON.parse(payload));
+const jsonValueSchema = z.json();
+
+export const parseJson = (payload: string): JSONType => jsonValueSchema.parse(JSON.parse(payload));

--- a/packages/host/src/interface/commands/task-command-inputs.ts
+++ b/packages/host/src/interface/commands/task-command-inputs.ts
@@ -48,6 +48,7 @@ import {
 } from "./task-command-parsing";
 import {
   commandInputRecordSchema,
+  commandInputStringSchema,
   type CommandInputRecord,
   type HostCommandArgs,
   requireParsedRecord,
@@ -57,8 +58,11 @@ const optionalBooleanSchema = z.union([z.boolean(), z.null(), z.undefined()]);
 const optionalStringSchema = z.union([z.string(), z.null(), z.undefined()]);
 const taskIdsSchema = z.array(z.unknown());
 
+const optionalDescriptionAssetsSchema = taskAssetDescriptionMutationSchema.optional();
+const optionalPlanSubtasksSchema = planSubtaskInputSchema.array().optional();
+
 const readRequiredString = (record: CommandInputRecord, key: string, label: string = key): string =>
-  requireString(z.string().safeParse(record[key]), label);
+  requireString(commandInputStringSchema.safeParse(record[key]), label);
 
 export const parseRepoPathInput = (input: HostCommandArgs, label: string): RepoPathInput => {
   const record = requireParsedRecord(commandInputRecordSchema.safeParse(input), label);
@@ -102,7 +106,7 @@ export const parseListAgentSessionsForTasksInput = (
   }
   const taskIds = parsedTaskIds.data.map((taskId, index) => {
     const field = `taskIds[${index}]`;
-    const parsedTaskId = z.string().safeParse(taskId);
+    const parsedTaskId = commandInputStringSchema.safeParse(taskId);
     if (!parsedTaskId.success) {
       throw new HostValidationError({
         message: `${field} must be a string.`,
@@ -177,7 +181,7 @@ export const parseCreateTaskInput = (input: HostCommandArgs): CreateTaskUseCaseI
     "task_create input",
   );
   const descriptionAssets = parseDescriptionAssets(
-    taskAssetDescriptionMutationSchema.optional().safeParse(record.descriptionAssets),
+    optionalDescriptionAssetsSchema.safeParse(record.descriptionAssets),
   );
   const result: CreateTaskUseCaseInput = {
     repoPath: readRequiredString(record, "repoPath"),
@@ -210,7 +214,7 @@ export const parseUpdateTaskInput = (input: HostCommandArgs): UpdateTaskInput =>
   );
   const patch = parseUpdatePatch(taskUpdatePatchSchema.safeParse(record.patch));
   const descriptionAssets = parseDescriptionAssets(
-    taskAssetDescriptionMutationSchema.optional().safeParse(record.descriptionAssets),
+    optionalDescriptionAssetsSchema.safeParse(record.descriptionAssets),
   );
   if (descriptionAssets && !Object.hasOwn(patch, "description")) {
     throw new HostValidationError({
@@ -250,7 +254,10 @@ export const parseMarkdownDocumentInput = (
   return {
     repoPath: readRequiredString(record, "repoPath"),
     taskId: readRequiredString(record, "taskId"),
-    markdown: parseRequiredMarkdown(z.string().safeParse(record.markdown), markdownLabel),
+    markdown: parseRequiredMarkdown(
+      commandInputStringSchema.safeParse(record.markdown),
+      markdownLabel,
+    ),
   };
 };
 
@@ -262,7 +269,10 @@ export const parseQaOutcomeInput = (
   return {
     repoPath: readRequiredString(record, "repoPath"),
     taskId: readRequiredString(record, "taskId"),
-    markdown: parseRequiredMarkdown(z.string().safeParse(record.reportMarkdown), "QA report"),
+    markdown: parseRequiredMarkdown(
+      commandInputStringSchema.safeParse(record.reportMarkdown),
+      "QA report",
+    ),
   };
 };
 
@@ -276,12 +286,10 @@ export const parseSetPlanInput = (input: HostCommandArgs): SetPlanInput => {
     repoPath: readRequiredString(record, "repoPath"),
     taskId: readRequiredString(record, "taskId"),
     markdown: parseRequiredMarkdown(
-      z.string().safeParse(planInput.markdown),
+      commandInputStringSchema.safeParse(planInput.markdown),
       "implementation plan",
     ),
-    subtasks: parsePlanSubtasks(
-      planSubtaskInputSchema.array().optional().safeParse(planInput.subtasks),
-    ),
+    subtasks: parsePlanSubtasks(optionalPlanSubtasksSchema.safeParse(planInput.subtasks)),
     hasExplicitSubtasks: "subtasks" in planInput,
   };
 };
@@ -303,7 +311,7 @@ export const parseBuildBlockedInput = (input: HostCommandArgs): BuildBlockedInpu
     commandInputRecordSchema.safeParse(input),
     "build_blocked input",
   );
-  const parsedReason = z.string().safeParse(record.reason);
+  const parsedReason = commandInputStringSchema.safeParse(record.reason);
   const reason = parsedReason.success ? parsedReason.data.trim() : "";
   if (!reason) {
     throw new HostValidationError({

--- a/packages/host/src/interface/commands/task-command-parsing.ts
+++ b/packages/host/src/interface/commands/task-command-parsing.ts
@@ -138,7 +138,7 @@ const normalizedAgentSessionInputSchema = z.record(z.string(), z.json()).transfo
   const normalized = { ...record };
   for (const key of agentSessionStringKeys) {
     const value = normalized[key];
-    const parsed = z.string().safeParse(value);
+    const parsed = commandInputStringSchema.safeParse(value);
     if (parsed.success) {
       normalized[key] = parsed.data.trim();
     }
@@ -191,7 +191,7 @@ export const parsePullRequestContent = (
 ): PullRequestContent => {
   const record = requireParsedRecord(result, "task_pull_request_upsert input.input");
   const title = requireString(commandInputStringSchema.safeParse(record.title), "input.title");
-  const body = z.string().safeParse(record.body);
+  const body = commandInputStringSchema.safeParse(record.body);
   if (!body.success) {
     throw invalidInput("input.body is required.", "input.body");
   }

--- a/packages/openducktor-mcp/package.json
+++ b/packages/openducktor-mcp/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "zod": "^4.4.3"
+    "zod": "^4.6.2"
   },
   "devDependencies": {
     "@openducktor/build-tools": "workspace:*",

--- a/packages/openducktor-web/package.json
+++ b/packages/openducktor-web/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.251",
     "undici": "^8.10.2",
-    "zod": "^4.4.3"
+    "zod": "^4.6.2"
   },
   "devDependencies": {
     "@openducktor/build-tools": "workspace:*",

--- a/packages/openducktor-web/src/host-event-stream-name.ts
+++ b/packages/openducktor-web/src/host-event-stream-name.ts
@@ -1,0 +1,11 @@
+import type { HostEventEnvelope } from "@openducktor/contracts";
+import { agentSessionLiveEnvelopeRepoPath } from "@openducktor/host-client";
+
+// JSON escaping keeps repository paths on one SSE field line, including unusual path characters.
+export const liveSessionStreamEventName = (repoPath: string): string =>
+  `agent-session-live:${JSON.stringify(repoPath)}`;
+
+export const hostEventStreamEventName = (envelope: HostEventEnvelope): string =>
+  envelope.channel === "openducktor://agent-session-live-event"
+    ? liveSessionStreamEventName(agentSessionLiveEnvelopeRepoPath(envelope.payload))
+    : "message";

--- a/packages/openducktor-web/src/local-host-transport.test.ts
+++ b/packages/openducktor-web/src/local-host-transport.test.ts
@@ -1,3 +1,4 @@
+import { liveSessionStreamEventName } from "./host-event-stream-name";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { AgentSessionLiveEnvelope } from "@openducktor/contracts";
 import { Effect } from "effect";
@@ -406,7 +407,12 @@ describe("local host SSE subscriptions", () => {
     const stopObservingLiveSessions = await liveSessionObservation;
 
     const emitHostEvent = (channel: string, payload: JSONType): void => {
-      FakeEventSource.instances[0]?.emit("message", JSON.stringify({ channel, payload }));
+      FakeEventSource.instances[0]?.emit(
+        channel === "openducktor://agent-session-live-event"
+          ? liveSessionStreamEventName("/repo")
+          : "message",
+        JSON.stringify({ channel, payload }),
+      );
     };
     emitHostEvent("openducktor://run-event", { type: "run" });
     emitHostEvent("openducktor://dev-server-event", {
@@ -453,6 +459,59 @@ describe("local host SSE subscriptions", () => {
 
     stopObservingLiveSessions();
     expect(FakeEventSource.instances[0]?.closed).toBe(true);
+  });
+
+  test("routes named live events only to observed repositories and removes unused listeners", async () => {
+    const { observeLocalHostAgentSessions } = await loadLocalHostTransport();
+    globalThis.fetch = createFetchFixture(mock(async () => new Response("null", { status: 200 })));
+    const first = mock((_event: AgentSessionLiveEnvelope) => {});
+    const duplicate = mock((_event: AgentSessionLiveEnvelope) => {});
+    const second = mock((_event: AgentSessionLiveEnvelope) => {});
+    const firstSetup = observeLocalHostAgentSessions({ repoPath: "/first" }, first);
+    const source = await waitForEventSourceInstance();
+    source.emit("open", "");
+    const stopFirst = await firstSetup;
+    const stopDuplicate = await observeLocalHostAgentSessions({ repoPath: "/first" }, duplicate);
+    const stopSecond = await observeLocalHostAgentSessions({ repoPath: "/second" }, second);
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(() => source.emit(liveSessionStreamEventName("/unobserved"), "not-json")).not.toThrow();
+    const snapshot = { type: "snapshot", repoPath: "/first", sessions: [] };
+    source.emit(
+      liveSessionStreamEventName("/first"),
+      JSON.stringify({
+        channel: "openducktor://agent-session-live-event",
+        payload: snapshot,
+      }),
+    );
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(duplicate).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+    expect(() =>
+      source.emit(
+        liveSessionStreamEventName("/first"),
+        JSON.stringify({
+          channel: "openducktor://agent-session-live-event",
+          payload: { ...snapshot, sessions: "invalid" },
+        }),
+      ),
+    ).toThrow("Invalid OpenDucktor host event envelope");
+    expect(() =>
+      source.emit(
+        liveSessionStreamEventName("/second"),
+        JSON.stringify({
+          channel: "openducktor://agent-session-live-event",
+          payload: snapshot,
+        }),
+      ),
+    ).toThrow("wrong stream event name");
+    stopFirst();
+    expect(source.hasListener(liveSessionStreamEventName("/first"))).toBe(true);
+    stopDuplicate();
+    expect(source.hasListener(liveSessionStreamEventName("/first"))).toBe(false);
+    expect(source.closed).toBe(false);
+    stopSecond();
+    expect(source.hasListener(liveSessionStreamEventName("/second"))).toBe(false);
+    expect(source.closed).toBe(true);
   });
 
   test("resolves dev-server subscriptions on initial open and emits reconnect control payloads afterward", async () => {
@@ -534,7 +593,7 @@ describe("local host SSE subscriptions", () => {
       },
     } satisfies AgentSessionLiveEnvelope;
     eventSource.emit(
-      "message",
+      liveSessionStreamEventName("/repo"),
       JSON.stringify({
         channel: "openducktor://agent-session-live-event",
         payload: transcriptEvent,
@@ -548,7 +607,7 @@ describe("local host SSE subscriptions", () => {
       sessions: [],
     } satisfies AgentSessionLiveEnvelope;
     eventSource.emit(
-      "message",
+      liveSessionStreamEventName("/repo"),
       JSON.stringify({
         channel: "openducktor://agent-session-live-event",
         payload: snapshot,
@@ -584,7 +643,7 @@ describe("local host SSE subscriptions", () => {
       },
     } satisfies AgentSessionLiveEnvelope;
     eventSource.emit(
-      "message",
+      liveSessionStreamEventName("/repo"),
       JSON.stringify({
         channel: "openducktor://agent-session-live-event",
         payload: reconnectTranscriptEvent,
@@ -593,7 +652,7 @@ describe("local host SSE subscriptions", () => {
     expect(listener).toHaveBeenCalledTimes(3);
     const replayedSnapshot = { ...snapshot };
     eventSource.emit(
-      "message",
+      liveSessionStreamEventName("/repo"),
       JSON.stringify({
         channel: "openducktor://agent-session-live-event",
         payload: replayedSnapshot,
@@ -601,7 +660,7 @@ describe("local host SSE subscriptions", () => {
     );
     const refreshedSnapshot = { ...snapshot };
     eventSource.emit(
-      "message",
+      liveSessionStreamEventName("/repo"),
       JSON.stringify({
         channel: "openducktor://agent-session-live-event",
         payload: refreshedSnapshot,
@@ -1041,6 +1100,43 @@ describe("local host SSE subscriptions", () => {
     ]);
   });
 
+  test("rejects and cleans up when a decoded task frame is invalid after opening but before setup returns", async () => {
+    const { subscribeLocalHostTaskStream } = await loadLocalHostTransport();
+    const subscriptionId = "05e77c20-ebf2-4e7f-a880-9c95c24627ee";
+    const fetchMock = mock(async (url: string | URL | Request) => {
+      if (url.toString().endsWith("/subscriptions")) {
+        return new Response(JSON.stringify({ streamToken: "stream-token", subscriptionId }), {
+          status: 201,
+        });
+      }
+      return new Response(null, { status: 204 });
+    });
+    globalThis.fetch = createFetchFixture(fetchMock);
+    const onTerminalFailure = mock(() => {});
+
+    const setup = subscribeLocalHostTaskStream(
+      { cursor: null },
+      mock(() => {}),
+      onTerminalFailure,
+    );
+    const eventSource = await waitForEventSourceInstance();
+    await waitForEventSourceListener(eventSource, "open");
+    eventSource.emit("open", "");
+    eventSource.emit("task-frame", JSON.stringify({ type: "invalid" }));
+
+    await expect(setup).rejects.toThrow("invalid frame");
+    expect(onTerminalFailure).not.toHaveBeenCalled();
+    expect(eventSource.closed).toBe(true);
+    expect(eventSource.hasListener("task-frame")).toBe(false);
+    expect(eventSource.hasListener("open")).toBe(false);
+    expect(eventSource.hasListener("error")).toBe(false);
+    expect(fetchMock.mock.calls.map(([url]) => url.toString())).toEqual([
+      "http://127.0.0.1:14327/session",
+      "http://127.0.0.1:14327/task-events/subscriptions",
+      `http://127.0.0.1:14327/task-events/subscriptions/${subscriptionId}`,
+    ]);
+  });
+
   test("leaves reconnects to the native EventSource after task stream readiness", async () => {
     const { subscribeLocalHostTaskStream } = await loadLocalHostTransport();
     const subscriptionId = "05e77c20-ebf2-4e7f-a880-9c95c24627ee";
@@ -1162,6 +1258,56 @@ describe("local host SSE subscriptions", () => {
       expect.objectContaining({
         _tag: "WebDependencyError",
         message: expect.stringContaining("invalid JSON"),
+      }),
+    );
+    await subscription.unsubscribe();
+    eventSource.emit("error", "after unsubscribe");
+    expect(onTerminalFailure).toHaveBeenCalledTimes(1);
+    expect(
+      fetchMock.mock.calls.filter(([url]) => url.toString().endsWith(subscriptionId)),
+    ).toHaveLength(1);
+  });
+
+  test("reports invalid decoded task frames once and suppresses terminal reports after unsubscribe", async () => {
+    const { subscribeLocalHostTaskStream } = await loadLocalHostTransport();
+    const subscriptionId = "05e77c20-ebf2-4e7f-a880-9c95c24627ee";
+    const fetchMock = mock(async (url: string | URL | Request) => {
+      if (url.toString().endsWith("/subscriptions")) {
+        return new Response(JSON.stringify({ streamToken: "stream-token", subscriptionId }), {
+          status: 201,
+        });
+      }
+      return new Response(null, { status: 204 });
+    });
+    globalThis.fetch = createFetchFixture(fetchMock);
+    const onTerminalFailure = mock(() => {});
+
+    const setup = subscribeLocalHostTaskStream(
+      { cursor: null },
+      mock(() => {}),
+      onTerminalFailure,
+    );
+    const eventSource = await waitForEventSourceInstance();
+    await waitForEventSourceListener(eventSource, "open");
+    eventSource.emit("open", "");
+    eventSource.emit(
+      "task-frame",
+      JSON.stringify({
+        type: "snapshot_required",
+        cursor: { epoch: "fc49d1f9-708c-4198-b56b-f1437b2bbcea", sequence: 0 },
+        reason: "buffer_gap",
+      }),
+    );
+    const subscription = await setup;
+    eventSource.emit("task-frame", JSON.stringify({ type: "invalid" }));
+    eventSource.emit("task-frame", JSON.stringify({ type: "invalid" }));
+
+    expect(onTerminalFailure).toHaveBeenCalledTimes(1);
+    expect(onTerminalFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _tag: "WebDependencyError",
+        operation: "validate-frame",
+        message: expect.stringContaining("invalid frame"),
       }),
     );
     await subscription.unsubscribe();

--- a/packages/openducktor-web/src/local-host-transport.ts
+++ b/packages/openducktor-web/src/local-host-transport.ts
@@ -45,6 +45,7 @@ import {
   readLocalHostErrorPayloadEffect,
   readLocalHostInvokeErrorPayloadEffect,
 } from "./local-host-errors";
+import { hostEventStreamEventName, liveSessionStreamEventName } from "./host-event-stream-name";
 import { subscribeLocalTaskEventStreamEffect } from "./local-task-event-transport";
 
 type BrowserSseControlEvent = ReturnType<typeof browserLiveControlEvent>;
@@ -52,6 +53,7 @@ type BrowserSseEvent = HostEventEnvelope | BrowserSseControlEvent;
 type BrowserSseListener = (event: BrowserSseEvent) => void;
 type BrowserSseListenerRegistration = {
   channel: HostEventChannel;
+  eventName: string;
   listener: BrowserSseListener;
   receivesControlEvents: boolean;
   onReplayGap?: (message: string) => void;
@@ -293,6 +295,7 @@ const subscribeSseChannelEffect = (
   listener: BrowserSseListener,
   receivesControlEvents = false,
   onReplayGap?: (message: string) => void,
+  eventName = "message",
 ): Effect.Effect<BrowserSseSubscription, WebError> =>
   Effect.gen(function* () {
     const baseUrl = (yield* getBrowserBackendUrlEffect()).replace(/\/$/, "");
@@ -320,9 +323,13 @@ const subscribeSseChannelEffect = (
         resolveReady = resolve;
       });
       const handleMessage: EventListener = (event) => {
-        const hostEvent = parseHostEvent(readEventSourceData(event, "message"));
+        const hostEvent = parseHostEvent(readEventSourceData(event, event.type));
+        const expectedName = hostEventStreamEventName(hostEvent);
+        if (event.type !== expectedName) {
+          throw new Error("OpenDucktor host event arrived on the wrong stream event name.");
+        }
         for (const registration of listeners.values()) {
-          if (registration.channel === hostEvent.channel) {
+          if (registration.channel === hostEvent.channel && registration.eventName === event.type) {
             registration.listener(hostEvent);
           }
         }
@@ -415,11 +422,18 @@ const subscribeSseChannelEffect = (
     nextSseListenerId += 1;
     const registration: BrowserSseListenerRegistration = {
       channel: eventChannel,
+      eventName,
       listener,
       receivesControlEvents,
     };
     if (onReplayGap) {
       registration.onReplayGap = onReplayGap;
+    }
+    if (
+      eventName !== "message" &&
+      ![...channel.listeners.values()].some((entry) => entry.eventName === eventName)
+    ) {
+      channel.eventSource.addEventListener(eventName, channel.handleMessage);
     }
     channel.listeners.set(listenerId, registration);
     const activeChannel = channel;
@@ -445,6 +459,12 @@ const subscribeSseChannelEffect = (
           return;
         }
         currentChannel.listeners.delete(listenerId);
+        if (
+          eventName !== "message" &&
+          ![...currentChannel.listeners.values()].some((entry) => entry.eventName === eventName)
+        ) {
+          currentChannel.eventSource.removeEventListener(eventName, currentChannel.handleMessage);
+        }
         closeSseChannelIfUnused(currentChannel);
       },
     };
@@ -469,10 +489,17 @@ const subscribeReadyLocalHostEventsEffect = (
   channel: HostEventChannel,
   listener: BrowserSseListener,
   onReplayGap?: (message: string) => void,
+  eventName = "message",
 ): Effect.Effect<DevServerEventSubscription, WebError> =>
   Effect.gen(function* () {
     yield* ensureLocalHostSessionDedupedEffect();
-    const subscription = yield* subscribeSseChannelEffect(channel, listener, true, onReplayGap);
+    const subscription = yield* subscribeSseChannelEffect(
+      channel,
+      listener,
+      true,
+      onReplayGap,
+      eventName,
+    );
     const readyExit = yield* Effect.exit(
       Effect.tryPromise({
         try: () => {
@@ -585,6 +612,7 @@ export const observeLocalHostAgentSessions = async (
         (message) => {
           listener({ type: "transcript_gap", repoPath: input.repoPath, message });
         },
+        liveSessionStreamEventName(input.repoPath),
       );
       const initialRefreshExit = yield* Effect.exit(
         Effect.tryPromise({

--- a/packages/openducktor-web/src/local-task-event-transport.ts
+++ b/packages/openducktor-web/src/local-task-event-transport.ts
@@ -25,6 +25,8 @@ const TASK_STREAM_TOKEN_HEADER = "x-openducktor-task-stream-token";
 const TASK_EVENT_SUBSCRIPTIONS_PATH = "task-events/subscriptions";
 const INITIAL_SSE_READY_TIMEOUT_MS = 10_000;
 
+const taskFrameDataSchema = z.string();
+
 type LocalTaskEventTransportContext = {
   ensureSession: () => Effect.Effect<void, WebError>;
   localHostRequestErrorEffect: (
@@ -209,9 +211,9 @@ export const subscribeLocalTaskEventStreamEffect = (
     };
     const handleFrame = (data: string): void => {
       if (closed) return;
-      let raw: z.output<typeof taskEventStreamFrameSchema>;
+      let raw: unknown;
       try {
-        raw = taskEventStreamFrameSchema.parse(JSON.parse(data));
+        raw = JSON.parse(data);
       } catch (cause) {
         const failure = new WebDependencyError({
           dependency: "task-event-stream",
@@ -251,7 +253,7 @@ export const subscribeLocalTaskEventStreamEffect = (
         );
         return;
       }
-      const data = z.string().safeParse(event.data);
+      const data = taskFrameDataSchema.safeParse(event.data);
       if (!data.success) {
         failSetupOrReportTerminalFailure(
           new WebDependencyError({

--- a/packages/openducktor-web/src/typescript-host-backend-support.ts
+++ b/packages/openducktor-web/src/typescript-host-backend-support.ts
@@ -3,6 +3,7 @@ import {
   type HostEventEnvelope,
   parseHostEventChannel,
 } from "@openducktor/contracts";
+import { hostEventStreamEventName } from "./host-event-stream-name";
 import type { HostEventBusPort, HostEventListener, HostEventUnsubscribe } from "@openducktor/host";
 import { Cause, Effect } from "effect";
 import {
@@ -23,6 +24,7 @@ import { parseHttpOriginEffect, portOfHttpOrigin } from "./http-origin";
 export type BufferedHostEvent = {
   id: number;
   payload: string;
+  eventName: string;
 };
 export type BufferedHostEventReplay = {
   events: BufferedHostEvent[];
@@ -52,6 +54,7 @@ export class BufferedHostEventStream {
     const event = {
       id: this.nextId,
       payload: JSON.stringify(envelope),
+      eventName: hostEventStreamEventName(envelope),
     };
     this.recent.push(event);
     if (this.recent.length > this.capacity) {

--- a/packages/openducktor-web/src/typescript-host-backend.test.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.test.ts
@@ -1,3 +1,4 @@
+import { liveSessionStreamEventName } from "./host-event-stream-name";
 import { describe, expect, mock, test } from "bun:test";
 import { TERMINAL_PROTOCOL_SUBPROTOCOL, type HostEventEnvelope } from "@openducktor/contracts";
 import {
@@ -1096,6 +1097,17 @@ describe("TypeScript web host backend", () => {
       for (const event of events) {
         expect(replay).toContain(JSON.stringify(event));
       }
+      expect(replay).toContain(`id: 3\nevent: ${liveSessionStreamEventName("/repo")}\ndata: `);
+      eventBus.publish({
+        channel: "openducktor://agent-session-live-event",
+        payload: {
+          type: "snapshot",
+          repoPath: "/other",
+          sessions: [],
+        },
+      });
+      const next = new TextDecoder().decode((await readImmediateStreamChunk(reader)).value);
+      expect(next).toContain(`id: 4\nevent: ${liveSessionStreamEventName("/other")}\ndata: `);
     } finally {
       await reader.cancel();
     }

--- a/packages/openducktor-web/src/typescript-host-backend.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.ts
@@ -416,9 +416,13 @@ const validateAppCookieOrHeader = (
   );
 
 const writeSseEvent = (event: BufferedHostEvent): string =>
-  [`id: ${event.id}`, ...event.payload.split(/\r?\n/).map((line) => `data: ${line}`), "", ""].join(
-    "\n",
-  );
+  [
+    `id: ${event.id}`,
+    `event: ${event.eventName}`,
+    ...event.payload.split(/\r?\n/).map((line) => `data: ${line}`),
+    "",
+    "",
+  ].join("\n");
 const writeSseNamedEvent = (eventName: string, data: string): string =>
   [`event: ${eventName}`, ...data.split(/\r?\n/).map((line) => `data: ${line}`), "", ""].join("\n");
 const SSE_READY_COMMENT = ": openducktor-ready\n\n";
@@ -513,14 +517,15 @@ const webHostRequestErrorResponse = (
   );
 };
 
-const webRequestBodySchema = z.record(z.string(), z.json());
+const webRequestJsonValueSchema = z.json();
+const webRequestBodySchema = z.record(z.string(), webRequestJsonValueSchema);
 
 const parseJsonObjectBody = (
   request: Request,
 ): Effect.Effect<WebRequestBody, WebHostRequestError> =>
   Effect.gen(function* () {
     const parsed = yield* Effect.tryPromise({
-      try: async () => z.json().parse(await request.json()),
+      try: async () => webRequestJsonValueSchema.parse(await request.json()),
       catch: (error) =>
         new WebHostRequestError({
           message: error instanceof Error ? error.message : "Malformed JSON request body.",


### PR DESCRIPTION
Live agent sessions repeatedly built schemas, validated the same payload within one process, and scanned unrelated sessions. This work increased CPU use as the number of sessions and the size of transcripts grew.

Reduce that work in the browser runner and Electron by routing events to subscribed repositories and sessions, reusing parsed values within each process, and formatting tool input only when it is visible. Keep validation at process and network boundaries. Use one OpenCode recipient resolver for indexed delivery and logging. Select recipients when dispatch starts, skip removed subscribers, read replacements before delivery, and defer new or newly matching subscribers until the next event.

Upgrade Zod to 4.6.2 and compile selected event parsers. Keep the previous UTF-16 string limits and timestamp precision through shared compatibility helpers. Document that consumers must use Zod to enforce the UTF-16 limit and that repository event names do not restrict host access.

An isolated OpenCode routing replay used 64 and 256 sessions with 8,192 events per sample. Delivery and logging records matched for the replayed events. At 256 subscribers, final median routing CPU time was 11.3 ms without logging and 78.5 ms with logging. The dispatch consistency fix adds about 0.13 microseconds and 5.1 microseconds per event, respectively, compared with the initial PR commit. These figures cover routing code only.

Validation: `bun run format:check`, `bun run lint`, `bun run typecheck`, `bun run test`, and `bun run build` pass. The full suite reports 10,185 passed, 0 failed, and 2 skipped. React Doctor reports 100/100 with no issues, and `bun run deps:check` passes. CI passes on Linux, macOS, and Windows, including the native worker checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository-specific live session events now route only to the relevant project.
  * Tool input details load on demand and retain their state when reopened.
  * Improved session tracking and event delivery for OpenCode integrations.
  * Added a public helper for resolving agent session event repository paths.

* **Bug Fixes**
  * Improved Unicode text length handling and event-stream validation.

* **Documentation**
  * Added performance audit guidance and documented repository-specific event streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->