### PR TITLE
fix(web): unblock Pierre diff worker in browser dev mode

### DIFF
--- a/docs/web-runner.md
+++ b/docs/web-runner.md
@@ -96,7 +96,7 @@ The host CORS allowlist includes the configured frontend origin, its hostname wi
 
 The launcher serves the browser config through `/openducktor-config.json` without authentication. Anyone who can reach the frontend port can read the app token. Restrict access as described in [Serve the runner on another machine](#serve-the-runner-on-another-machine).
 
-Workspace mode serves the frontend with the Vite dev server. The dev server exposes its module graph and `fs.allow` paths, so prefer production mode (`bunx @openducktor/web` without `--workspace`) on a remote machine. The launcher restricts Vite `fs.allow` to the web package and frontend sources, and allows the external URL hostname when it is not an IP address.
+Workspace mode serves the frontend with the Vite dev server. The dev server exposes its module graph and `fs.allow` paths, so prefer production mode (`bunx @openducktor/web` without `--workspace`) on a remote machine. The launcher restricts Vite `fs.allow` to the web package, the frontend sources, and the workspace `node_modules` directory, and allows the external URL hostname when it is not an IP address.
 
 The browser shell requires `VITE_ODT_BROWSER_BACKEND_URL` and `VITE_ODT_BROWSER_AUTH_TOKEN`. It does not use a default URL. The launcher injects both through `/openducktor-config.json`. The host accepts a configured `http` or `https` origin without user info, path, query, or fragment. The port is optional. The web host does not fall back to a desktop runtime route.
 

--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -457,6 +457,23 @@ describe("launcher internals", () => {
     ).toEqual(["/web-package", path.join("/web-package", "../frontend/src")]);
   });
 
