### PR TITLE
fix(dev-servers): report the command a dev server was started with

### DIFF
--- a/packages/contracts/src/dev-server-schemas.test.ts
+++ b/packages/contracts/src/dev-server-schemas.test.ts
@@ -44,6 +44,7 @@ describe("dev-server-schemas", () => {
             scriptId: "frontend",
             name: "Frontend",
             command: "bun run dev",
+            startedCommand: null,
             status: "running",
             pid: 4242,
             startedAt: "2026-03-25T10:00:00.000Z",
@@ -62,6 +63,7 @@ describe("dev-server-schemas", () => {
         scriptId: "frontend",
         name: "Frontend",
         command: "bun run dev",
+        startedCommand: null,
         status,
         runIdentity: null,
         pid: null,
@@ -85,6 +87,7 @@ describe("dev-server-schemas", () => {
       scriptId: "frontend",
       name: "Frontend",
       command: "bun run dev",
+      startedCommand: null,
       status: "failed",
       runIdentity: null,
       pid: null,
@@ -123,6 +126,7 @@ describe("dev-server-schemas", () => {
           scriptId: "frontend",
           name: "Frontend",
           command: "bun run dev",
+          startedCommand: null,
           status: "stopped",
           runIdentity: null,
           pid: null,
@@ -137,6 +141,26 @@ describe("dev-server-schemas", () => {
     expect(parsed.scripts[0]?.runIdentity).toBeNull();
     expect(parsed.scripts[0]?.startedCommand).toBeNull();
     expect(parsed.scripts[0]?.bufferedTerminalChunks).toEqual([]);
+  });
+
+  test("requires scripts to state the started command explicitly", () => {
+    const parsed = devServerScriptStateSchema.safeParse({
+      scriptId: "frontend",
+      name: "Frontend",
+      command: "bun run dev",
+      status: "stopped",
+      runIdentity: null,
+      pid: null,
+      startedAt: null,
+      exitCode: null,
+      lastError: null,
+    });
+
+    expect(parsed.success).toBe(false);
+    if (parsed.success) {
+      throw new Error("Expected a script without startedCommand to be rejected.");
+    }
+    expect(parsed.error.issues[0]?.path).toEqual(["startedCommand"]);
   });
 
   test("keeps the started command distinct from the configured command", () => {
@@ -172,6 +196,7 @@ describe("dev-server-schemas", () => {
             scriptId: "frontend",
             name: "Frontend",
             command: "bun run dev",
+            startedCommand: null,
             status: "running",
             runIdentity: { runId: "frontend:1" },
             pid: 4242,
@@ -196,6 +221,7 @@ describe("dev-server-schemas", () => {
             scriptId: "frontend",
             name: "Frontend",
             command: "bun run dev",
+            startedCommand: null,
             status: "stopped",
             runIdentity: {
               runId: "frontend:2",

--- a/packages/contracts/src/dev-server-schemas.test.ts
+++ b/packages/contracts/src/dev-server-schemas.test.ts
@@ -163,6 +163,32 @@ describe("dev-server-schemas", () => {
     expect(parsed.error.issues[0]?.path).toEqual(["startedCommand"]);
   });
 
+  test("rejects a run that does not state the started command", () => {
+    const parsed = devServerScriptStateSchema.safeParse({
+      scriptId: "frontend",
+      name: "Frontend",
+      command: "bun run dev:next",
+      startedCommand: null,
+      status: "running",
+      runIdentity: {
+        runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
+      pid: 4242,
+      startedAt: "2026-03-25T10:00:00.000Z",
+      exitCode: null,
+      lastError: null,
+      bufferedTerminalChunks: [],
+    });
+
+    expect(parsed.success).toBe(false);
+    if (parsed.success) {
+      throw new Error("Expected a run without a started command to be rejected.");
+    }
+    expect(parsed.error.issues).toHaveLength(1);
+    expect(parsed.error.issues[0]?.path).toEqual(["startedCommand"]);
+  });
+
   test("keeps the started command distinct from the configured command", () => {
     const parsed = devServerScriptStateSchema.parse({
       scriptId: "frontend",
@@ -221,7 +247,7 @@ describe("dev-server-schemas", () => {
             scriptId: "frontend",
             name: "Frontend",
             command: "bun run dev",
-            startedCommand: null,
+            startedCommand: "bun run dev",
             status: "stopped",
             runIdentity: {
               runId: "frontend:2",

--- a/packages/contracts/src/dev-server-schemas.test.ts
+++ b/packages/contracts/src/dev-server-schemas.test.ts
@@ -135,7 +135,30 @@ describe("dev-server-schemas", () => {
     });
 
     expect(parsed.scripts[0]?.runIdentity).toBeNull();
+    expect(parsed.scripts[0]?.startedCommand).toBeNull();
     expect(parsed.scripts[0]?.bufferedTerminalChunks).toEqual([]);
+  });
+
+  test("keeps the started command distinct from the configured command", () => {
+    const parsed = devServerScriptStateSchema.parse({
+      scriptId: "frontend",
+      name: "Frontend",
+      command: "bun run dev:next",
+      startedCommand: "bun run dev",
+      status: "running",
+      runIdentity: {
+        runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
+      pid: 4242,
+      startedAt: "2026-03-25T10:00:00.000Z",
+      exitCode: null,
+      lastError: null,
+      bufferedTerminalChunks: [],
+    });
+
+    expect(parsed.command).toBe("bun run dev:next");
+    expect(parsed.startedCommand).toBe("bun run dev");
   });
 
   test("rejects structurally incomplete run identity", () => {

--- a/packages/contracts/src/dev-server-schemas.ts
+++ b/packages/contracts/src/dev-server-schemas.ts
@@ -59,6 +59,14 @@ export const devServerScriptStateSchema = z
       return;
     }
 
+    if (script.runIdentity !== null && script.startedCommand === null) {
+      context.addIssue({
+        code: "custom",
+        message: "Dev server scripts with a run must state the started command.",
+        path: ["startedCommand"],
+      });
+    }
+
     for (const [index, chunk] of script.bufferedTerminalChunks.entries()) {
       if (
         chunk.scriptId !== script.scriptId ||

--- a/packages/contracts/src/dev-server-schemas.ts
+++ b/packages/contracts/src/dev-server-schemas.ts
@@ -35,6 +35,7 @@ export const devServerScriptStateSchema = z
     scriptId: z.string().min(1),
     name: z.string().min(1),
     command: z.string().min(1),
+    startedCommand: z.string().min(1).nullable().default(null),
     status: devServerScriptStatusSchema,
     runIdentity: devServerRunIdentitySchema.nullable(),
     pid: z.number().int().positive().nullable(),

--- a/packages/contracts/src/dev-server-schemas.ts
+++ b/packages/contracts/src/dev-server-schemas.ts
@@ -35,7 +35,7 @@ export const devServerScriptStateSchema = z
     scriptId: z.string().min(1),
     name: z.string().min(1),
     command: z.string().min(1),
-    startedCommand: z.string().min(1).nullable().default(null),
+    startedCommand: z.string().min(1).nullable(),
     status: devServerScriptStatusSchema,
     runIdentity: devServerRunIdentitySchema.nullable(),
     pid: z.number().int().positive().nullable(),

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
@@ -51,6 +51,7 @@ const runningScript: DevServerScriptState = {
   scriptId: "frontend",
   name: "Frontend",
   command: "bun run dev",
+  startedCommand: "bun run dev",
   status: "running",
   runIdentity: {
     runId: "frontend:1",
@@ -88,6 +89,7 @@ const backendScript: DevServerScriptState = {
   scriptId: "backend",
   name: "Backend",
   command: "bun run api",
+  startedCommand: "bun run api",
   status: "running",
   runIdentity: {
     runId: "backend:1",
@@ -115,6 +117,7 @@ const failedScript: DevServerScriptState = {
   scriptId: "failed",
   name: "Failed server",
   command: "bun run broken",
+  startedCommand: "bun run broken",
   status: "failed",
   runIdentity: {
     runId: "failed:1",
@@ -347,6 +350,29 @@ describe("AgentStudioDevServerPanel", () => {
     expect(html).toContain("Frontend");
     expect(html).toContain("bun run dev");
     expect(html).not.toContain("agent-studio-dev-server-empty-log-state");
+  });
+
+  test("prefers the started command over the configured command", () => {
+    const driftedScript: DevServerScriptState = {
+      ...runningScript,
+      command: "bun run dev:next",
+      startedCommand: "bun run dev",
+    };
+    const html = renderToStaticMarkup(
+      createElement(AgentStudioDevServerPanel, {
+        model: baseModel({
+          mode: "active",
+          isExpanded: true,
+          scripts: [driftedScript],
+          selectedScriptId: driftedScript.scriptId,
+          selectedScript: driftedScript,
+          selectedScriptTerminalBuffer: buildTerminalBuffer(driftedScript),
+        }),
+      }),
+    );
+
+    expect(html).toContain("bun run dev");
+    expect(html).not.toContain("bun run dev:next");
   });
 
   test("renders failed dev server tabs with failed status styling", () => {

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
@@ -353,7 +353,7 @@ describe("AgentStudioDevServerPanel", () => {
   });
 
   test("prefers the started command over the configured command", () => {
-    const driftedScript: DevServerScriptState = {
+    const reconfiguredScript: DevServerScriptState = {
       ...runningScript,
       command: "bun run dev:next",
       startedCommand: "bun run dev",
@@ -363,10 +363,10 @@ describe("AgentStudioDevServerPanel", () => {
         model: baseModel({
           mode: "active",
           isExpanded: true,
-          scripts: [driftedScript],
-          selectedScriptId: driftedScript.scriptId,
-          selectedScript: driftedScript,
-          selectedScriptTerminalBuffer: buildTerminalBuffer(driftedScript),
+          scripts: [reconfiguredScript],
+          selectedScriptId: reconfiguredScript.scriptId,
+          selectedScript: reconfiguredScript,
+          selectedScriptTerminalBuffer: buildTerminalBuffer(reconfiguredScript),
         }),
       }),
     );

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
@@ -355,8 +355,8 @@ describe("AgentStudioDevServerPanel", () => {
   test("prefers the started command over the configured command", () => {
     const reconfiguredScript: DevServerScriptState = {
       ...runningScript,
-      command: "bun run dev:next",
-      startedCommand: "bun run dev",
+      command: "bun run configured",
+      startedCommand: "bun run started",
     };
     const html = renderToStaticMarkup(
       createElement(AgentStudioDevServerPanel, {
@@ -371,8 +371,37 @@ describe("AgentStudioDevServerPanel", () => {
       }),
     );
 
-    expect(html).toContain("bun run dev");
-    expect(html).not.toContain("bun run dev:next");
+    expect(html).toContain("bun run started");
+    expect(html).not.toContain("bun run configured");
+  });
+
+  test("shows the configured command before the first run", () => {
+    const neverStartedScript: DevServerScriptState = {
+      ...runningScript,
+      command: "bun run configured",
+      startedCommand: null,
+      status: "stopped",
+      runIdentity: null,
+      pid: null,
+      startedAt: null,
+      exitCode: null,
+      lastError: null,
+      bufferedTerminalChunks: [],
+    };
+    const html = renderToStaticMarkup(
+      createElement(AgentStudioDevServerPanel, {
+        model: baseModel({
+          mode: "stopped",
+          isExpanded: true,
+          scripts: [neverStartedScript],
+          selectedScriptId: neverStartedScript.scriptId,
+          selectedScript: neverStartedScript,
+          selectedScriptTerminalBuffer: buildTerminalBuffer(neverStartedScript),
+        }),
+      }),
+    );
+
+    expect(html).toContain("bun run configured");
   });
 
   test("renders failed dev server tabs with failed status styling", () => {

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
@@ -404,6 +404,33 @@ describe("AgentStudioDevServerPanel", () => {
     expect(html).toContain("bun run configured");
   });
 
+  test("shows the last started command after the server stops", () => {
+    const stoppedAfterRunScript: DevServerScriptState = {
+      ...runningScript,
+      command: "bun run configured",
+      startedCommand: "bun run started",
+      status: "stopped",
+      pid: null,
+      startedAt: null,
+      lastError: null,
+    };
+    const html = renderToStaticMarkup(
+      createElement(AgentStudioDevServerPanel, {
+        model: baseModel({
+          mode: "stopped",
+          isExpanded: true,
+          scripts: [stoppedAfterRunScript],
+          selectedScriptId: stoppedAfterRunScript.scriptId,
+          selectedScript: stoppedAfterRunScript,
+          selectedScriptTerminalBuffer: buildTerminalBuffer(stoppedAfterRunScript),
+        }),
+      }),
+    );
+
+    expect(html).toContain("bun run started");
+    expect(html).not.toContain("bun run configured");
+  });
+
   test("renders failed dev server tabs with failed status styling", () => {
     const html = renderToStaticMarkup(
       createElement(AgentStudioDevServerPanel, {

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
@@ -371,7 +371,7 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
                   <div className="flex flex-wrap items-center gap-2">
                     <span className="font-mono text-[var(--dev-server-terminal-subtle)]">$</span>
                     <span className="font-mono text-[var(--dev-server-terminal-foreground)]">
-                      {selectedScriptContent.command}
+                      {selectedScriptContent.startedCommand ?? selectedScriptContent.command}
                     </span>
                   </div>
                 </div>

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
@@ -94,6 +94,34 @@ const getEmptyTerminalMessage = (script: DevServerScriptState): string => {
   return "Terminal output will appear here once this dev server writes output. Drag to select logs, then press Cmd/Ctrl+C to copy.";
 };
 
+const getDisplayedScriptCommand = (script: DevServerScriptState): string =>
+  script.startedCommand ?? script.command;
+
+const getHeaderSummary = (
+  mode: AgentStudioDevServerPanelMode,
+  worktreePath: string | null,
+): string => {
+  if (mode === "empty") {
+    return DEV_SERVER_EMPTY_REASON;
+  }
+
+  if (mode === "disabled") {
+    return DEV_SERVER_DISABLED_REASON;
+  }
+
+  if (mode === "loading") {
+    return "Loading builder dev server state…";
+  }
+
+  if (mode === "stopped") {
+    return "Start the configured builder dev servers for this task worktree.";
+  }
+
+  return worktreePath
+    ? `Running in ${worktreePath}`
+    : "Builder dev server terminals stream here while the task worktree is active.";
+};
+
 function CompactStartButton({
   button,
   disabledReason,
@@ -136,6 +164,186 @@ function CompactStartButton({
   );
 }
 
+function CompactDevServerPanel({
+  compactAction,
+  disabledReason,
+  disabledReasonId,
+  isActionPending,
+  isStartPending,
+  mode,
+  onStart,
+  panelError,
+}: {
+  compactAction: ReactElement | undefined;
+  disabledReason: string | null;
+  disabledReasonId: string;
+  isActionPending: boolean;
+  isStartPending: boolean;
+  mode: AgentStudioDevServerPanelMode;
+  onStart: () => void;
+  panelError: string | null;
+}): ReactElement {
+  const isEmpty = mode === "empty";
+  const isDisabled = mode === "disabled";
+  const isLoading = mode === "loading";
+  const startDisabled = isEmpty || isDisabled || isLoading || isActionPending;
+  const startLabel = getStartLabel(isLoading, isStartPending);
+  const startButton = (
+    <Button
+      type="button"
+      size="sm"
+      className="w-full justify-center rounded-lg"
+      disabled={startDisabled}
+      onClick={onStart}
+      data-testid="agent-studio-dev-server-start-button"
+    >
+      <Play className="size-4" />
+      {startLabel}
+    </Button>
+  );
+  // `disabledReason` is only produced for the stable `empty`/`disabled` modes.
+  // It cannot overlap with the transient loading/start-pending button labels.
+
+  return (
+    <div
+      className="border-t border-border bg-card/70 p-3"
+      data-testid="agent-studio-dev-server-compact-panel"
+    >
+      <div className="flex items-center gap-2">
+        <div className="min-w-0 flex-1">
+          <CompactStartButton
+            button={startButton}
+            disabledReason={disabledReason}
+            disabledReasonId={disabledReasonId}
+          />
+        </div>
+        {compactAction}
+      </div>
+      <DevServerErrorBanner
+        className="mt-3 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+        message={panelError}
+      />
+    </div>
+  );
+}
+
+function DevServerWorktreePathHeader({
+  headerSummary,
+  isWorktreePathCopied,
+  onCopyWorktreePath,
+  worktreePath,
+}: {
+  headerSummary: string;
+  isWorktreePathCopied: boolean;
+  onCopyWorktreePath: () => void;
+  worktreePath: string | null;
+}): ReactElement {
+  if (worktreePath === null) {
+    return (
+      <p
+        className="mt-3 text-xs text-muted-foreground"
+        data-testid="agent-studio-dev-server-header-summary"
+      >
+        {headerSummary}
+      </p>
+    );
+  }
+
+  return (
+    <div className="inline-flex max-w-full items-center gap-1.5 text-xs text-muted-foreground">
+      <p className="min-w-0 truncate" data-testid="agent-studio-dev-server-header-summary">
+        {headerSummary}
+      </p>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="size-6 shrink-0 text-muted-foreground hover:bg-muted hover:text-foreground"
+        onClick={onCopyWorktreePath}
+        data-testid="agent-studio-dev-server-copy-worktree-path"
+        aria-label="Copy working directory"
+      >
+        {isWorktreePathCopied ? (
+          <Check className="size-3.5 text-emerald-500 dark:text-emerald-400" />
+        ) : (
+          <Copy className="size-3.5" />
+        )}
+      </Button>
+    </div>
+  );
+}
+
+function DevServerErrorBanner({
+  className,
+  message,
+}: {
+  className: string;
+  message: string | null;
+}): ReactElement | null {
+  if (message === null) {
+    return null;
+  }
+
+  return (
+    <div className={className} data-testid="agent-studio-dev-server-error-banner">
+      {message}
+    </div>
+  );
+}
+
+function DevServerTerminalContent({
+  onRendererError,
+  script,
+  terminalBuffer,
+  terminalChunkCount,
+  terminalScopeKey,
+}: {
+  onRendererError: (message: string | null) => void;
+  script: DevServerScriptState | null;
+  terminalBuffer: AgentStudioDevServerTerminalBuffer | null;
+  terminalChunkCount: number;
+  terminalScopeKey: string;
+}): ReactElement | null {
+  if (script === null) {
+    return null;
+  }
+
+  return (
+    <TabsContent
+      value={script.scriptId}
+      className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden outline-none"
+    >
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-[var(--dev-server-terminal-panel)] text-[var(--dev-server-terminal-foreground)]">
+        <div className="border-b border-[var(--dev-server-terminal-border)] bg-[var(--dev-server-terminal-panel-header)] px-3 py-2 text-xs text-[var(--dev-server-terminal-muted)]">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-mono text-[var(--dev-server-terminal-subtle)]">$</span>
+            <span className="font-mono text-[var(--dev-server-terminal-foreground)]">
+              {getDisplayedScriptCommand(script)}
+            </span>
+          </div>
+        </div>
+
+        <div className="relative min-h-0 flex-1 overflow-hidden bg-[var(--dev-server-terminal-panel)]">
+          <AgentStudioDevServerTerminal
+            scopeKey={terminalScopeKey}
+            scriptId={script.scriptId}
+            terminalBuffer={terminalBuffer}
+            onRendererError={onRendererError}
+          />
+          {terminalChunkCount === 0 ? (
+            <div
+              className="pointer-events-none absolute inset-0 flex items-center justify-center px-6 py-8 text-center text-sm text-[var(--dev-server-terminal-muted)]"
+              data-testid="agent-studio-dev-server-empty-log-state"
+            >
+              {getEmptyTerminalMessage(script)}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </TabsContent>
+  );
+}
+
 export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel({
   model,
   compactAction,
@@ -174,27 +382,10 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
     errorLogContext: "AgentStudioDevServerPanel",
   });
 
-  const headerSummary = useMemo(() => {
-    if (model.mode === "empty") {
-      return DEV_SERVER_EMPTY_REASON;
-    }
-
-    if (model.mode === "disabled") {
-      return DEV_SERVER_DISABLED_REASON;
-    }
-
-    if (model.mode === "loading") {
-      return "Loading builder dev server state…";
-    }
-
-    if (model.mode === "stopped") {
-      return "Start the configured builder dev servers for this task worktree.";
-    }
-
-    return model.worktreePath
-      ? `Running in ${model.worktreePath}`
-      : "Builder dev server terminals stream here while the task worktree is active.";
-  }, [model.mode, model.worktreePath]);
+  const headerSummary = useMemo(
+    () => getHeaderSummary(model.mode, model.worktreePath),
+    [model.mode, model.worktreePath],
+  );
 
   const handleCopyWorktreePath = useCallback(() => {
     if (!model.worktreePath) {
@@ -205,51 +396,17 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
   }, [copyWorktreePath, model.worktreePath]);
 
   if (!hasExpandedActions) {
-    const isEmpty = model.mode === "empty";
-    const isDisabled = model.mode === "disabled";
-    const isLoading = model.mode === "loading";
-    const startDisabled = isEmpty || isDisabled || isLoading || isActionPending;
-    const startLabel = getStartLabel(isLoading, model.isStartPending);
-    const startButton = (
-      <Button
-        type="button"
-        size="sm"
-        className="w-full justify-center rounded-lg"
-        disabled={startDisabled}
-        onClick={model.onStart}
-        data-testid="agent-studio-dev-server-start-button"
-      >
-        <Play className="size-4" />
-        {startLabel}
-      </Button>
-    );
-    // `disabledReason` is only produced for the stable `empty`/`disabled` modes.
-    // It cannot overlap with the transient loading/start-pending button labels.
-
     return (
-      <div
-        className="border-t border-border bg-card/70 p-3"
-        data-testid="agent-studio-dev-server-compact-panel"
-      >
-        <div className="flex items-center gap-2">
-          <div className="min-w-0 flex-1">
-            <CompactStartButton
-              button={startButton}
-              disabledReason={model.disabledReason}
-              disabledReasonId={disabledReasonId}
-            />
-          </div>
-          {compactAction}
-        </div>
-        {panelError ? (
-          <div
-            className="mt-3 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive"
-            data-testid="agent-studio-dev-server-error-banner"
-          >
-            {panelError}
-          </div>
-        ) : null}
-      </div>
+      <CompactDevServerPanel
+        compactAction={compactAction}
+        disabledReason={model.disabledReason}
+        disabledReasonId={disabledReasonId}
+        isActionPending={isActionPending}
+        isStartPending={model.isStartPending}
+        mode={model.mode}
+        onStart={model.onStart}
+        panelError={panelError}
+      />
     );
   }
 
@@ -288,45 +445,18 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
           </Button>
         </div>
 
-        {model.worktreePath ? (
-          <div className="inline-flex max-w-full items-center gap-1.5 text-xs text-muted-foreground">
-            <p className="min-w-0 truncate" data-testid="agent-studio-dev-server-header-summary">
-              {headerSummary}
-            </p>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="size-6 shrink-0 text-muted-foreground hover:bg-muted hover:text-foreground"
-              onClick={handleCopyWorktreePath}
-              data-testid="agent-studio-dev-server-copy-worktree-path"
-              aria-label="Copy working directory"
-            >
-              {copiedWorktreePath ? (
-                <Check className="size-3.5 text-emerald-500 dark:text-emerald-400" />
-              ) : (
-                <Copy className="size-3.5" />
-              )}
-            </Button>
-          </div>
-        ) : (
-          <p
-            className="mt-3 text-xs text-muted-foreground"
-            data-testid="agent-studio-dev-server-header-summary"
-          >
-            {headerSummary}
-          </p>
-        )}
+        <DevServerWorktreePathHeader
+          headerSummary={headerSummary}
+          isWorktreePathCopied={copiedWorktreePath}
+          onCopyWorktreePath={handleCopyWorktreePath}
+          worktreePath={model.worktreePath}
+        />
       </div>
 
-      {panelError ? (
-        <div
-          className="border-b border-border bg-destructive/10 px-3 py-2 text-xs text-destructive"
-          data-testid="agent-studio-dev-server-error-banner"
-        >
-          {panelError}
-        </div>
-      ) : null}
+      <DevServerErrorBanner
+        className="border-b border-border bg-destructive/10 px-3 py-2 text-xs text-destructive"
+        message={panelError}
+      />
 
       <Tabs
         value={selectedTabsValue}
@@ -361,40 +491,13 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
             </TabsList>
           </div>
 
-          {selectedScriptContent ? (
-            <TabsContent
-              value={selectedScriptContent.scriptId}
-              className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden outline-none"
-            >
-              <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-[var(--dev-server-terminal-panel)] text-[var(--dev-server-terminal-foreground)]">
-                <div className="border-b border-[var(--dev-server-terminal-border)] bg-[var(--dev-server-terminal-panel-header)] px-3 py-2 text-xs text-[var(--dev-server-terminal-muted)]">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="font-mono text-[var(--dev-server-terminal-subtle)]">$</span>
-                    <span className="font-mono text-[var(--dev-server-terminal-foreground)]">
-                      {selectedScriptContent.startedCommand ?? selectedScriptContent.command}
-                    </span>
-                  </div>
-                </div>
-
-                <div className="relative min-h-0 flex-1 overflow-hidden bg-[var(--dev-server-terminal-panel)]">
-                  <AgentStudioDevServerTerminal
-                    scopeKey={terminalScopeKey}
-                    scriptId={selectedScriptContent.scriptId}
-                    terminalBuffer={selectedScriptTerminalBuffer}
-                    onRendererError={setRendererError}
-                  />
-                  {selectedScriptTerminalChunkCount === 0 ? (
-                    <div
-                      className="pointer-events-none absolute inset-0 flex items-center justify-center px-6 py-8 text-center text-sm text-[var(--dev-server-terminal-muted)]"
-                      data-testid="agent-studio-dev-server-empty-log-state"
-                    >
-                      {getEmptyTerminalMessage(selectedScriptContent)}
-                    </div>
-                  ) : null}
-                </div>
-              </div>
-            </TabsContent>
-          ) : null}
+          <DevServerTerminalContent
+            onRendererError={setRendererError}
+            script={selectedScriptContent}
+            terminalBuffer={selectedScriptTerminalBuffer}
+            terminalChunkCount={selectedScriptTerminalChunkCount}
+            terminalScopeKey={terminalScopeKey}
+          />
         </div>
       </Tabs>
     </div>

--- a/packages/frontend/src/components/features/agents/task-execution-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-panel.test.tsx
@@ -222,6 +222,7 @@ const selectedScript: DevServerScriptState = {
   scriptId: "frontend",
   name: "Frontend",
   command: "bun run dev",
+  startedCommand: "bun run dev",
   status: "running",
   runIdentity: {
     runId: "frontend:1",

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -36,6 +36,7 @@ const buildScript = (overrides: Partial<DevServerScriptState> = {}): DevServerSc
     scriptId: "frontend",
     name: "Frontend",
     command: "bun run dev",
+    startedCommand: null,
     status: "stopped",
     runIdentity,
     pid: null,

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -32,11 +32,12 @@ const buildScript = (overrides: Partial<DevServerScriptState> = {}): DevServerSc
     overrides.runIdentity === undefined
       ? (bufferedRunIdentity ?? defaultRunIdentity)
       : overrides.runIdentity;
+  const startedCommand = runIdentity === null ? null : (overrides.command ?? "bun run dev");
   return {
     scriptId: "frontend",
     name: "Frontend",
     command: "bun run dev",
-    startedCommand: null,
+    startedCommand,
     status: "stopped",
     runIdentity,
     pid: null,

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-run-ownership.test.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-run-ownership.test.ts
@@ -28,6 +28,7 @@ const scriptState = (
   scriptId,
   name: scriptId,
   command: `run ${scriptId}`,
+  startedCommand: identity === null ? null : `run ${scriptId}`,
   status: identity === null ? "stopped" : "running",
   runIdentity: identity,
   pid: identity === null ? null : 1,

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-test-fixtures.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-test-fixtures.ts
@@ -37,6 +37,7 @@ export const buildScript = (
     scriptId: "frontend",
     name: "Frontend",
     command: "bun run dev",
+    startedCommand: null,
     status: "stopped",
     runIdentity,
     pid: null,

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-test-fixtures.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-test-fixtures.ts
@@ -33,11 +33,12 @@ export const buildScript = (
     overrides.runIdentity === undefined
       ? (bufferedRunIdentity ?? defaultRunIdentity)
       : overrides.runIdentity;
+  const startedCommand = runIdentity === null ? null : (overrides.command ?? "bun run dev");
   return {
     scriptId: "frontend",
     name: "Frontend",
     command: "bun run dev",
-    startedCommand: null,
+    startedCommand,
     status: "stopped",
     runIdentity,
     pid: null,

--- a/packages/host/src/application/dev-servers/dev-server-runtime-scripts.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-runtime-scripts.test.ts
@@ -1,7 +1,9 @@
 import type { RepoConfig } from "@openducktor/contracts";
 import { Effect } from "effect";
+import { HostInvariantError } from "../../effect/host-errors";
 import type { DevServerProcessHandle } from "../../ports/dev-server-process-port";
 import {
+  listRunningScripts,
   markScriptProcessHandleMissing,
   stopScriptProcessHandle,
   type UpdateScriptState,
@@ -108,6 +110,55 @@ describe("dev-server runtime script helpers", () => {
       status: "running",
       pid: 402,
       startedAt: "2026-05-24T00:00:00.000Z",
+    });
+  });
+
+  test("reports the started command for a live process", () => {
+    const runtime = createRuntime();
+    const script = requireScript(runtime, "web");
+    script.command = "bun run dev:next";
+    script.startedCommand = "bun run dev";
+    script.status = "running";
+    script.runIdentity = {
+      runId: "web:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
+    };
+    script.pid = 401;
+    script.startedAt = "2026-05-24T00:00:00.000Z";
+
+    expect(listRunningScripts(runtime)).toEqual([
+      {
+        command: "bun run dev",
+        name: "Web",
+        pid: 401,
+        repoPath: "/canonical/repo",
+        scriptId: "web",
+        taskId: "task-1",
+      },
+    ]);
+  });
+
+  test("fails when a live process has no recorded started command", () => {
+    const runtime = createRuntime();
+    const script = requireScript(runtime, "web");
+    script.status = "running";
+    script.runIdentity = {
+      runId: "web:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
+    };
+    script.pid = 401;
+
+    let caught: unknown;
+    try {
+      listRunningScripts(runtime);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(HostInvariantError);
+    expect(caught).toMatchObject({
+      invariant: "dev_server_started_command_recorded",
+      message: "Dev server script has no recorded started command: web",
     });
   });
 });

--- a/packages/host/src/application/dev-servers/dev-server-runtime-scripts.ts
+++ b/packages/host/src/application/dev-servers/dev-server-runtime-scripts.ts
@@ -1,6 +1,6 @@
 import type { DevServerScriptState } from "@openducktor/contracts";
 import { Effect } from "effect";
-import { errorMessage } from "../../effect/host-errors";
+import { errorMessage, HostInvariantError } from "../../effect/host-errors";
 import type { DevServerProcessHandle } from "../../ports/dev-server-process-port";
 import type { StoppedDevServerScript } from "./dev-server-service-types";
 import type { DevServerGroupRuntime } from "./dev-server-state";
@@ -15,14 +15,23 @@ const stoppedScriptFromState = (
   runtime: DevServerGroupRuntime,
   script: DevServerScriptState,
   pid: number,
-): StoppedDevServerScript => ({
-  command: script.startedCommand ?? script.command,
-  name: script.name,
-  pid,
-  repoPath: runtime.state.repoPath,
-  scriptId: script.scriptId,
-  taskId: runtime.state.taskId,
-});
+): StoppedDevServerScript => {
+  if (script.startedCommand === null) {
+    throw new HostInvariantError({
+      invariant: "dev_server_started_command_recorded",
+      message: `Dev server script has no recorded started command: ${script.scriptId}`,
+    });
+  }
+
+  return {
+    command: script.startedCommand,
+    name: script.name,
+    pid,
+    repoPath: runtime.state.repoPath,
+    scriptId: script.scriptId,
+    taskId: runtime.state.taskId,
+  };
+};
 
 export const markScriptProcessHandleMissing = ({
   pid,

--- a/packages/host/src/application/dev-servers/dev-server-runtime-scripts.ts
+++ b/packages/host/src/application/dev-servers/dev-server-runtime-scripts.ts
@@ -16,7 +16,7 @@ const stoppedScriptFromState = (
   script: DevServerScriptState,
   pid: number,
 ): StoppedDevServerScript => ({
-  command: script.command,
+  command: script.startedCommand ?? script.command,
   name: script.name,
   pid,
   repoPath: runtime.state.repoPath,

--- a/packages/host/src/application/dev-servers/dev-server-service.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.test.ts
@@ -378,6 +378,33 @@ describe("createDevServerService", () => {
       "Dev servers are already running for task task-1. Stop or restart them instead.",
     );
   });
+  test("keeps the started command when repository settings change during the run", async () => {
+    const { processPort, starts } = createProcessPort();
+    const config = repoConfig();
+    const service = createDevServerService({
+      processPort,
+      taskWorktreeService: createTaskWorktreeService({ workingDirectory: "/worktrees/task-1" }),
+      workspaceSettingsService: createWorkspaceSettingsService(config),
+    });
+
+    await Effect.runPromise(service.start({ repoPath: "/repo", taskId: "task-1" }));
+    config.devServers = [{ id: "web", name: "Web", command: "bun run dev:next" }];
+
+    await expect(
+      Effect.runPromise(service.getState({ repoPath: "/repo", taskId: "task-1" })),
+    ).resolves.toMatchObject({
+      scripts: [{ scriptId: "web", command: "bun run dev", status: "running" }],
+    });
+
+    await Effect.runPromise(service.restart({ repoPath: "/repo", taskId: "task-1" }));
+
+    expect(starts.map((start) => start.command)).toEqual(["bun run dev", "bun run dev:next"]);
+    await expect(
+      Effect.runPromise(service.getState({ repoPath: "/repo", taskId: "task-1" })),
+    ).resolves.toMatchObject({
+      scripts: [{ scriptId: "web", command: "bun run dev:next", status: "running" }],
+    });
+  });
   test("requires a task worktree before starting scripts", async () => {
     const { processPort } = createProcessPort();
     const service = createDevServerService({

--- a/packages/host/src/application/dev-servers/dev-server-service.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.test.ts
@@ -446,6 +446,26 @@ describe("createDevServerService", () => {
       ],
     });
   });
+  test("reports the started command when stopping scripts after repository settings change", async () => {
+    const { config, service } = createServiceWithMutableConfig();
+
+    await Effect.runPromise(service.start({ repoPath: "/repo", taskId: "task-1" }));
+    config.devServers = [{ id: "web", name: "Web", command: "bun run dev:next" }];
+    await Effect.runPromise(service.getState({ repoPath: "/repo", taskId: "task-1" }));
+
+    await expect(Effect.runPromise(service.stopAll())).resolves.toEqual({
+      stoppedScripts: [
+        {
+          command: "bun run dev",
+          name: "Web",
+          pid: 400,
+          repoPath: "/canonical/repo",
+          scriptId: "web",
+          taskId: "task-1",
+        },
+      ],
+    });
+  });
   test("requires a task worktree before starting scripts", async () => {
     const { processPort } = createProcessPort();
     const service = createDevServerService({

--- a/packages/host/src/application/dev-servers/dev-server-service.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.test.ts
@@ -421,7 +421,7 @@ describe("createDevServerService", () => {
       ],
     });
   });
-  test("keeps the failed run's command when repository settings change", async () => {
+  test("keeps the started command after a failure when repository settings change", async () => {
     const { processPort, starts } = createProcessPort();
     const config = repoConfig();
     const service = createDevServerService({

--- a/packages/host/src/application/dev-servers/dev-server-service.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.test.ts
@@ -180,6 +180,7 @@ describe("createDevServerService", () => {
           scriptId: "web",
           name: "Web",
           command: "bun run dev",
+          startedCommand: null,
           status: "stopped",
           pid: null,
           startedAt: null,
@@ -230,6 +231,7 @@ describe("createDevServerService", () => {
           scriptId: "web",
           status: "running",
           pid: 400,
+          startedCommand: "bun run dev",
           bufferedTerminalChunks: [
             {
               data: "Starting `bun run dev`\r\n",
@@ -393,7 +395,14 @@ describe("createDevServerService", () => {
     await expect(
       Effect.runPromise(service.getState({ repoPath: "/repo", taskId: "task-1" })),
     ).resolves.toMatchObject({
-      scripts: [{ scriptId: "web", command: "bun run dev", status: "running" }],
+      scripts: [
+        {
+          scriptId: "web",
+          command: "bun run dev:next",
+          startedCommand: "bun run dev",
+          status: "running",
+        },
+      ],
     });
 
     await Effect.runPromise(service.restart({ repoPath: "/repo", taskId: "task-1" }));
@@ -402,7 +411,41 @@ describe("createDevServerService", () => {
     await expect(
       Effect.runPromise(service.getState({ repoPath: "/repo", taskId: "task-1" })),
     ).resolves.toMatchObject({
-      scripts: [{ scriptId: "web", command: "bun run dev:next", status: "running" }],
+      scripts: [
+        {
+          scriptId: "web",
+          command: "bun run dev:next",
+          startedCommand: "bun run dev:next",
+          status: "running",
+        },
+      ],
+    });
+  });
+  test("keeps the failed run's command when repository settings change", async () => {
+    const { processPort, starts } = createProcessPort();
+    const config = repoConfig();
+    const service = createDevServerService({
+      processPort,
+      taskWorktreeService: createTaskWorktreeService({ workingDirectory: "/worktrees/task-1" }),
+      workspaceSettingsService: createWorkspaceSettingsService(config),
+    });
+
+    await Effect.runPromise(service.start({ repoPath: "/repo", taskId: "task-1" }));
+    config.devServers = [{ id: "web", name: "Web", command: "bun run dev:next" }];
+    starts[0]?.onExit({ pid: 400, exitCode: 7, signal: null, error: null });
+
+    await expect(
+      Effect.runPromise(service.getState({ repoPath: "/repo", taskId: "task-1" })),
+    ).resolves.toMatchObject({
+      scripts: [
+        {
+          scriptId: "web",
+          command: "bun run dev:next",
+          startedCommand: "bun run dev",
+          status: "failed",
+          exitCode: 7,
+        },
+      ],
     });
   });
   test("requires a task worktree before starting scripts", async () => {

--- a/packages/host/src/application/dev-servers/dev-server-service.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.test.ts
@@ -118,6 +118,16 @@ const createProcessPort = () => {
   };
   return { handles, processPort, starts, stoppedPids };
 };
+const createServiceWithMutableConfig = () => {
+  const { processPort, starts } = createProcessPort();
+  const config = repoConfig();
+  const service = createDevServerService({
+    processPort,
+    taskWorktreeService: createTaskWorktreeService({ workingDirectory: "/worktrees/task-1" }),
+    workspaceSettingsService: createWorkspaceSettingsService(config),
+  });
+  return { config, service, starts };
+};
 const devServerStartFailureSchema = z.object({
   message: z.string(),
   details: z.object({
@@ -381,13 +391,7 @@ describe("createDevServerService", () => {
     );
   });
   test("keeps the started command when repository settings change during the run", async () => {
-    const { processPort, starts } = createProcessPort();
-    const config = repoConfig();
-    const service = createDevServerService({
-      processPort,
-      taskWorktreeService: createTaskWorktreeService({ workingDirectory: "/worktrees/task-1" }),
-      workspaceSettingsService: createWorkspaceSettingsService(config),
-    });
+    const { config, service, starts } = createServiceWithMutableConfig();
 
     await Effect.runPromise(service.start({ repoPath: "/repo", taskId: "task-1" }));
     config.devServers = [{ id: "web", name: "Web", command: "bun run dev:next" }];
@@ -422,13 +426,7 @@ describe("createDevServerService", () => {
     });
   });
   test("keeps the started command after a failure when repository settings change", async () => {
-    const { processPort, starts } = createProcessPort();
-    const config = repoConfig();
-    const service = createDevServerService({
-      processPort,
-      taskWorktreeService: createTaskWorktreeService({ workingDirectory: "/worktrees/task-1" }),
-      workspaceSettingsService: createWorkspaceSettingsService(config),
-    });
+    const { config, service, starts } = createServiceWithMutableConfig();
 
     await Effect.runPromise(service.start({ repoPath: "/repo", taskId: "task-1" }));
     config.devServers = [{ id: "web", name: "Web", command: "bun run dev:next" }];

--- a/packages/host/src/application/dev-servers/dev-server-service.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.ts
@@ -195,7 +195,7 @@ export const createDevServerService = ({
       }
       updateScriptState(runtime, scriptConfig.id, (script) => {
         script.status = "starting";
-        script.command = scriptConfig.command;
+        script.startedCommand = scriptConfig.command;
         startTerminalRun(runtime, script, hostInstanceId);
         script.pid = null;
         script.startedAt = null;

--- a/packages/host/src/application/dev-servers/dev-server-service.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.ts
@@ -195,6 +195,7 @@ export const createDevServerService = ({
       }
       updateScriptState(runtime, scriptConfig.id, (script) => {
         script.status = "starting";
+        script.command = scriptConfig.command;
         startTerminalRun(runtime, script, hostInstanceId);
         script.pid = null;
         script.startedAt = null;

--- a/packages/host/src/application/dev-servers/dev-server-state.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-state.test.ts
@@ -26,6 +26,11 @@ const repoConfig: RepoConfig = {
   agentStudioState: { openTaskIds: [] },
 };
 
+const updatedRepoConfig: RepoConfig = {
+  ...repoConfig,
+  devServers: [{ id: "web", name: "Web next", command: "bun run dev:next" }],
+};
+
 const createRuntime = (): DevServerGroupRuntime => ({
   processes: new Map(),
   state: buildGroupState(repoConfig, "task-1", "/worktrees/task-1", "2026-05-24T00:00:00.000Z"),
@@ -64,15 +69,7 @@ describe("dev-server state helpers", () => {
     firstScript.startedCommand = "bun run dev";
     startTerminalRun(runtime, firstScript, "host-1");
 
-    syncGroupState(
-      runtime.state,
-      {
-        ...repoConfig,
-        devServers: [{ id: "web", name: "Web next", command: "bun run dev:next" }],
-      },
-      "task-1",
-      "/worktrees/task-1",
-    );
+    syncGroupState(runtime.state, updatedRepoConfig, "task-1", "/worktrees/task-1");
 
     expect(runtime.state.scripts[0]).toMatchObject({
       command: "bun run dev:next",
@@ -84,15 +81,7 @@ describe("dev-server state helpers", () => {
   test("leaves the started command unset for scripts without a run", () => {
     const runtime = createRuntime();
 
-    syncGroupState(
-      runtime.state,
-      {
-        ...repoConfig,
-        devServers: [{ id: "web", name: "Web next", command: "bun run dev:next" }],
-      },
-      "task-1",
-      "/worktrees/task-1",
-    );
+    syncGroupState(runtime.state, updatedRepoConfig, "task-1", "/worktrees/task-1");
 
     expect(runtime.state.scripts[0]).toMatchObject({
       command: "bun run dev:next",

--- a/packages/host/src/application/dev-servers/dev-server-state.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-state.test.ts
@@ -55,12 +55,13 @@ describe("dev-server state helpers", () => {
     expect(runtime.terminalRunGeneration).toBe(2);
   });
 
-  test("keeps the command captured by a run when the configured command changes", () => {
+  test("keeps the started command when the configured command changes", () => {
     const runtime = createRuntime();
     const firstScript = runtime.state.scripts[0];
     if (!firstScript) {
       throw new Error("Expected configured web script.");
     }
+    firstScript.startedCommand = "bun run dev";
     startTerminalRun(runtime, firstScript, "host-1");
 
     syncGroupState(
@@ -74,12 +75,13 @@ describe("dev-server state helpers", () => {
     );
 
     expect(runtime.state.scripts[0]).toMatchObject({
-      command: "bun run dev",
+      command: "bun run dev:next",
       name: "Web next",
+      startedCommand: "bun run dev",
     });
   });
 
-  test("follows the configured command for scripts without a run", () => {
+  test("leaves the started command unset for scripts without a run", () => {
     const runtime = createRuntime();
 
     syncGroupState(
@@ -95,6 +97,7 @@ describe("dev-server state helpers", () => {
     expect(runtime.state.scripts[0]).toMatchObject({
       command: "bun run dev:next",
       name: "Web next",
+      startedCommand: null,
     });
   });
 

--- a/packages/host/src/application/dev-servers/dev-server-state.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-state.test.ts
@@ -55,6 +55,49 @@ describe("dev-server state helpers", () => {
     expect(runtime.terminalRunGeneration).toBe(2);
   });
 
+  test("keeps the command captured by a run when the configured command changes", () => {
+    const runtime = createRuntime();
+    const firstScript = runtime.state.scripts[0];
+    if (!firstScript) {
+      throw new Error("Expected configured web script.");
+    }
+    startTerminalRun(runtime, firstScript, "host-1");
+
+    syncGroupState(
+      runtime.state,
+      {
+        ...repoConfig,
+        devServers: [{ id: "web", name: "Web next", command: "bun run dev:next" }],
+      },
+      "task-1",
+      "/worktrees/task-1",
+    );
+
+    expect(runtime.state.scripts[0]).toMatchObject({
+      command: "bun run dev",
+      name: "Web next",
+    });
+  });
+
+  test("follows the configured command for scripts without a run", () => {
+    const runtime = createRuntime();
+
+    syncGroupState(
+      runtime.state,
+      {
+        ...repoConfig,
+        devServers: [{ id: "web", name: "Web next", command: "bun run dev:next" }],
+      },
+      "task-1",
+      "/worktrees/task-1",
+    );
+
+    expect(runtime.state.scripts[0]).toMatchObject({
+      command: "bun run dev:next",
+      name: "Web next",
+    });
+  });
+
   test("does not reuse a run identity after a script is removed and re-added", () => {
     const runtime = createRuntime();
     const firstScript = runtime.state.scripts[0];

--- a/packages/host/src/application/dev-servers/dev-server-state.ts
+++ b/packages/host/src/application/dev-servers/dev-server-state.ts
@@ -47,6 +47,9 @@ const scriptStateFromConfig = (script: RepoConfig["devServers"][number]): DevSer
   bufferedTerminalChunks: [],
 });
 
+const resolveScriptCommand = (script: DevServerScriptState, configuredCommand: string): string =>
+  script.runIdentity === null ? configuredCommand : script.command;
+
 export const scriptHasLiveProcess = (script: DevServerScriptState): boolean => script.pid !== null;
 
 export const buildGroupState = (
@@ -79,7 +82,7 @@ export const syncGroupState = (
 
     return {
       ...existingScript,
-      command: script.command,
+      command: resolveScriptCommand(existingScript, script.command),
       name: script.name,
     };
   });

--- a/packages/host/src/application/dev-servers/dev-server-state.ts
+++ b/packages/host/src/application/dev-servers/dev-server-state.ts
@@ -38,6 +38,7 @@ const scriptStateFromConfig = (script: RepoConfig["devServers"][number]): DevSer
   scriptId: script.id,
   name: script.name,
   command: script.command,
+  startedCommand: null,
   status: "stopped",
   runIdentity: null,
   pid: null,
@@ -46,9 +47,6 @@ const scriptStateFromConfig = (script: RepoConfig["devServers"][number]): DevSer
   lastError: null,
   bufferedTerminalChunks: [],
 });
-
-const resolveScriptCommand = (script: DevServerScriptState, configuredCommand: string): string =>
-  script.runIdentity === null ? configuredCommand : script.command;
 
 export const scriptHasLiveProcess = (script: DevServerScriptState): boolean => script.pid !== null;
 
@@ -82,7 +80,7 @@ export const syncGroupState = (
 
     return {
       ...existingScript,
-      command: resolveScriptCommand(existingScript, script.command),
+      command: script.command,
       name: script.name,
     };
   });

--- a/packages/host/src/application/dev-servers/dev-server-terminal-writer.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-terminal-writer.test.ts
@@ -19,6 +19,7 @@ const createRuntime = (runIdentity: DevServerRunIdentity | null): DevServerGroup
         scriptId: "web",
         name: "Web",
         command: "bun run dev",
+        startedCommand: runIdentity === null ? null : "bun run dev",
         status: runIdentity === null ? "stopped" : "running",
         runIdentity,
         pid: runIdentity === null ? null : 4242,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dev server panels now display the command used when a script was last started, including after it stops or fails.
  - The last started command is preserved when repository settings change during a run.
  - Scripts that have never run continue to display their configured command.

- **Bug Fixes**
  - Improved command accuracy for stopped and failed dev server scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->