### PR TITLE
fix(frontend): cut settings save time from 1-2s to milliseconds

### DIFF
--- a/docs/tanstack-query-cache-strategy.md
+++ b/docs/tanstack-query-cache-strategy.md
@@ -91,8 +91,6 @@ Do not depend on a background refetch for correct state.
 
 For example, a settings save updates the settings cache. A repository settings save invalidates repository config. A task mutation invalidates task data and runs.
 
-A settings save invalidates only the caches whose source data changed. It invalidates repository config for workspace changes, runtime checks for agent runtime changes, and Git provider context for the repositories whose provider config or path changed. A task retention change refreshes task views.
-
 ## Data that does not belong in Query
 
 Keep these values outside TanStack Query:

--- a/docs/tanstack-query-cache-strategy.md
+++ b/docs/tanstack-query-cache-strategy.md
@@ -91,6 +91,8 @@ Do not depend on a background refetch for correct state.
 
 For example, a settings save updates the settings cache. A repository settings save invalidates repository config. A task mutation invalidates task data and runs.
 
+A settings save invalidates only the caches whose source data changed. It invalidates repository config for workspace changes, runtime checks for agent runtime changes, and Git provider context for the repositories whose provider config or path changed. A task retention change refreshes task views.
+
 ## Data that does not belong in Query
 
 Keep these values outside TanStack Query:

--- a/packages/frontend/src/state/operations/workspace/settings-snapshot-changes.test.ts
+++ b/packages/frontend/src/state/operations/workspace/settings-snapshot-changes.test.ts
@@ -123,13 +123,13 @@ describe("diffSettingsSnapshots", () => {
     expect(changes.changedGitProviderRepoPaths).toEqual(["/repo-a"]);
   });
 