+  test("allows workspace node_modules in Vite fs.allow so dependency assets load in workspace mode", () => {
+    expect(
+      viteServerOptions({
+        backendPort: 14327,
+        developmentInstanceId: "browser-test",
+        frontendPort: 1420,
+        packageRoot: "/repo/packages/openducktor-web",
+        workspaceMode: true,
+        workspaceRoot: "/repo",
+      }).fs?.allow,
+    ).toEqual([
+      "/repo/packages/openducktor-web",
+      path.join("/repo/packages/openducktor-web", "../frontend/src"),
+      "/repo/node_modules",
+    ]);
+  });
+
   test("does not restrict Vite hosts for IP external URLs", () => {
     expect(
       viteServerOptions({

--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -458,21 +458,26 @@ describe("launcher internals", () => {
     ).toEqual(["/web-package", path.join("/web-package", "../frontend/src")]);
   });
 
-  test("allows workspace node_modules in Vite fs.allow so dependency assets load in workspace mode", () => {
-    expect(
-      viteServerOptions({
-        backendPort: 14327,
-        developmentInstanceId: "browser-test",
-        frontendPort: 1420,
-        packageRoot: "/repo/packages/openducktor-web",
-        workspaceMode: true,
-        workspaceRoot: "/repo",
-      }).fs?.allow,
-    ).toEqual([
-      "/repo/packages/openducktor-web",
-      path.join("/repo/packages/openducktor-web", "../frontend/src"),
-      "/repo/node_modules",
-    ]);
+  test("allows the workspace node_modules path in Vite fs.allow when dependencies are not installed", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "odt-vite-allow-missing-"));
+    try {
+      expect(
+        viteServerOptions({
+          backendPort: 14327,
+          developmentInstanceId: "browser-test",
+          frontendPort: 1420,
+          packageRoot: "/repo/packages/openducktor-web",
+          workspaceMode: true,
+          workspaceRoot,
+        }).fs?.allow,
+      ).toEqual([
+        "/repo/packages/openducktor-web",
+        path.join("/repo/packages/openducktor-web", "../frontend/src"),
+        path.join(workspaceRoot, "node_modules"),
+      ]);
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
   });
 
   test("resolves a symlinked workspace node_modules to the real dependency store", async () => {

--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { realpathSync } from "node:fs";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { createServer as createHttpServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
@@ -472,6 +473,34 @@ describe("launcher internals", () => {
       path.join("/repo/packages/openducktor-web", "../frontend/src"),
       "/repo/node_modules",
     ]);
+  });
+
+  test("resolves a symlinked workspace node_modules to the real dependency store", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "odt-vite-allow-"));
+    try {
+      const store = path.join(root, "store");
+      const workspaceRoot = path.join(root, "worktree");
+      await mkdir(store, { recursive: true });
+      await mkdir(workspaceRoot, { recursive: true });
+      await symlink(store, path.join(workspaceRoot, "node_modules"), "dir");
+
+      expect(
+        viteServerOptions({
+          backendPort: 14327,
+          developmentInstanceId: "browser-test",
+          frontendPort: 1420,
+          packageRoot: "/repo/packages/openducktor-web",
+          workspaceMode: true,
+          workspaceRoot,
+        }).fs?.allow,
+      ).toEqual([
+        "/repo/packages/openducktor-web",
+        path.join("/repo/packages/openducktor-web", "../frontend/src"),
+        realpathSync(store),
+      ]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   test("does not restrict Vite hosts for IP external URLs", () => {

--- a/packages/openducktor-web/src/launcher.ts
+++ b/packages/openducktor-web/src/launcher.ts
@@ -318,12 +318,16 @@ const cleanupStartedFrontendServerEffect = (
   });
 
 export const viteServerOptions = (options: LauncherOptions): ViteServerOptions => {
+  const allowedPaths = [options.packageRoot, path.join(options.packageRoot, "../frontend/src")];
+  if (options.workspaceMode) {
+    allowedPaths.push(path.join(options.workspaceRoot, "node_modules"));
+  }
   const serverOptions: ViteServerOptions = {
     host: options.host?.trim() || LOCALHOST,
     port: options.frontendPort,
     strictPort: true,
     fs: {
-      allow: [options.packageRoot, path.join(options.packageRoot, "../frontend/src")],
+      allow: allowedPaths,
     },
   };
   const externalUrl = options.externalUrl?.trim();

--- a/packages/openducktor-web/src/launcher.ts
+++ b/packages/openducktor-web/src/launcher.ts
@@ -1,5 +1,6 @@
 import type { ServerOptions as ViteServerOptions } from "vite";
 import { randomUUID } from "node:crypto";
+import { existsSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { OPENDUCKTOR_DEV_INSTANCE_ENV } from "@openducktor/contracts";
 import type { McpBridgeDiscoveryMode } from "@openducktor/host";
@@ -320,7 +321,10 @@ const cleanupStartedFrontendServerEffect = (
 export const viteServerOptions = (options: LauncherOptions): ViteServerOptions => {
   const allowedPaths = [options.packageRoot, path.join(options.packageRoot, "../frontend/src")];
   if (options.workspaceMode) {
-    allowedPaths.push(path.join(options.workspaceRoot, "node_modules"));
+    const dependenciesRoot = path.join(options.workspaceRoot, "node_modules");
+    allowedPaths.push(
+      existsSync(dependenciesRoot) ? realpathSync(dependenciesRoot) : dependenciesRoot,
+    );
   }
   const serverOptions: ViteServerOptions = {
     host: options.host?.trim() || LOCALHOST,


### PR DESCRIPTION
## Problem

In workspace mode (`bun run browser:dev`), opening an agent view failed with:

> The request id ".../node_modules/.bun/@pierre+diffs@.../dist/worker/worker-portable.js" is outside of Vite serving allow list.

The diff viewer builds its worker with `new URL("@pierre/diffs/worker/worker-portable.js", import.meta.url)`. Vite rewrites that to a `/@fs/...` URL under the workspace dependency store. The launcher limited Vite `fs.allow` to the web package and the frontend sources, so Vite rejected the worker request with 403 and Pierre diffs could not render.

## Goal

Make browser dev mode serve the Pierre diff worker again, without widening the dev server to the whole repository.

## Change

- Allow the workspace `node_modules` directory in Vite `fs.allow` when the launcher runs in workspace mode.
- Resolve that directory with `realpathSync`, because Vite serves dependencies through their real path. This covers symlinked dependency stores.
- Production and non-workspace modes keep the previous allow list.

Workspace mode is dev only. Vite still blocks repository files such as `.env` and `.git`, and the docs already recommend production mode for remote access.