-  test("reports the new path when a repository path changes", () => {
+  test("reports both paths when a repository path changes", () => {
     const changes = diffSettingsSnapshots(
       createSnapshot({ "repo-a": createRepoSettingsConfigFixture("repo-a", "/repo-a") }),
       createSnapshot({ "repo-a": createRepoSettingsConfigFixture("repo-a", "/repo-moved") }),
     );
 
-    expect(changes.changedGitProviderRepoPaths).toEqual(["/repo-moved"]);
+    expect(changes.changedGitProviderRepoPaths).toEqual(["/repo-moved", "/repo-a"]);
   });
 
   test("reports a repository added after the previous snapshot", () => {

--- a/packages/frontend/src/state/operations/workspace/settings-snapshot-changes.test.ts
+++ b/packages/frontend/src/state/operations/workspace/settings-snapshot-changes.test.ts
@@ -1,35 +1,14 @@
 import { describe, expect, test } from "bun:test";
+import { DEFAULT_AGENT_RUNTIMES } from "@openducktor/contracts";
 import {
-  DEFAULT_AGENT_RUNTIMES,
-  type RepoGitConfig,
-  type SettingsRepoConfig,
-  settingsRepoConfigSchema,
-} from "@openducktor/contracts";
-import { createSettingsSnapshotFixture } from "@/test-utils/shared-test-fixtures";
+  createGitProviderConfigFixture,
+  createRepoSettingsConfigFixture,
+  createSettingsSnapshotFixture,
+} from "@/test-utils/shared-test-fixtures";
 import { diffSettingsSnapshots } from "./settings-snapshot-changes";
 
-const githubProvider = (name: string): NonNullable<RepoGitConfig["provider"]> => ({
-  id: "github",
-  enabled: true,
-  repository: { host: "github.com", owner: "Maxsky5", name },
-  autoDetected: false,
-});
-
-const createRepoConfig = (
-  workspaceId: string,
-  repoPath: string,
-  provider?: RepoGitConfig["provider"],
-): SettingsRepoConfig =>
-  settingsRepoConfigSchema.parse({
-    workspaceId,
-    workspaceName: workspaceId,
-    repoPath,
-    defaultRuntimeKind: "opencode",
-    git: provider === undefined ? {} : { provider },
-  });
-
 const createSnapshot = (
-  workspaces: Record<string, SettingsRepoConfig>,
+  workspaces: Record<string, ReturnType<typeof createRepoSettingsConfigFixture>>,
   overrides: Parameters<typeof createSettingsSnapshotFixture>[0] = {},
 ) => createSettingsSnapshotFixture({ workspaces, ...overrides });
 
@@ -38,8 +17,8 @@ describe("diffSettingsSnapshots", () => {
     const changes = diffSettingsSnapshots(
       undefined,
       createSnapshot({
-        "repo-a": createRepoConfig("repo-a", "/repo-a"),
-        "repo-b": createRepoConfig("repo-b", "/repo-b"),
+        "repo-a": createRepoSettingsConfigFixture("repo-a", "/repo-a"),
+        "repo-b": createRepoSettingsConfigFixture("repo-b", "/repo-b"),
       }),
     );
 
@@ -53,8 +32,12 @@ describe("diffSettingsSnapshots", () => {
 
   test("reports no changes for identical snapshots", () => {
     const workspaces = {
-      "repo-a": createRepoConfig("repo-a", "/repo-a"),
-      "repo-b": createRepoConfig("repo-b", "/repo-b", githubProvider("repo-b")),
+      "repo-a": createRepoSettingsConfigFixture("repo-a", "/repo-a"),
+      "repo-b": createRepoSettingsConfigFixture(
+        "repo-b",
+        "/repo-b",
+        createGitProviderConfigFixture({ name: "repo-b" }),
+      ),
     };
 
     expect(diffSettingsSnapshots(createSnapshot(workspaces), createSnapshot(workspaces))).toEqual({
@@ -68,12 +51,20 @@ describe("diffSettingsSnapshots", () => {
   test("reports only the repository whose git provider config changed", () => {
     const changes = diffSettingsSnapshots(
       createSnapshot({
-        "repo-a": createRepoConfig("repo-a", "/repo-a"),
-        "repo-b": createRepoConfig("repo-b", "/repo-b", githubProvider("repo-b")),
+        "repo-a": createRepoSettingsConfigFixture("repo-a", "/repo-a"),
+        "repo-b": createRepoSettingsConfigFixture(
+          "repo-b",
+          "/repo-b",
+          createGitProviderConfigFixture({ name: "repo-b" }),
+        ),
       }),
       createSnapshot({
-        "repo-a": createRepoConfig("repo-a", "/repo-a"),
-        "repo-b": createRepoConfig("repo-b", "/repo-b", githubProvider("renamed")),
+        "repo-a": createRepoSettingsConfigFixture("repo-a", "/repo-a"),
+        "repo-b": createRepoSettingsConfigFixture(
+          "repo-b",
+          "/repo-b",
+          createGitProviderConfigFixture({ name: "renamed" }),
+        ),
       }),
     );
 
@@ -81,10 +72,61 @@ describe("diffSettingsSnapshots", () => {
     expect(changes.changedGitProviderRepoPaths).toEqual(["/repo-b"]);
   });
 
+  test("reports a workspace change that does not touch the git provider", () => {
+    const changes = diffSettingsSnapshots(
+      createSnapshot({ "repo-a": createRepoSettingsConfigFixture("repo-a", "/repo-a") }),
+      createSnapshot({
+        "repo-a": {
+          ...createRepoSettingsConfigFixture("repo-a", "/repo-a"),
+          hooks: { preStart: ["bun run setup"], postComplete: [] },
+        },
+      }),
+    );
+
+    expect(changes.workspacesChanged).toBe(true);
+    expect(changes.changedGitProviderRepoPaths).toEqual([]);
+  });
+
+  test("reports a repository whose provider was removed", () => {
+    const changes = diffSettingsSnapshots(
+      createSnapshot({
+        "repo-a": createRepoSettingsConfigFixture(
+          "repo-a",
+          "/repo-a",
+          createGitProviderConfigFixture(),
+        ),
+      }),
+      createSnapshot({ "repo-a": createRepoSettingsConfigFixture("repo-a", "/repo-a") }),
+    );
+
+    expect(changes.changedGitProviderRepoPaths).toEqual(["/repo-a"]);
+  });
+
+  test("reports a repository whose provider was disabled", () => {
+    const changes = diffSettingsSnapshots(
+      createSnapshot({
+        "repo-a": createRepoSettingsConfigFixture(
+          "repo-a",
+          "/repo-a",
+          createGitProviderConfigFixture(),
+        ),
+      }),
+      createSnapshot({
+        "repo-a": createRepoSettingsConfigFixture(
+          "repo-a",
+          "/repo-a",
+          createGitProviderConfigFixture({ enabled: false }),
+        ),
+      }),
+    );
+
+    expect(changes.changedGitProviderRepoPaths).toEqual(["/repo-a"]);
+  });
+
   test("reports the new path when a repository path changes", () => {
     const changes = diffSettingsSnapshots(
-      createSnapshot({ "repo-a": createRepoConfig("repo-a", "/repo-a") }),
-      createSnapshot({ "repo-a": createRepoConfig("repo-a", "/repo-moved") }),
+      createSnapshot({ "repo-a": createRepoSettingsConfigFixture("repo-a", "/repo-a") }),
+      createSnapshot({ "repo-a": createRepoSettingsConfigFixture("repo-a", "/repo-moved") }),
     );
 
     expect(changes.changedGitProviderRepoPaths).toEqual(["/repo-moved"]);
@@ -93,7 +135,7 @@ describe("diffSettingsSnapshots", () => {
   test("reports a repository added after the previous snapshot", () => {
     const changes = diffSettingsSnapshots(
       createSnapshot({}),
-      createSnapshot({ "repo-a": createRepoConfig("repo-a", "/repo-a") }),
+      createSnapshot({ "repo-a": createRepoSettingsConfigFixture("repo-a", "/repo-a") }),
     );
 
     expect(changes.changedGitProviderRepoPaths).toEqual(["/repo-a"]);
@@ -110,5 +152,18 @@ describe("diffSettingsSnapshots", () => {
     expect(changes.agentRuntimesChanged).toBe(true);
     expect(changes.kanbanDoneVisibleDaysChanged).toBe(true);
     expect(changes.changedGitProviderRepoPaths).toEqual([]);
+  });
+
+  test("reports a defaults-only agent runtime change", () => {
+    const nextRuntimes = structuredClone(DEFAULT_AGENT_RUNTIMES);
+    nextRuntimes.codex.defaults.commandNetworkAccess =
+      !nextRuntimes.codex.defaults.commandNetworkAccess;
+    const changes = diffSettingsSnapshots(
+      createSnapshot({}),
+      createSnapshot({}, { agentRuntimes: nextRuntimes }),
+    );
+
+    expect(changes.agentRuntimesChanged).toBe(true);
+    expect(changes.workspacesChanged).toBe(false);
   });
 });

--- a/packages/frontend/src/state/operations/workspace/settings-snapshot-changes.test.ts
+++ b/packages/frontend/src/state/operations/workspace/settings-snapshot-changes.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_AGENT_RUNTIMES,
+  type RepoGitConfig,
+  type SettingsRepoConfig,
+  settingsRepoConfigSchema,
+} from "@openducktor/contracts";
+import { createSettingsSnapshotFixture } from "@/test-utils/shared-test-fixtures";
+import { diffSettingsSnapshots } from "./settings-snapshot-changes";
+
+const githubProvider = (name: string): NonNullable<RepoGitConfig["provider"]> => ({
+  id: "github",
+  enabled: true,
+  repository: { host: "github.com", owner: "Maxsky5", name },
+  autoDetected: false,
+});
+
+const createRepoConfig = (
+  workspaceId: string,
+  repoPath: string,
+  provider?: RepoGitConfig["provider"],
+): SettingsRepoConfig =>
+  settingsRepoConfigSchema.parse({
+    workspaceId,
+    workspaceName: workspaceId,
+    repoPath,
+    defaultRuntimeKind: "opencode",
+    git: provider === undefined ? {} : { provider },
+  });
+
+const createSnapshot = (
+  workspaces: Record<string, SettingsRepoConfig>,
+  overrides: Parameters<typeof createSettingsSnapshotFixture>[0] = {},
+) => createSettingsSnapshotFixture({ workspaces, ...overrides });
+
+describe("diffSettingsSnapshots", () => {
+  test("reports every repository when the previous snapshot is missing", () => {
+    const changes = diffSettingsSnapshots(
+      undefined,
+      createSnapshot({
+        "repo-a": createRepoConfig("repo-a", "/repo-a"),
+        "repo-b": createRepoConfig("repo-b", "/repo-b"),
+      }),
+    );
+
+    expect(changes).toEqual({
+      workspacesChanged: true,
+      agentRuntimesChanged: true,
+      kanbanDoneVisibleDaysChanged: false,
+      changedGitProviderRepoPaths: ["/repo-a", "/repo-b"],
+    });
+  });
+
+  test("reports no changes for identical snapshots", () => {
+    const workspaces = {
+      "repo-a": createRepoConfig("repo-a", "/repo-a"),
+      "repo-b": createRepoConfig("repo-b", "/repo-b", githubProvider("repo-b")),
+    };
+
+    expect(diffSettingsSnapshots(createSnapshot(workspaces), createSnapshot(workspaces))).toEqual({
+      workspacesChanged: false,
+      agentRuntimesChanged: false,
+      kanbanDoneVisibleDaysChanged: false,
+      changedGitProviderRepoPaths: [],
+    });
+  });
+
+  test("reports only the repository whose git provider config changed", () => {
+    const changes = diffSettingsSnapshots(
+      createSnapshot({
+        "repo-a": createRepoConfig("repo-a", "/repo-a"),
+        "repo-b": createRepoConfig("repo-b", "/repo-b", githubProvider("repo-b")),
+      }),
+      createSnapshot({
+        "repo-a": createRepoConfig("repo-a", "/repo-a"),
+        "repo-b": createRepoConfig("repo-b", "/repo-b", githubProvider("renamed")),
+      }),
+    );
+
+    expect(changes.workspacesChanged).toBe(true);
+    expect(changes.changedGitProviderRepoPaths).toEqual(["/repo-b"]);
+  });
+
+  test("reports the new path when a repository path changes", () => {
+    const changes = diffSettingsSnapshots(
+      createSnapshot({ "repo-a": createRepoConfig("repo-a", "/repo-a") }),
+      createSnapshot({ "repo-a": createRepoConfig("repo-a", "/repo-moved") }),
+    );
+
+    expect(changes.changedGitProviderRepoPaths).toEqual(["/repo-moved"]);
+  });
+
+  test("reports a repository added after the previous snapshot", () => {
+    const changes = diffSettingsSnapshots(
+      createSnapshot({}),
+      createSnapshot({ "repo-a": createRepoConfig("repo-a", "/repo-a") }),
+    );
+
+    expect(changes.changedGitProviderRepoPaths).toEqual(["/repo-a"]);
+  });
+
+  test("reports changed agent runtimes and kanban retention", () => {
+    const nextRuntimes = structuredClone(DEFAULT_AGENT_RUNTIMES);
+    nextRuntimes.codex.enabled = true;
+    const changes = diffSettingsSnapshots(
+      createSnapshot({}, { kanban: { doneVisibleDays: 1 } }),
+      createSnapshot({}, { agentRuntimes: nextRuntimes, kanban: { doneVisibleDays: 7 } }),
+    );
+
+    expect(changes.agentRuntimesChanged).toBe(true);
+    expect(changes.kanbanDoneVisibleDaysChanged).toBe(true);
+    expect(changes.changedGitProviderRepoPaths).toEqual([]);
+  });
+});

--- a/packages/frontend/src/state/operations/workspace/settings-snapshot-changes.ts
+++ b/packages/frontend/src/state/operations/workspace/settings-snapshot-changes.ts
@@ -1,0 +1,51 @@
+import type { RepoGitConfig, SettingsSnapshot } from "@openducktor/contracts";
+
+type RepositoryProviderConfigSnapshot = {
+  repoPath: string;
+  git: RepoGitConfig;
+};
+
+export type SettingsSnapshotChanges = {
+  workspacesChanged: boolean;
+  agentRuntimesChanged: boolean;
+  kanbanDoneVisibleDaysChanged: boolean;
+  changedGitProviderRepoPaths: string[];
+};
+
+const isSameJsonValue = <Value>(left: Value, right: Value): boolean =>
+  JSON.stringify(left) === JSON.stringify(right);
+
+const changedGitProviderRepoPaths = (
+  previous: Record<string, RepositoryProviderConfigSnapshot> | undefined,
+  next: Record<string, RepositoryProviderConfigSnapshot>,
+): string[] => {
+  if (previous === undefined) {
+    return Object.values(next).map((workspace) => workspace.repoPath);
+  }
+
+  const repoPaths: string[] = [];
+  for (const [workspaceId, nextWorkspace] of Object.entries(next)) {
+    const previousWorkspace = previous[workspaceId];
+    if (
+      previousWorkspace === undefined ||
+      previousWorkspace.repoPath !== nextWorkspace.repoPath ||
+      !isSameJsonValue(previousWorkspace.git, nextWorkspace.git)
+    ) {
+      repoPaths.push(nextWorkspace.repoPath);
+    }
+  }
+  return repoPaths;
+};
+
+export const diffSettingsSnapshots = (
+  previous: SettingsSnapshot | undefined,
+  next: SettingsSnapshot,
+): SettingsSnapshotChanges => ({
+  workspacesChanged:
+    previous === undefined || !isSameJsonValue(previous.workspaces, next.workspaces),
+  agentRuntimesChanged:
+    previous === undefined || !isSameJsonValue(previous.agentRuntimes, next.agentRuntimes),
+  kanbanDoneVisibleDaysChanged:
+    previous !== undefined && previous.kanban.doneVisibleDays !== next.kanban.doneVisibleDays,
+  changedGitProviderRepoPaths: changedGitProviderRepoPaths(previous?.workspaces, next.workspaces),
+});

--- a/packages/frontend/src/state/operations/workspace/settings-snapshot-changes.ts
+++ b/packages/frontend/src/state/operations/workspace/settings-snapshot-changes.ts
@@ -18,18 +18,22 @@ const changedGitProviderRepoPaths = (
     return Object.values(next).map((workspace) => workspace.repoPath);
   }
 
-  const repoPaths: string[] = [];
+  const repoPaths = new Set<string>();
   for (const [workspaceId, nextWorkspace] of Object.entries(next)) {
     const previousWorkspace = previous[workspaceId];
-    if (
-      previousWorkspace === undefined ||
-      previousWorkspace.repoPath !== nextWorkspace.repoPath ||
-      !isSameJsonValue(previousWorkspace.git, nextWorkspace.git)
-    ) {
-      repoPaths.push(nextWorkspace.repoPath);
+    if (previousWorkspace === undefined) {
+      repoPaths.add(nextWorkspace.repoPath);
+      continue;
+    }
+    if (!isSameJsonValue(previousWorkspace.git, nextWorkspace.git)) {
+      repoPaths.add(nextWorkspace.repoPath);
+    }
+    if (previousWorkspace.repoPath !== nextWorkspace.repoPath) {
+      repoPaths.add(nextWorkspace.repoPath);
+      repoPaths.add(previousWorkspace.repoPath);
     }
   }
-  return repoPaths;
+  return [...repoPaths];
 };
 
 export const diffSettingsSnapshots = (

--- a/packages/frontend/src/state/operations/workspace/settings-snapshot-changes.ts
+++ b/packages/frontend/src/state/operations/workspace/settings-snapshot-changes.ts
@@ -1,9 +1,4 @@
-import type { RepoGitConfig, SettingsSnapshot } from "@openducktor/contracts";
-
-type RepositoryProviderConfigSnapshot = {
-  repoPath: string;
-  git: RepoGitConfig;
-};
+import type { SettingsSnapshot } from "@openducktor/contracts";
 
 export type SettingsSnapshotChanges = {
   workspacesChanged: boolean;
@@ -16,8 +11,8 @@ const isSameJsonValue = <Value>(left: Value, right: Value): boolean =>
   JSON.stringify(left) === JSON.stringify(right);
 
 const changedGitProviderRepoPaths = (
-  previous: Record<string, RepositoryProviderConfigSnapshot> | undefined,
-  next: Record<string, RepositoryProviderConfigSnapshot>,
+  previous: SettingsSnapshot["workspaces"] | undefined,
+  next: SettingsSnapshot["workspaces"],
 ): string[] => {
   if (previous === undefined) {
     return Object.values(next).map((workspace) => workspace.repoPath);

--- a/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.test.tsx
+++ b/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.test.tsx
@@ -2,9 +2,6 @@ import { describe, expect, mock, spyOn, test } from "bun:test";
 import {
   agentPromptTemplateIdValues,
   DEFAULT_AGENT_RUNTIMES,
-  type RepoGitConfig,
-  type SettingsRepoConfig,
-  settingsRepoConfigSchema,
   type SettingsSnapshot,
   type SettingsSnapshotSaveInput,
 } from "@openducktor/contracts";
@@ -14,6 +11,9 @@ import { IsolatedQueryWrapper } from "@/test-utils/isolated-query-wrapper";
 import { createHookHarness as createSharedHookHarness } from "@/test-utils/react-hook-harness";
 import {
   createDeferred,
+  createGitProviderConfigFixture,
+  createGitProviderContextFixture,
+  createRepoSettingsConfigFixture,
   createSettingsSnapshotFixture,
   createTaskCardFixture,
 } from "@/test-utils/shared-test-fixtures";
@@ -102,26 +102,6 @@ const createWorkspaceRecord = (path = "/repo-a") => ({
 
 const createSettingsSnapshot = (): SettingsSnapshot => createSettingsSnapshotFixture();
 
-const createGithubProvider = (name: string): NonNullable<RepoGitConfig["provider"]> => ({
-  id: "github",
-  enabled: true,
-  repository: { host: "github.com", owner: "Maxsky5", name },
-  autoDetected: false,
-});
-
-const createRepoSettingsConfig = (
-  workspaceId: string,
-  repoPath: string,
-  provider?: RepoGitConfig["provider"],
-): SettingsRepoConfig =>
-  settingsRepoConfigSchema.parse({
-    workspaceId,
-    workspaceName: workspaceId,
-    repoPath,
-    defaultRuntimeKind: "opencode",
-    git: provider === undefined ? {} : { provider },
-  });
-
 const isRepositoryGitProviderContextRepoFilter = (
   filters: { queryKey?: unknown } | undefined,
   repoPath: string,
@@ -129,6 +109,71 @@ const isRepositoryGitProviderContextRepoFilter = (
   Array.isArray(filters?.queryKey) &&
   filters.queryKey[0] === repositoryGitProviderContextQueryKeys.all[0] &&
   filters.queryKey[1] === repoPath;
+
+const startSettingsSave = async ({
+  previousSnapshot,
+  normalizedSnapshot,
+  gateProviderRefreshRepoPath,
+  seedProviderContextRepoPaths,
+}: {
+  previousSnapshot: SettingsSnapshot;
+  normalizedSnapshot: SettingsSnapshot;
+  gateProviderRefreshRepoPath?: string;
+  seedProviderContextRepoPaths?: string[];
+}) => {
+  const original = {
+    workspaceSaveSettingsSnapshot: host.workspaceSaveSettingsSnapshot,
+    workspaceGetSettingsSnapshot: host.workspaceGetSettingsSnapshot,
+  };
+  host.workspaceSaveSettingsSnapshot = mock(async () => [createWorkspaceRecord()]);
+  host.workspaceGetSettingsSnapshot = mock(async () => normalizedSnapshot);
+  const applyWorkspaceRecords = mock(() => {});
+  const harness = createHookHarness({
+    activeWorkspace: createWorkspaceRecord(),
+    applyWorkspaceRecords,
+    applyWorkspaceRecord: mock(() => {}),
+  });
+  const providerRefresh = createDeferred<void>();
+  const providerRefreshStarted = createDeferred<void>();
+
+  await harness.mount();
+  const queryClient = harness.getQueryClient();
+  const originalInvalidateQueries = queryClient.invalidateQueries.bind(queryClient);
+  const invalidateQueries = spyOn(queryClient, "invalidateQueries").mockImplementation(
+    async (filters, options) => {
+      if (
+        gateProviderRefreshRepoPath !== undefined &&
+        isRepositoryGitProviderContextRepoFilter(filters, gateProviderRefreshRepoPath)
+      ) {
+        providerRefreshStarted.resolve();
+        await providerRefresh.promise;
+        return;
+      }
+      await originalInvalidateQueries(filters, options);
+    },
+  );
+  queryClient.setQueryData(workspaceQueryKeys.settingsSnapshot(), previousSnapshot);
+  for (const repoPath of seedProviderContextRepoPaths ?? []) {
+    queryClient.setQueryData(
+      repositoryGitProviderContextQueryKeys.repo(repoPath),
+      createGitProviderContextFixture(),
+    );
+  }
+
+  return {
+    queryClient,
+    invalidateQueries,
+    applyWorkspaceRecords,
+    save: harness.getLatest().saveSettingsSnapshot(normalizedSnapshot),
+    providerRefreshStarted,
+    cleanup: async (): Promise<void> => {
+      providerRefresh.resolve();
+      await harness.unmount();
+      host.workspaceSaveSettingsSnapshot = original.workspaceSaveSettingsSnapshot;
+      host.workspaceGetSettingsSnapshot = original.workspaceGetSettingsSnapshot;
+    },
+  };
+};
 
 const createRepoConfig = (): Awaited<ReturnType<typeof host.workspaceGetRepoConfig>> => ({
   workspaceId: "repo-a",
@@ -1030,188 +1075,167 @@ describe("use-repo-settings-operations", () => {
   });
 
   test("skips invalidations when the saved settings change nothing watched", async () => {
-    const applyWorkspaceRecords = mock(() => {});
     const snapshot = createSettingsSnapshotFixture({
-      workspaces: { "repo-a": createRepoSettingsConfig("repo-a", "/repo-a") },
+      workspaces: { "repo-a": createRepoSettingsConfigFixture("repo-a", "/repo-a") },
     });
-    const original = {
-      workspaceSaveSettingsSnapshot: host.workspaceSaveSettingsSnapshot,
-      workspaceGetSettingsSnapshot: host.workspaceGetSettingsSnapshot,
-    };
-    host.workspaceSaveSettingsSnapshot = mock(async () => [createWorkspaceRecord()]);
-    host.workspaceGetSettingsSnapshot = mock(async () => snapshot);
-    const harness = createHookHarness({
-      activeWorkspace: createWorkspaceRecord(),
-      applyWorkspaceRecords,
-      applyWorkspaceRecord: mock(() => {}),
+    const run = await startSettingsSave({
+      previousSnapshot: snapshot,
+      normalizedSnapshot: snapshot,
     });
 
     try {
-      await harness.mount();
-      const queryClient = harness.getQueryClient();
-      const invalidateQueries = spyOn(queryClient, "invalidateQueries").mockImplementation(
-        async () => {},
-      );
-      queryClient.setQueryData(workspaceQueryKeys.settingsSnapshot(), snapshot);
+      await run.save;
 
-      await harness.getLatest().saveSettingsSnapshot(snapshot);
-
-      expect(invalidateQueries).not.toHaveBeenCalled();
-      expect(applyWorkspaceRecords).toHaveBeenCalledTimes(1);
+      expect(run.invalidateQueries).not.toHaveBeenCalled();
+      expect(run.applyWorkspaceRecords).toHaveBeenCalledTimes(1);
     } finally {
-      await harness.unmount();
-      host.workspaceSaveSettingsSnapshot = original.workspaceSaveSettingsSnapshot;
-      host.workspaceGetSettingsSnapshot = original.workspaceGetSettingsSnapshot;
+      await run.cleanup();
+    }
+  });
+
+  test("invalidates repository config when a non-git workspace setting changed", async () => {
+    const previousSnapshot = createSettingsSnapshotFixture({
+      workspaces: { "repo-a": createRepoSettingsConfigFixture("repo-a", "/repo-a") },
+    });
+    const normalizedSnapshot = createSettingsSnapshotFixture({
+      workspaces: {
+        "repo-a": {
+          ...createRepoSettingsConfigFixture("repo-a", "/repo-a"),
+          hooks: { preStart: ["bun run setup"], postComplete: [] },
+        },
+      },
+    });
+    const run = await startSettingsSave({ previousSnapshot, normalizedSnapshot });
+
+    try {
+      await run.save;
+
+      expect(run.invalidateQueries).toHaveBeenCalledWith({
+        queryKey: [...workspaceQueryKeys.all, "repo-config"],
+      });
+      expect(run.invalidateQueries).not.toHaveBeenCalledWith({ queryKey: checksQueryKeys.all });
+      expect(run.invalidateQueries).not.toHaveBeenCalledWith({
+        queryKey: repositoryGitProviderContextQueryKeys.all,
+      });
+    } finally {
+      await run.cleanup();
     }
   });
 
   test("invalidates only the repository whose git provider config changed", async () => {
     const previousSnapshot = createSettingsSnapshotFixture({
       workspaces: {
-        "repo-a": createRepoSettingsConfig("repo-a", "/repo-a"),
-        "repo-b": createRepoSettingsConfig("repo-b", "/repo-b", createGithubProvider("repo-b")),
+        "repo-a": createRepoSettingsConfigFixture("repo-a", "/repo-a"),
+        "repo-b": createRepoSettingsConfigFixture(
+          "repo-b",
+          "/repo-b",
+          createGitProviderConfigFixture({ name: "repo-b" }),
+        ),
       },
     });
     const normalizedSnapshot = createSettingsSnapshotFixture({
       workspaces: {
-        "repo-a": createRepoSettingsConfig("repo-a", "/repo-a"),
-        "repo-b": createRepoSettingsConfig("repo-b", "/repo-b", createGithubProvider("renamed")),
+        "repo-a": createRepoSettingsConfigFixture("repo-a", "/repo-a"),
+        "repo-b": createRepoSettingsConfigFixture(
+          "repo-b",
+          "/repo-b",
+          createGitProviderConfigFixture({ name: "renamed" }),
+        ),
       },
     });
-    const original = {
-      workspaceSaveSettingsSnapshot: host.workspaceSaveSettingsSnapshot,
-      workspaceGetSettingsSnapshot: host.workspaceGetSettingsSnapshot,
-    };
-    host.workspaceSaveSettingsSnapshot = mock(async () => [createWorkspaceRecord()]);
-    host.workspaceGetSettingsSnapshot = mock(async () => normalizedSnapshot);
-    const harness = createHookHarness({
-      activeWorkspace: createWorkspaceRecord(),
-      applyWorkspaceRecords: mock(() => {}),
-      applyWorkspaceRecord: mock(() => {}),
+    const run = await startSettingsSave({
+      previousSnapshot,
+      normalizedSnapshot,
+      seedProviderContextRepoPaths: ["/repo-a", "/repo-b"],
     });
 
     try {
-      await harness.mount();
-      const queryClient = harness.getQueryClient();
-      const invalidateQueries = spyOn(queryClient, "invalidateQueries").mockImplementation(
-        async () => {},
-      );
-      queryClient.setQueryData(workspaceQueryKeys.settingsSnapshot(), previousSnapshot);
+      await run.save;
 
-      await harness.getLatest().saveSettingsSnapshot(normalizedSnapshot);
-
-      expect(invalidateQueries).toHaveBeenCalledWith({
+      expect(run.invalidateQueries).toHaveBeenCalledWith({
         queryKey: repositoryGitProviderContextQueryKeys.repo("/repo-b"),
       });
-      expect(invalidateQueries).not.toHaveBeenCalledWith({
+      expect(run.invalidateQueries).not.toHaveBeenCalledWith({
         queryKey: repositoryGitProviderContextQueryKeys.repo("/repo-a"),
       });
-      expect(invalidateQueries).not.toHaveBeenCalledWith({
+      expect(run.invalidateQueries).not.toHaveBeenCalledWith({
         queryKey: repositoryGitProviderContextQueryKeys.all,
       });
-      expect(invalidateQueries).toHaveBeenCalledWith({
+      expect(run.invalidateQueries).toHaveBeenCalledWith({
         queryKey: [...workspaceQueryKeys.all, "repo-config"],
       });
-      expect(invalidateQueries).not.toHaveBeenCalledWith({ queryKey: checksQueryKeys.all });
+      expect(run.invalidateQueries).not.toHaveBeenCalledWith({ queryKey: checksQueryKeys.all });
+      expect(
+        run.queryClient.getQueryState(repositoryGitProviderContextQueryKeys.repo("/repo-b"))
+          ?.isInvalidated,
+      ).toBe(true);
+      expect(
+        run.queryClient.getQueryState(repositoryGitProviderContextQueryKeys.repo("/repo-a"))
+          ?.isInvalidated,
+      ).toBe(false);
     } finally {
-      await harness.unmount();
-      host.workspaceSaveSettingsSnapshot = original.workspaceSaveSettingsSnapshot;
-      host.workspaceGetSettingsSnapshot = original.workspaceGetSettingsSnapshot;
+      await run.cleanup();
     }
   });
 
   test("invalidates runtime checks when the save changes agent runtimes", async () => {
     const nextRuntimes = structuredClone(DEFAULT_AGENT_RUNTIMES);
     nextRuntimes.codex.enabled = true;
-    const previousSnapshot = createSettingsSnapshot();
-    const normalizedSnapshot = createSettingsSnapshotFixture({ agentRuntimes: nextRuntimes });
-    const original = {
-      workspaceSaveSettingsSnapshot: host.workspaceSaveSettingsSnapshot,
-      workspaceGetSettingsSnapshot: host.workspaceGetSettingsSnapshot,
-    };
-    host.workspaceSaveSettingsSnapshot = mock(async () => [createWorkspaceRecord()]);
-    host.workspaceGetSettingsSnapshot = mock(async () => normalizedSnapshot);
-    const harness = createHookHarness({
-      activeWorkspace: createWorkspaceRecord(),
-      applyWorkspaceRecords: mock(() => {}),
-      applyWorkspaceRecord: mock(() => {}),
+    const run = await startSettingsSave({
+      previousSnapshot: createSettingsSnapshot(),
+      normalizedSnapshot: createSettingsSnapshotFixture({ agentRuntimes: nextRuntimes }),
     });
 
     try {
-      await harness.mount();
-      const queryClient = harness.getQueryClient();
-      const invalidateQueries = spyOn(queryClient, "invalidateQueries").mockImplementation(
-        async () => {},
-      );
-      queryClient.setQueryData(workspaceQueryKeys.settingsSnapshot(), previousSnapshot);
+      await run.save;
 
-      await harness.getLatest().saveSettingsSnapshot(normalizedSnapshot);
-
-      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: checksQueryKeys.all });
-      expect(invalidateQueries).not.toHaveBeenCalledWith({ queryKey: runtimeQueryKeys.all });
-      expect(invalidateQueries).not.toHaveBeenCalledWith({
+      expect(run.invalidateQueries).toHaveBeenCalledWith({ queryKey: checksQueryKeys.all });
+      expect(run.invalidateQueries).not.toHaveBeenCalledWith({ queryKey: runtimeQueryKeys.all });
+      expect(run.invalidateQueries).not.toHaveBeenCalledWith({
         queryKey: [...workspaceQueryKeys.all, "repo-config"],
       });
-      expect(invalidateQueries).not.toHaveBeenCalledWith({
+      expect(run.invalidateQueries).not.toHaveBeenCalledWith({
         queryKey: repositoryGitProviderContextQueryKeys.all,
       });
     } finally {
-      await harness.unmount();
-      host.workspaceSaveSettingsSnapshot = original.workspaceSaveSettingsSnapshot;
-      host.workspaceGetSettingsSnapshot = original.workspaceGetSettingsSnapshot;
+      await run.cleanup();
     }
   });
 
   test("does not wait for the changed repository provider refresh before resolving", async () => {
     const previousSnapshot = createSettingsSnapshotFixture({
       workspaces: {
-        "repo-b": createRepoSettingsConfig("repo-b", "/repo-b", createGithubProvider("repo-b")),
+        "repo-b": createRepoSettingsConfigFixture(
+          "repo-b",
+          "/repo-b",
+          createGitProviderConfigFixture({ name: "repo-b" }),
+        ),
       },
     });
     const normalizedSnapshot = createSettingsSnapshotFixture({
       workspaces: {
-        "repo-b": createRepoSettingsConfig("repo-b", "/repo-b", createGithubProvider("renamed")),
+        "repo-b": createRepoSettingsConfigFixture(
+          "repo-b",
+          "/repo-b",
+          createGitProviderConfigFixture({ name: "renamed" }),
+        ),
       },
     });
-    const original = {
-      workspaceSaveSettingsSnapshot: host.workspaceSaveSettingsSnapshot,
-      workspaceGetSettingsSnapshot: host.workspaceGetSettingsSnapshot,
-    };
-    host.workspaceSaveSettingsSnapshot = mock(async () => [createWorkspaceRecord()]);
-    host.workspaceGetSettingsSnapshot = mock(async () => normalizedSnapshot);
-    const harness = createHookHarness({
-      activeWorkspace: createWorkspaceRecord(),
-      applyWorkspaceRecords: mock(() => {}),
-      applyWorkspaceRecord: mock(() => {}),
+    const run = await startSettingsSave({
+      previousSnapshot,
+      normalizedSnapshot,
+      gateProviderRefreshRepoPath: "/repo-b",
     });
-    const providerRefresh = createDeferred<void>();
-    const providerRefreshStarted = createDeferred<void>();
 
     try {
-      await harness.mount();
-      const queryClient = harness.getQueryClient();
-      const invalidateQueries = spyOn(queryClient, "invalidateQueries").mockImplementation(
-        async (filters) => {
-          if (isRepositoryGitProviderContextRepoFilter(filters, "/repo-b")) {
-            providerRefreshStarted.resolve();
-            await providerRefresh.promise;
-          }
-        },
-      );
-      queryClient.setQueryData(workspaceQueryKeys.settingsSnapshot(), previousSnapshot);
+      await run.providerRefreshStarted.promise;
+      await run.save;
 
-      const save = harness.getLatest().saveSettingsSnapshot(normalizedSnapshot);
-      await providerRefreshStarted.promise;
-      await save;
-
-      expect(invalidateQueries).toHaveBeenCalledWith({
+      expect(run.invalidateQueries).toHaveBeenCalledWith({
         queryKey: repositoryGitProviderContextQueryKeys.repo("/repo-b"),
       });
     } finally {
-      providerRefresh.resolve();
-      await harness.unmount();
-      host.workspaceSaveSettingsSnapshot = original.workspaceSaveSettingsSnapshot;
-      host.workspaceGetSettingsSnapshot = original.workspaceGetSettingsSnapshot;
+      await run.cleanup();
     }
   });
 

--- a/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.test.tsx
+++ b/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.test.tsx
@@ -997,7 +997,7 @@ describe("use-repo-settings-operations", () => {
     }
   });
 
-  test("waits for provider context refresh after saving settings", async () => {
+  test("refreshes provider context in the background after saving settings", async () => {
     const applyWorkspaceRecords = mock(() => {});
     const applyWorkspaceRecord = mock(() => {});
     const snapshot = createSettingsSnapshot();
@@ -1035,17 +1035,10 @@ describe("use-repo-settings-operations", () => {
       queryClient.setQueryData(runtimeKey, { runtimes: [] });
       queryClient.setQueryData(checksKey, { ok: true });
 
-      let saveFinished = false;
-      const save = harness
-        .getLatest()
-        .saveSettingsSnapshot(snapshot)
-        .then(() => {
-          saveFinished = true;
-        });
+      const save = harness.getLatest().saveSettingsSnapshot(snapshot);
       await providerRefreshStarted.promise;
-      await Promise.resolve();
+      await save;
 
-      expect(saveFinished).toBe(false);
       expect(queryClient.getQueryState(runtimeKey)?.isInvalidated).toBe(false);
       expect(queryClient.getQueryState(checksKey)?.isInvalidated).toBe(true);
       expect(invalidateQueries).not.toHaveBeenCalledWith({ queryKey: runtimeQueryKeys.all });
@@ -1055,9 +1048,6 @@ describe("use-repo-settings-operations", () => {
       expect(invalidateQueries).toHaveBeenCalledWith({
         queryKey: repositoryGitProviderContextQueryKeys.all,
       });
-      providerRefresh.resolve();
-      await save;
-      expect(saveFinished).toBe(true);
     } finally {
       providerRefresh.resolve();
       await harness.unmount();

--- a/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.test.tsx
+++ b/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, mock, spyOn, test } from "bun:test";
 import {
   agentPromptTemplateIdValues,
   DEFAULT_AGENT_RUNTIMES,
+  type RepositoryGitProviderContext,
   type SettingsSnapshot,
   type SettingsSnapshotSaveInput,
 } from "@openducktor/contracts";
@@ -115,17 +116,24 @@ const startSettingsSave = async ({
   normalizedSnapshot,
   gateProviderRefreshRepoPath,
   seedProviderContextRepoPaths,
+  saveError,
 }: {
   previousSnapshot: SettingsSnapshot;
   normalizedSnapshot: SettingsSnapshot;
   gateProviderRefreshRepoPath?: string;
   seedProviderContextRepoPaths?: string[];
+  saveError?: Error;
 }) => {
   const original = {
     workspaceSaveSettingsSnapshot: host.workspaceSaveSettingsSnapshot,
     workspaceGetSettingsSnapshot: host.workspaceGetSettingsSnapshot,
   };
-  host.workspaceSaveSettingsSnapshot = mock(async () => [createWorkspaceRecord()]);
+  host.workspaceSaveSettingsSnapshot = mock(async () => {
+    if (saveError !== undefined) {
+      throw saveError;
+    }
+    return [createWorkspaceRecord()];
+  });
   host.workspaceGetSettingsSnapshot = mock(async () => normalizedSnapshot);
   const applyWorkspaceRecords = mock(() => {});
   const harness = createHookHarness({
@@ -141,6 +149,12 @@ const startSettingsSave = async ({
   const originalInvalidateQueries = queryClient.invalidateQueries.bind(queryClient);
   const invalidateQueries = spyOn(queryClient, "invalidateQueries").mockImplementation(
     async (filters, options) => {
+      await originalInvalidateQueries(filters, options);
+    },
+  );
+  const originalResetQueries = queryClient.resetQueries.bind(queryClient);
+  const resetQueries = spyOn(queryClient, "resetQueries").mockImplementation(
+    async (filters, options) => {
       if (
         gateProviderRefreshRepoPath !== undefined &&
         isRepositoryGitProviderContextRepoFilter(filters, gateProviderRefreshRepoPath)
@@ -149,7 +163,7 @@ const startSettingsSave = async ({
         await providerRefresh.promise;
         return;
       }
-      await originalInvalidateQueries(filters, options);
+      await originalResetQueries(filters, options);
     },
   );
   queryClient.setQueryData(workspaceQueryKeys.settingsSnapshot(), previousSnapshot);
@@ -163,6 +177,7 @@ const startSettingsSave = async ({
   return {
     queryClient,
     invalidateQueries,
+    resetQueries,
     applyWorkspaceRecords,
     save: harness.getLatest().saveSettingsSnapshot(normalizedSnapshot),
     providerRefreshStarted,
@@ -1087,6 +1102,7 @@ describe("use-repo-settings-operations", () => {
       await run.save;
 
       expect(run.invalidateQueries).not.toHaveBeenCalled();
+      expect(run.resetQueries).not.toHaveBeenCalled();
       expect(run.applyWorkspaceRecords).toHaveBeenCalledTimes(1);
     } finally {
       await run.cleanup();
@@ -1114,9 +1130,7 @@ describe("use-repo-settings-operations", () => {
         queryKey: [...workspaceQueryKeys.all, "repo-config"],
       });
       expect(run.invalidateQueries).not.toHaveBeenCalledWith({ queryKey: checksQueryKeys.all });
-      expect(run.invalidateQueries).not.toHaveBeenCalledWith({
-        queryKey: repositoryGitProviderContextQueryKeys.all,
-      });
+      expect(run.resetQueries).not.toHaveBeenCalled();
     } finally {
       await run.cleanup();
     }
@@ -1152,27 +1166,24 @@ describe("use-repo-settings-operations", () => {
     try {
       await run.save;
 
-      expect(run.invalidateQueries).toHaveBeenCalledWith({
+      expect(run.resetQueries).toHaveBeenCalledWith({
         queryKey: repositoryGitProviderContextQueryKeys.repo("/repo-b"),
       });
-      expect(run.invalidateQueries).not.toHaveBeenCalledWith({
+      expect(run.resetQueries).not.toHaveBeenCalledWith({
         queryKey: repositoryGitProviderContextQueryKeys.repo("/repo-a"),
-      });
-      expect(run.invalidateQueries).not.toHaveBeenCalledWith({
-        queryKey: repositoryGitProviderContextQueryKeys.all,
       });
       expect(run.invalidateQueries).toHaveBeenCalledWith({
         queryKey: [...workspaceQueryKeys.all, "repo-config"],
       });
       expect(run.invalidateQueries).not.toHaveBeenCalledWith({ queryKey: checksQueryKeys.all });
       expect(
-        run.queryClient.getQueryState(repositoryGitProviderContextQueryKeys.repo("/repo-b"))
-          ?.isInvalidated,
-      ).toBe(true);
+        run.queryClient.getQueryData(repositoryGitProviderContextQueryKeys.repo("/repo-b")),
+      ).toBeUndefined();
       expect(
-        run.queryClient.getQueryState(repositoryGitProviderContextQueryKeys.repo("/repo-a"))
-          ?.isInvalidated,
-      ).toBe(false);
+        run.queryClient.getQueryData<RepositoryGitProviderContext>(
+          repositoryGitProviderContextQueryKeys.repo("/repo-a"),
+        ),
+      ).toEqual(createGitProviderContextFixture());
     } finally {
       await run.cleanup();
     }
@@ -1194,9 +1205,7 @@ describe("use-repo-settings-operations", () => {
       expect(run.invalidateQueries).not.toHaveBeenCalledWith({
         queryKey: [...workspaceQueryKeys.all, "repo-config"],
       });
-      expect(run.invalidateQueries).not.toHaveBeenCalledWith({
-        queryKey: repositoryGitProviderContextQueryKeys.all,
-      });
+      expect(run.resetQueries).not.toHaveBeenCalled();
     } finally {
       await run.cleanup();
     }
@@ -1231,9 +1240,32 @@ describe("use-repo-settings-operations", () => {
       await run.providerRefreshStarted.promise;
       await run.save;
 
-      expect(run.invalidateQueries).toHaveBeenCalledWith({
+      expect(run.resetQueries).toHaveBeenCalledWith({
         queryKey: repositoryGitProviderContextQueryKeys.repo("/repo-b"),
       });
+    } finally {
+      await run.cleanup();
+    }
+  });
+
+  test("propagates a host save failure without touching the cache", async () => {
+    const snapshot = createSettingsSnapshotFixture({
+      workspaces: { "repo-a": createRepoSettingsConfigFixture("repo-a", "/repo-a") },
+    });
+    const run = await startSettingsSave({
+      previousSnapshot: snapshot,
+      normalizedSnapshot: snapshot,
+      saveError: new Error("host save failed"),
+    });
+
+    try {
+      await expect(run.save).rejects.toThrow("host save failed");
+
+      expect(
+        run.queryClient.getQueryData<SettingsSnapshot>(workspaceQueryKeys.settingsSnapshot()),
+      ).toBe(snapshot);
+      expect(run.invalidateQueries).not.toHaveBeenCalled();
+      expect(run.resetQueries).not.toHaveBeenCalled();
     } finally {
       await run.cleanup();
     }

--- a/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.test.tsx
+++ b/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.test.tsx
@@ -1,8 +1,12 @@
 import { describe, expect, mock, spyOn, test } from "bun:test";
 import {
   agentPromptTemplateIdValues,
-  type SettingsSnapshotSaveInput,
+  DEFAULT_AGENT_RUNTIMES,
+  type RepoGitConfig,
+  type SettingsRepoConfig,
+  settingsRepoConfigSchema,
   type SettingsSnapshot,
+  type SettingsSnapshotSaveInput,
 } from "@openducktor/contracts";
 import { type QueryClient, QueryObserver, useQueryClient } from "@tanstack/react-query";
 import type { PropsWithChildren, ReactElement } from "react";
@@ -97,6 +101,34 @@ const createWorkspaceRecord = (path = "/repo-a") => ({
 });
 
 const createSettingsSnapshot = (): SettingsSnapshot => createSettingsSnapshotFixture();
+
+const createGithubProvider = (name: string): NonNullable<RepoGitConfig["provider"]> => ({
+  id: "github",
+  enabled: true,
+  repository: { host: "github.com", owner: "Maxsky5", name },
+  autoDetected: false,
+});
+
+const createRepoSettingsConfig = (
+  workspaceId: string,
+  repoPath: string,
+  provider?: RepoGitConfig["provider"],
+): SettingsRepoConfig =>
+  settingsRepoConfigSchema.parse({
+    workspaceId,
+    workspaceName: workspaceId,
+    repoPath,
+    defaultRuntimeKind: "opencode",
+    git: provider === undefined ? {} : { provider },
+  });
+
+const isRepositoryGitProviderContextRepoFilter = (
+  filters: { queryKey?: unknown } | undefined,
+  repoPath: string,
+): boolean =>
+  Array.isArray(filters?.queryKey) &&
+  filters.queryKey[0] === repositoryGitProviderContextQueryKeys.all[0] &&
+  filters.queryKey[1] === repoPath;
 
 const createRepoConfig = (): Awaited<ReturnType<typeof host.workspaceGetRepoConfig>> => ({
   workspaceId: "repo-a",
@@ -997,22 +1029,160 @@ describe("use-repo-settings-operations", () => {
     }
   });
 
-  test("refreshes provider context in the background after saving settings", async () => {
+  test("skips invalidations when the saved settings change nothing watched", async () => {
     const applyWorkspaceRecords = mock(() => {});
-    const applyWorkspaceRecord = mock(() => {});
-    const snapshot = createSettingsSnapshot();
-    const workspaceSaveSettingsSnapshot = mock(async () => [createWorkspaceRecord()]);
-    const workspaceGetSettingsSnapshot = mock(async () => snapshot);
+    const snapshot = createSettingsSnapshotFixture({
+      workspaces: { "repo-a": createRepoSettingsConfig("repo-a", "/repo-a") },
+    });
     const original = {
       workspaceSaveSettingsSnapshot: host.workspaceSaveSettingsSnapshot,
       workspaceGetSettingsSnapshot: host.workspaceGetSettingsSnapshot,
     };
-    host.workspaceSaveSettingsSnapshot = workspaceSaveSettingsSnapshot;
-    host.workspaceGetSettingsSnapshot = workspaceGetSettingsSnapshot;
+    host.workspaceSaveSettingsSnapshot = mock(async () => [createWorkspaceRecord()]);
+    host.workspaceGetSettingsSnapshot = mock(async () => snapshot);
     const harness = createHookHarness({
       activeWorkspace: createWorkspaceRecord(),
       applyWorkspaceRecords,
-      applyWorkspaceRecord,
+      applyWorkspaceRecord: mock(() => {}),
+    });
+
+    try {
+      await harness.mount();
+      const queryClient = harness.getQueryClient();
+      const invalidateQueries = spyOn(queryClient, "invalidateQueries").mockImplementation(
+        async () => {},
+      );
+      queryClient.setQueryData(workspaceQueryKeys.settingsSnapshot(), snapshot);
+
+      await harness.getLatest().saveSettingsSnapshot(snapshot);
+
+      expect(invalidateQueries).not.toHaveBeenCalled();
+      expect(applyWorkspaceRecords).toHaveBeenCalledTimes(1);
+    } finally {
+      await harness.unmount();
+      host.workspaceSaveSettingsSnapshot = original.workspaceSaveSettingsSnapshot;
+      host.workspaceGetSettingsSnapshot = original.workspaceGetSettingsSnapshot;
+    }
+  });
+
+  test("invalidates only the repository whose git provider config changed", async () => {
+    const previousSnapshot = createSettingsSnapshotFixture({
+      workspaces: {
+        "repo-a": createRepoSettingsConfig("repo-a", "/repo-a"),
+        "repo-b": createRepoSettingsConfig("repo-b", "/repo-b", createGithubProvider("repo-b")),
+      },
+    });
+    const normalizedSnapshot = createSettingsSnapshotFixture({
+      workspaces: {
+        "repo-a": createRepoSettingsConfig("repo-a", "/repo-a"),
+        "repo-b": createRepoSettingsConfig("repo-b", "/repo-b", createGithubProvider("renamed")),
+      },
+    });
+    const original = {
+      workspaceSaveSettingsSnapshot: host.workspaceSaveSettingsSnapshot,
+      workspaceGetSettingsSnapshot: host.workspaceGetSettingsSnapshot,
+    };
+    host.workspaceSaveSettingsSnapshot = mock(async () => [createWorkspaceRecord()]);
+    host.workspaceGetSettingsSnapshot = mock(async () => normalizedSnapshot);
+    const harness = createHookHarness({
+      activeWorkspace: createWorkspaceRecord(),
+      applyWorkspaceRecords: mock(() => {}),
+      applyWorkspaceRecord: mock(() => {}),
+    });
+
+    try {
+      await harness.mount();
+      const queryClient = harness.getQueryClient();
+      const invalidateQueries = spyOn(queryClient, "invalidateQueries").mockImplementation(
+        async () => {},
+      );
+      queryClient.setQueryData(workspaceQueryKeys.settingsSnapshot(), previousSnapshot);
+
+      await harness.getLatest().saveSettingsSnapshot(normalizedSnapshot);
+
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: repositoryGitProviderContextQueryKeys.repo("/repo-b"),
+      });
+      expect(invalidateQueries).not.toHaveBeenCalledWith({
+        queryKey: repositoryGitProviderContextQueryKeys.repo("/repo-a"),
+      });
+      expect(invalidateQueries).not.toHaveBeenCalledWith({
+        queryKey: repositoryGitProviderContextQueryKeys.all,
+      });
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: [...workspaceQueryKeys.all, "repo-config"],
+      });
+      expect(invalidateQueries).not.toHaveBeenCalledWith({ queryKey: checksQueryKeys.all });
+    } finally {
+      await harness.unmount();
+      host.workspaceSaveSettingsSnapshot = original.workspaceSaveSettingsSnapshot;
+      host.workspaceGetSettingsSnapshot = original.workspaceGetSettingsSnapshot;
+    }
+  });
+
+  test("invalidates runtime checks when the save changes agent runtimes", async () => {
+    const nextRuntimes = structuredClone(DEFAULT_AGENT_RUNTIMES);
+    nextRuntimes.codex.enabled = true;
+    const previousSnapshot = createSettingsSnapshot();
+    const normalizedSnapshot = createSettingsSnapshotFixture({ agentRuntimes: nextRuntimes });
+    const original = {
+      workspaceSaveSettingsSnapshot: host.workspaceSaveSettingsSnapshot,
+      workspaceGetSettingsSnapshot: host.workspaceGetSettingsSnapshot,
+    };
+    host.workspaceSaveSettingsSnapshot = mock(async () => [createWorkspaceRecord()]);
+    host.workspaceGetSettingsSnapshot = mock(async () => normalizedSnapshot);
+    const harness = createHookHarness({
+      activeWorkspace: createWorkspaceRecord(),
+      applyWorkspaceRecords: mock(() => {}),
+      applyWorkspaceRecord: mock(() => {}),
+    });
+
+    try {
+      await harness.mount();
+      const queryClient = harness.getQueryClient();
+      const invalidateQueries = spyOn(queryClient, "invalidateQueries").mockImplementation(
+        async () => {},
+      );
+      queryClient.setQueryData(workspaceQueryKeys.settingsSnapshot(), previousSnapshot);
+
+      await harness.getLatest().saveSettingsSnapshot(normalizedSnapshot);
+
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: checksQueryKeys.all });
+      expect(invalidateQueries).not.toHaveBeenCalledWith({ queryKey: runtimeQueryKeys.all });
+      expect(invalidateQueries).not.toHaveBeenCalledWith({
+        queryKey: [...workspaceQueryKeys.all, "repo-config"],
+      });
+      expect(invalidateQueries).not.toHaveBeenCalledWith({
+        queryKey: repositoryGitProviderContextQueryKeys.all,
+      });
+    } finally {
+      await harness.unmount();
+      host.workspaceSaveSettingsSnapshot = original.workspaceSaveSettingsSnapshot;
+      host.workspaceGetSettingsSnapshot = original.workspaceGetSettingsSnapshot;
+    }
+  });
+
+  test("does not wait for the changed repository provider refresh before resolving", async () => {
+    const previousSnapshot = createSettingsSnapshotFixture({
+      workspaces: {
+        "repo-b": createRepoSettingsConfig("repo-b", "/repo-b", createGithubProvider("repo-b")),
+      },
+    });
+    const normalizedSnapshot = createSettingsSnapshotFixture({
+      workspaces: {
+        "repo-b": createRepoSettingsConfig("repo-b", "/repo-b", createGithubProvider("renamed")),
+      },
+    });
+    const original = {
+      workspaceSaveSettingsSnapshot: host.workspaceSaveSettingsSnapshot,
+      workspaceGetSettingsSnapshot: host.workspaceGetSettingsSnapshot,
+    };
+    host.workspaceSaveSettingsSnapshot = mock(async () => [createWorkspaceRecord()]);
+    host.workspaceGetSettingsSnapshot = mock(async () => normalizedSnapshot);
+    const harness = createHookHarness({
+      activeWorkspace: createWorkspaceRecord(),
+      applyWorkspaceRecords: mock(() => {}),
+      applyWorkspaceRecord: mock(() => {}),
     });
     const providerRefresh = createDeferred<void>();
     const providerRefreshStarted = createDeferred<void>();
@@ -1020,33 +1190,22 @@ describe("use-repo-settings-operations", () => {
     try {
       await harness.mount();
       const queryClient = harness.getQueryClient();
-      const originalInvalidateQueries = queryClient.invalidateQueries.bind(queryClient);
       const invalidateQueries = spyOn(queryClient, "invalidateQueries").mockImplementation(
-        async (filters, options) => {
-          await originalInvalidateQueries(filters, options);
-          if (filters?.queryKey === repositoryGitProviderContextQueryKeys.all) {
+        async (filters) => {
+          if (isRepositoryGitProviderContextRepoFilter(filters, "/repo-b")) {
             providerRefreshStarted.resolve();
             await providerRefresh.promise;
           }
         },
       );
-      const runtimeKey = runtimeQueryKeys.executable("opencode", "/tools/opencode");
-      const checksKey = checksQueryKeys.runtime();
-      queryClient.setQueryData(runtimeKey, { runtimes: [] });
-      queryClient.setQueryData(checksKey, { ok: true });
+      queryClient.setQueryData(workspaceQueryKeys.settingsSnapshot(), previousSnapshot);
 
-      const save = harness.getLatest().saveSettingsSnapshot(snapshot);
+      const save = harness.getLatest().saveSettingsSnapshot(normalizedSnapshot);
       await providerRefreshStarted.promise;
       await save;
 
-      expect(queryClient.getQueryState(runtimeKey)?.isInvalidated).toBe(false);
-      expect(queryClient.getQueryState(checksKey)?.isInvalidated).toBe(true);
-      expect(invalidateQueries).not.toHaveBeenCalledWith({ queryKey: runtimeQueryKeys.all });
       expect(invalidateQueries).toHaveBeenCalledWith({
-        queryKey: checksQueryKeys.all,
-      });
-      expect(invalidateQueries).toHaveBeenCalledWith({
-        queryKey: repositoryGitProviderContextQueryKeys.all,
+        queryKey: repositoryGitProviderContextQueryKeys.repo("/repo-b"),
       });
     } finally {
       providerRefresh.resolve();

--- a/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.ts
+++ b/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.ts
@@ -194,7 +194,7 @@ export function useRepoSettingsOperations({
         );
       }
       void queryClient.invalidateQueries({ queryKey: checksQueryKeys.all });
-      await queryClient.invalidateQueries({
+      void queryClient.invalidateQueries({
         queryKey: repositoryGitProviderContextQueryKeys.all,
       });
     },

--- a/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.ts
+++ b/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.ts
@@ -198,7 +198,7 @@ export function useRepoSettingsOperations({
         void queryClient.invalidateQueries({ queryKey: checksQueryKeys.all });
       }
       for (const repoPath of changes.changedGitProviderRepoPaths) {
-        void queryClient.invalidateQueries({
+        void queryClient.resetQueries({
           queryKey: repositoryGitProviderContextQueryKeys.repo(repoPath),
         });
       }

--- a/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.ts
+++ b/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.ts
@@ -24,6 +24,7 @@ import {
   workspaceQueryKeys,
 } from "../../queries/workspace";
 import { host } from "../shared/host";
+import { diffSettingsSnapshots } from "./settings-snapshot-changes";
 
 type UseRepoSettingsOperationsArgs = {
   activeWorkspace: WorkspaceRecord | null;
@@ -179,24 +180,28 @@ export function useRepoSettingsOperations({
         ...settingsSnapshotQueryOptions(),
         staleTime: 0,
       });
-      await queryClient.invalidateQueries({
-        queryKey: REPO_CONFIG_QUERY_KEY_PREFIX,
-      });
+      const changes = diffSettingsSnapshots(previousSnapshot, normalizedSnapshot);
+      if (changes.workspacesChanged) {
+        await queryClient.invalidateQueries({
+          queryKey: REPO_CONFIG_QUERY_KEY_PREFIX,
+        });
+      }
       queryClient.setQueryData(workspaceQueryKeys.list(), workspaces);
       applyWorkspaceRecords(workspaces);
       const savedActiveWorkspace = workspaces.find((workspace) => workspace.isActive);
-      const retentionChanged =
-        previousSnapshot !== undefined &&
-        previousSnapshot.kanban.doneVisibleDays !== normalizedSnapshot.kanban.doneVisibleDays;
-      if (retentionChanged) {
+      if (changes.kanbanDoneVisibleDaysChanged) {
         await getProductionTaskViewSync(queryClient).refreshAfterTaskRetentionChange(
           savedActiveWorkspace?.repoPath ?? null,
         );
       }
-      void queryClient.invalidateQueries({ queryKey: checksQueryKeys.all });
-      void queryClient.invalidateQueries({
-        queryKey: repositoryGitProviderContextQueryKeys.all,
-      });
+      if (changes.agentRuntimesChanged) {
+        void queryClient.invalidateQueries({ queryKey: checksQueryKeys.all });
+      }
+      for (const repoPath of changes.changedGitProviderRepoPaths) {
+        void queryClient.invalidateQueries({
+          queryKey: repositoryGitProviderContextQueryKeys.repo(repoPath),
+        });
+      }
     },
     [applyWorkspaceRecords, queryClient, settingsSnapshotQueryKey],
   );

--- a/packages/frontend/src/test-utils/shared-test-fixtures.ts
+++ b/packages/frontend/src/test-utils/shared-test-fixtures.ts
@@ -7,8 +7,11 @@ import {
   DEFAULT_KANBAN_SETTINGS,
   DEFAULT_NOTIFICATION_SETTINGS,
   GITHUB_PROVIDER_DESCRIPTOR,
+  type RepoGitConfig,
   repositoryGitProviderContextSchema,
   type RepositoryGitProviderContext,
+  settingsRepoConfigSchema,
+  type SettingsRepoConfig,
   type SettingsSnapshot,
   type TaskCard,
   type TaskStoreCheck,
@@ -144,14 +147,24 @@ const BASE_REPO_RUNTIME_MCP_FIXTURE: NonNullable<RepoRuntimeHealthCheck["mcp"]> 
   failureKind: null,
 };
 
+export const createGitProviderConfigFixture = ({
+  owner = "example",
+  name = "repo",
+  enabled = true,
+}: {
+  owner?: string;
+  name?: string;
+  enabled?: boolean;
+} = {}): NonNullable<RepoGitConfig["provider"]> => ({
+  id: "github",
+  enabled,
+  autoDetected: false,
+  repository: { host: "github.com", owner, name },
+});
+
 const BASE_GIT_PROVIDER_CONTEXT_FIXTURE = {
   descriptor: GITHUB_PROVIDER_DESCRIPTOR,
-  config: {
-    id: "github",
-    enabled: true,
-    autoDetected: false,
-    repository: { host: "github.com", owner: "example", name: "repo" },
-  },
+  config: createGitProviderConfigFixture(),
   health: {
     providerId: "github",
     enabled: true,
@@ -254,6 +267,19 @@ export const createSettingsSnapshotFixture = (
 
   return structuredClone(merged);
 };
+
+export const createRepoSettingsConfigFixture = (
+  workspaceId: string,
+  repoPath: string,
+  provider?: RepoGitConfig["provider"],
+): SettingsRepoConfig =>
+  settingsRepoConfigSchema.parse({
+    workspaceId,
+    workspaceName: workspaceId,
+    repoPath,
+    defaultRuntimeKind: "opencode",
+    git: provider === undefined ? {} : { provider },
+  });
 
 export const createDeferred = <T>() => {
   let resolve: ((value: T | PromiseLike<T>) => void) | null = null;


### PR DESCRIPTION
Saving settings had regressed to 1-2 seconds. The save awaited a Git provider refresh whose health check runs `gh api user` over the network. The save also invalidated repository config, runtime checks, and provider context on every save, even when the saved settings did not touch them.

This PR makes settings saves fast again. The save no longer waits for the provider refresh, and it invalidates only the caches whose source data changed: repository config when workspaces changed, runtime checks when agent runtimes changed, and Git provider context only for the repositories whose provider config or path changed. A theme or general settings save now triggers no Git provider network call and no runtime check.

The slowdown came from a fix that awaited the provider refresh. The provider UI still refreshes after a save, in the background, and the snapshot diff keeps that refresh scoped to the repositories that changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Settings saves now refresh only affected workspace, repository, task-view, agent-runtime, and Git provider data.
  * Unchanged settings no longer trigger unnecessary data refreshes.
  * Git provider updates are targeted to affected repositories, improving save responsiveness.

* **Bug Fixes**
  * Repository additions, removals, path changes, and provider configuration changes are detected more accurately.
  * Agent runtime and task-view retention changes now refresh the relevant data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->