### PR TITLE
fix(opencode): stop duplicate and wrong chat attachment previews

### DIFF
--- a/docs/runtime-integration-guide.md
+++ b/docs/runtime-integration-guide.md
@@ -128,7 +128,7 @@ If `attachmentSupport` is absent, the runtime did not provide model attachment d
 
 An attachment part has an ID, local path, name, kind, and optional MIME type. In a browser, the frontend asks the host to stage the `File`, then sends the staged path.
 
-The adapter owns native encoding. Claude reads the staged file and sends an SDK image or document block. Its catalog permits JPEG, PNG, GIF, WebP, and PDF. Codex maps images to `localImage`. OpenCode sends a native file part with MIME type, local URL, and the staged source path, so history keeps the local preview path after a host restart.
+The adapter owns native encoding. Encode each attachment in the runtime's native prompt form. Keep the staged path in the encoded part so a later history read can restore the local preview.
 
 A prompt cannot mix a slash command and attachments because a slash command uses a separate native call.
 

--- a/docs/runtime-integration-guide.md
+++ b/docs/runtime-integration-guide.md
@@ -128,7 +128,7 @@ If `attachmentSupport` is absent, the runtime did not provide model attachment d
 
 An attachment part has an ID, local path, name, kind, and optional MIME type. In a browser, the frontend asks the host to stage the `File`, then sends the staged path.
 
-The adapter owns native encoding. Claude reads the staged file and sends an SDK image or document block. Its catalog permits JPEG, PNG, GIF, WebP, and PDF. Codex maps images to `localImage`. OpenCode sends a native file part with MIME type and local URL.
+The adapter owns native encoding. Claude reads the staged file and sends an SDK image or document block. Its catalog permits JPEG, PNG, GIF, WebP, and PDF. Codex maps images to `localImage`. OpenCode sends a native file part with MIME type, local URL, and the staged source path, so history keeps the local preview path after a host restart.
 
 A prompt cannot mix a slash command and attachments because a slash command uses a separate native call.
 

--- a/docs/runtime-integration-guide.md
+++ b/docs/runtime-integration-guide.md
@@ -128,7 +128,7 @@ If `attachmentSupport` is absent, the runtime did not provide model attachment d
 
 An attachment part has an ID, local path, name, kind, and optional MIME type. In a browser, the frontend asks the host to stage the `File`, then sends the staged path.
 
-The adapter owns native encoding. Encode each attachment in the runtime's native prompt form. Keep the staged path in the encoded part so a later history read can restore the local preview.
+Encode each attachment in the runtime's native prompt form. Keep the staged path in the encoded part so a later history read can restore the local preview.
 
 A prompt cannot mix a slash command and attachments because a slash command uses a separate native call.
 

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -1458,6 +1458,95 @@ describe("event-stream", () => {
     ]);
   });
 
+  test("recovers queued staged paths when live metadata holds a partial attachment list", async () => {
+    const { emitted, sessionRecord } = await runEventStreamWithSession(
+      [
+        makeUserMessageUpdatedEvent({
+          messageId: "msg-attachment-partial-pair-1",
+          text: "Describe both screenshots",
+          createdAt: Date.parse("2026-02-22T12:00:02.000Z"),
+        }),
+        {
+          type: "message.part.updated",
+          properties: {
+            part: {
+              id: "part-pair-file-1",
+              sessionID: "external-session-1",
+              messageID: "msg-attachment-partial-pair-1",
+              type: "file",
+              mime: "image/png",
+              filename: "Screenshot-2026-03-17-at-12.04.45.png",
+              url: "data:image/png;base64,aGVsbG8=",
+            },
+          },
+        } satisfies OpenCodeProtocolObject,
+        {
+          type: "message.part.updated",
+          properties: {
+            part: {
+              id: "part-pair-file-2",
+              sessionID: "external-session-1",
+              messageID: "msg-attachment-partial-pair-1",
+              type: "file",
+              mime: "image/png",
+              filename: "Second-2026-03-17-at-12.05.00.png",
+              url: "data:image/png;base64,d29ybGQ=",
+            },
+          },
+        } satisfies OpenCodeProtocolObject,
+      ],
+      (nextSessionRecord) => {
+        nextSessionRecord.messageRoleById.set("msg-attachment-partial-pair-1", "user");
+        nextSessionRecord.pendingQueuedUserMessages.push({
+          messageId: "msg-attachment-partial-pair-1",
+          signature: buildQueuedRequestSignature(
+            [
+              { kind: "text", text: "Describe both screenshots" },
+              IMAGE_ATTACHMENT_DISPLAY_PART,
+              SECOND_IMAGE_ATTACHMENT_DISPLAY_PART,
+            ] satisfies AgentUserMessagePart[],
+            undefined,
+          ),
+          attachmentIdentitySignature: buildQueuedRequestAttachmentIdentitySignature(
+            [
+              { kind: "text", text: "Describe both screenshots" },
+              IMAGE_ATTACHMENT_DISPLAY_PART,
+              SECOND_IMAGE_ATTACHMENT_DISPLAY_PART,
+            ] satisfies AgentUserMessagePart[],
+            undefined,
+          ),
+          attachmentParts: [IMAGE_ATTACHMENT_DISPLAY_PART, SECOND_IMAGE_ATTACHMENT_DISPLAY_PART],
+        });
+      },
+    );
+
+    expect(sessionRecord.pendingQueuedUserMessages).toHaveLength(0);
+    const userMessages = emitted.filter((event) => event.type === "user_message");
+    const userMessage = userMessages.at(-1);
+    if (userMessage?.type !== "user_message") {
+      throw new Error("Expected user_message event");
+    }
+    const attachmentParts = userMessage.parts.filter((part) => part.kind === "attachment");
+    expect(attachmentParts).toEqual([
+      expect.objectContaining({
+        attachment: expect.objectContaining({ path: "/tmp/local-screenshot.png" }),
+      }),
+      expect.objectContaining({
+        attachment: expect.objectContaining({ path: "/tmp/local-second-screenshot.png" }),
+      }),
+    ]);
+
+    const metadata = sessionRecord.messageMetadataById.get("msg-attachment-partial-pair-1");
+    const metadataAttachmentPaths =
+      metadata?.displayParts?.flatMap((part) =>
+        part.kind === "attachment" ? [part.attachment.path] : [],
+      ) ?? [];
+    expect(metadataAttachmentPaths).toEqual([
+      "/tmp/local-screenshot.png",
+      "/tmp/local-second-screenshot.png",
+    ]);
+  });
+
   test("matches queued attachment sends when the runtime fills user parts through message.part.updated", async () => {
     const { emitted, sessionRecord } = await runEventStreamWithSession(
       [

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -77,6 +77,17 @@ const PDF_ATTACHMENT_DISPLAY_PART = {
   },
 };
 
+const SECOND_IMAGE_ATTACHMENT_DISPLAY_PART = {
+  kind: "attachment" as const,
+  attachment: {
+    id: "attachment-image-2",
+    path: "/tmp/local-second-screenshot.png",
+    name: "Second-2026-03-17-at-12.05.00.png",
+    kind: "image" as const,
+    mime: "image/png",
+  },
+};
+
 test("global event observation becomes ready only after the lazy SSE stream connects", async () => {
   let connect: (() => void) | undefined;
   const connected = new Promise<void>((resolve) => {
@@ -1359,6 +1370,92 @@ describe("event-stream", () => {
         }),
       }),
     );
+  });
+
+  test("keeps one attachment per send when metadata and the matched queued send both preserve it", async () => {
+    const { emitted } = await runEventStreamWithSession(
+      [
+        makeUserMessageUpdatedEvent({
+          messageId: "msg-attachment-pair-1",
+          createdAt: Date.parse("2026-02-22T12:00:02.000Z"),
+          parts: [
+            {
+              id: "part-pair-text-1",
+              sessionID: "external-session-1",
+              messageID: "msg-attachment-pair-1",
+              type: "text",
+              text: "Describe both screenshots",
+            },
+            {
+              id: "part-pair-file-1",
+              sessionID: "external-session-1",
+              messageID: "msg-attachment-pair-1",
+              type: "file",
+              mime: "image/png",
+              filename: "Screenshot-2026-03-17-at-12.04.45.png",
+              url: "data:image/png;base64,aGVsbG8=",
+            },
+            {
+              id: "part-pair-file-2",
+              sessionID: "external-session-1",
+              messageID: "msg-attachment-pair-1",
+              type: "file",
+              mime: "image/png",
+              filename: "Second-2026-03-17-at-12.05.00.png",
+              url: "data:image/png;base64,d29ybGQ=",
+            },
+          ],
+        }),
+      ],
+      (nextSessionRecord) => {
+        nextSessionRecord.messageMetadataById.set("msg-attachment-pair-1", {
+          timestamp: "2026-02-22T12:00:02.000Z",
+          displayParts: [IMAGE_ATTACHMENT_DISPLAY_PART, SECOND_IMAGE_ATTACHMENT_DISPLAY_PART],
+        });
+        nextSessionRecord.pendingQueuedUserMessages.push({
+          messageId: "msg-attachment-pair-1",
+          signature: buildQueuedRequestSignature(
+            [
+              { kind: "text", text: "Describe both screenshots" },
+              IMAGE_ATTACHMENT_DISPLAY_PART,
+              SECOND_IMAGE_ATTACHMENT_DISPLAY_PART,
+            ] satisfies AgentUserMessagePart[],
+            undefined,
+          ),
+          attachmentIdentitySignature: buildQueuedRequestAttachmentIdentitySignature(
+            [
+              { kind: "text", text: "Describe both screenshots" },
+              IMAGE_ATTACHMENT_DISPLAY_PART,
+              SECOND_IMAGE_ATTACHMENT_DISPLAY_PART,
+            ] satisfies AgentUserMessagePart[],
+            undefined,
+          ),
+          attachmentParts: [IMAGE_ATTACHMENT_DISPLAY_PART, SECOND_IMAGE_ATTACHMENT_DISPLAY_PART],
+        });
+      },
+    );
+
+    const userMessages = emitted.filter((event) => event.type === "user_message");
+    const userMessage = userMessages.at(-1);
+    if (userMessage?.type !== "user_message") {
+      throw new Error("Expected user_message event");
+    }
+    const attachmentParts = userMessage.parts.filter((part) => part.kind === "attachment");
+    expect(attachmentParts).toHaveLength(2);
+    expect(attachmentParts).toEqual([
+      expect.objectContaining({
+        attachment: expect.objectContaining({
+          path: "/tmp/local-screenshot.png",
+          name: "Screenshot-2026-03-17-at-12.04.45.png",
+        }),
+      }),
+      expect.objectContaining({
+        attachment: expect.objectContaining({
+          path: "/tmp/local-second-screenshot.png",
+          name: "Second-2026-03-17-at-12.05.00.png",
+        }),
+      }),
+    ]);
   });
 
   test("matches queued attachment sends when the runtime fills user parts through message.part.updated", async () => {

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events/user-display.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events/user-display.ts
@@ -16,11 +16,22 @@ const readPreservedAttachmentParts = (input: {
     input.metadata?.displayParts?.filter(
       (part): part is AttachmentDisplayPart => part.kind === "attachment",
     ) ?? [];
-  if (metadataAttachments.length > 0) {
+  const queuedAttachments = input.matchedQueuedSend?.attachmentParts ?? [];
+  if (metadataAttachments.length === 0) {
+    return queuedAttachments;
+  }
+  if (queuedAttachments.length === 0) {
     return metadataAttachments;
   }
 
-  return input.matchedQueuedSend?.attachmentParts ?? [];
+  const mergedAttachments = metadataAttachments.map((metadataAttachment, index) => {
+    const queuedAttachment = queuedAttachments[index];
+    if (!queuedAttachment || metadataAttachment.attachment.localPreviewAvailable !== false) {
+      return metadataAttachment;
+    }
+    return queuedAttachment;
+  });
+  return [...mergedAttachments, ...queuedAttachments.slice(metadataAttachments.length)];
 };
 
 export const buildVisibleUserMessage = (input: {

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events/user-display.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events/user-display.ts
@@ -12,16 +12,15 @@ const readPreservedAttachmentParts = (input: {
   metadata?: SessionMessageMetadata;
   matchedQueuedSend?: QueuedUserMessageSend | null;
 }): AttachmentDisplayPart[] => {
-  const preservedById = new Map<string, AttachmentDisplayPart>();
-  for (const part of [
-    ...(input.metadata?.displayParts?.filter(
+  const metadataAttachments =
+    input.metadata?.displayParts?.filter(
       (part): part is AttachmentDisplayPart => part.kind === "attachment",
-    ) ?? []),
-    ...(input.matchedQueuedSend?.attachmentParts ?? []),
-  ]) {
-    preservedById.set(part.attachment.id, part);
+    ) ?? [];
+  if (metadataAttachments.length > 0) {
+    return metadataAttachments;
   }
-  return [...preservedById.values()];
+
+  return input.matchedQueuedSend?.attachmentParts ?? [];
 };
 
 export const buildVisibleUserMessage = (input: {

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events/user-display.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events/user-display.ts
@@ -12,12 +12,16 @@ const readPreservedAttachmentParts = (input: {
   metadata?: SessionMessageMetadata;
   matchedQueuedSend?: QueuedUserMessageSend | null;
 }): AttachmentDisplayPart[] => {
-  return [
+  const preservedById = new Map<string, AttachmentDisplayPart>();
+  for (const part of [
     ...(input.metadata?.displayParts?.filter(
       (part): part is AttachmentDisplayPart => part.kind === "attachment",
     ) ?? []),
     ...(input.matchedQueuedSend?.attachmentParts ?? []),
-  ];
+  ]) {
+    preservedById.set(part.attachment.id, part);
+  }
+  return [...preservedById.values()];
 };
 
 export const buildVisibleUserMessage = (input: {

--- a/packages/adapters-opencode-sdk/src/message-execution.test.ts
+++ b/packages/adapters-opencode-sdk/src/message-execution.test.ts
@@ -664,6 +664,46 @@ describe("message-execution", () => {
     });
   });
 
+  test("resolves relative attachment paths into the native source metadata", async () => {
+    const { session, promptAsync } = createSession();
+
+    await sendUserMessage({
+      session,
+      request: {
+        externalSessionId: "session-1",
+        parts: [
+          {
+            kind: "attachment",
+            attachment: {
+              id: "attachment-relative-1",
+              path: "uploads/photo.png",
+              name: "photo.png",
+              kind: "image",
+              mime: "image/png",
+            },
+          },
+        ],
+      },
+      tools: {},
+    });
+
+    const promptRequest:
+      | { parts?: Array<{ type: string; url?: string; source?: unknown }> }
+      | undefined = promptAsync.mock.calls[0]?.[0];
+    const attachmentPart = promptRequest?.parts?.find((part) => part.type === "file");
+    expect(attachmentPart).toBeDefined();
+    expect(attachmentPart?.url).toBe("file:///repo/uploads/photo.png");
+    expect(attachmentPart?.source).toEqual({
+      type: "file",
+      path: "/repo/uploads/photo.png",
+      text: {
+        value: "/repo/uploads/photo.png",
+        start: 0,
+        end: 23,
+      },
+    });
+  });
+
   test("encodes file URLs for special characters and relative paths", async () => {
     const { session, promptAsync } = createSession();
 

--- a/packages/adapters-opencode-sdk/src/message-execution.test.ts
+++ b/packages/adapters-opencode-sdk/src/message-execution.test.ts
@@ -473,7 +473,7 @@ describe("message-execution", () => {
     expect(command).not.toHaveBeenCalled();
   });
 
-  test("routes local attachments through native prompt file parts without repo source text", async () => {
+  test("routes local attachments through native prompt file parts with staged source metadata", async () => {
     const { session, promptAsync } = createSession();
 
     await sendUserMessage({
@@ -500,6 +500,15 @@ describe("message-execution", () => {
           mime: "image/png",
           url: "file:///tmp/diagram.png",
           filename: "diagram.png",
+          source: {
+            type: "file",
+            path: "/tmp/diagram.png",
+            text: {
+              value: "/tmp/diagram.png",
+              start: 0,
+              end: 16,
+            },
+          },
         },
       ],
     });
@@ -586,6 +595,15 @@ describe("message-execution", () => {
           mime: "image/png",
           url: "file:///tmp/diagram.png",
           filename: "diagram.png",
+          source: {
+            type: "file",
+            path: "/tmp/diagram.png",
+            text: {
+              value: "/tmp/diagram.png",
+              start: 0,
+              end: 16,
+            },
+          },
         },
       ],
     });
@@ -619,7 +637,7 @@ describe("message-execution", () => {
     ]);
   });
 
-  test("omits file source metadata for local attachments so the runtime accepts the payload schema", async () => {
+  test("sends staged source metadata for local attachments so history can restore preview paths", async () => {
     const { session, promptAsync } = createSession();
 
     await sendUserMessage({
@@ -635,7 +653,15 @@ describe("message-execution", () => {
       promptAsync.mock.calls[0]?.[0];
     const attachmentPart = promptRequest?.parts?.find((part) => part.type === "file");
     expect(attachmentPart).toBeDefined();
-    expect(attachmentPart?.source).toBeUndefined();
+    expect(attachmentPart?.source).toEqual({
+      type: "file",
+      path: "/tmp/diagram.png",
+      text: {
+        value: "/tmp/diagram.png",
+        start: 0,
+        end: 16,
+      },
+    });
   });
 
   test("encodes file URLs for special characters and relative paths", async () => {

--- a/packages/adapters-opencode-sdk/src/message-execution.ts
+++ b/packages/adapters-opencode-sdk/src/message-execution.ts
@@ -1,6 +1,7 @@
 import {
   type AgentModelSelection,
   type AgentUserMessageDisplayPart,
+  type AgentUserMessagePart,
   type AgentUserMessageState,
   classifySystemSlashCommandInvocation,
   normalizeAgentUserMessageParts,
@@ -72,6 +73,18 @@ type OpenCodePromptPart =
       };
     };
 
+type OpenCodePromptFilePart = Extract<OpenCodePromptPart, { type: "file" }>;
+type OpenCodePromptFileSource = NonNullable<OpenCodePromptFilePart["source"]>;
+
+const toFileSource = (
+  path: string,
+  text: OpenCodePromptFileSource["text"],
+): OpenCodePromptFileSource => ({
+  type: "file",
+  path,
+  text,
+});
+
 const toCommandModelInput = (
   modelInput: ReturnType<typeof normalizeModelInput>,
 ): string | undefined => {
@@ -84,7 +97,7 @@ const toCommandModelInput = (
 const toPromptFilePart = (
   fileReference: ReturnType<typeof buildOpenCodePromptText>["fileReferences"][number],
   workingDirectory: string,
-): Extract<OpenCodePromptPart, { type: "file" }> => {
+): OpenCodePromptFilePart => {
   const normalizedPath = fileReference.file.path.trim();
   if (normalizedPath.length === 0) {
     throw new Error("OpenCode file references require a non-empty path.");
@@ -95,11 +108,34 @@ const toPromptFilePart = (
     mime: detectAgentFileReferenceMime(fileReference.file),
     url: toFileUrl(resolveAgainstWorkingDirectory(workingDirectory, normalizedPath)),
     filename: fileReference.file.name,
-    source: {
-      type: "file",
-      path: normalizedPath,
-      text: fileReference.sourceText,
-    },
+    source: toFileSource(normalizedPath, fileReference.sourceText),
+  };
+};
+
+const toPromptAttachmentPart = (
+  part: Extract<AgentUserMessagePart, { kind: "attachment" }>,
+  workingDirectory: string,
+): OpenCodePromptFilePart => {
+  const { attachment } = part;
+  const normalizedPath = attachment.path.trim();
+  if (normalizedPath.length === 0) {
+    throw new Error("OpenCode attachments require a non-empty path.");
+  }
+  if (!attachment.mime || attachment.mime.trim().length === 0) {
+    throw new Error(`OpenCode attachment "${attachment.name}" is missing a MIME type.`);
+  }
+
+  const resolvedPath = resolveAgainstWorkingDirectory(workingDirectory, normalizedPath);
+  return {
+    type: "file",
+    mime: attachment.mime,
+    url: toFileUrl(resolvedPath),
+    filename: attachment.name,
+    source: toFileSource(resolvedPath, {
+      value: resolvedPath,
+      start: 0,
+      end: resolvedPath.length,
+    }),
   };
 };
 
@@ -129,38 +165,9 @@ const toPromptParts = (
       toPromptFilePart(fileReference, workingDirectory),
     ),
     ...promptText.subagentReferences.map(toPromptSubagentPart),
-    ...parts.flatMap((part) => {
-      if (part.kind !== "attachment") {
-        return [];
-      }
-
-      const normalizedPath = part.attachment.path.trim();
-      if (normalizedPath.length === 0) {
-        throw new Error("OpenCode attachments require a non-empty path.");
-      }
-      if (!part.attachment.mime || part.attachment.mime.trim().length === 0) {
-        throw new Error(`OpenCode attachment "${part.attachment.name}" is missing a MIME type.`);
-      }
-
-      const resolvedPath = resolveAgainstWorkingDirectory(workingDirectory, normalizedPath);
-      return [
-        {
-          type: "file" as const,
-          mime: part.attachment.mime,
-          url: toFileUrl(resolvedPath),
-          filename: part.attachment.name,
-          source: {
-            type: "file" as const,
-            path: resolvedPath,
-            text: {
-              value: resolvedPath,
-              start: 0,
-              end: resolvedPath.length,
-            },
-          },
-        },
-      ];
-    }),
+    ...parts.flatMap((part) =>
+      part.kind === "attachment" ? toPromptAttachmentPart(part, workingDirectory) : [],
+    ),
   ];
 };
 

--- a/packages/adapters-opencode-sdk/src/message-execution.ts
+++ b/packages/adapters-opencode-sdk/src/message-execution.ts
@@ -142,12 +142,22 @@ const toPromptParts = (
         throw new Error(`OpenCode attachment "${part.attachment.name}" is missing a MIME type.`);
       }
 
+      const resolvedPath = resolveAgainstWorkingDirectory(workingDirectory, normalizedPath);
       return [
         {
           type: "file" as const,
           mime: part.attachment.mime,
-          url: toFileUrl(resolveAgainstWorkingDirectory(workingDirectory, normalizedPath)),
+          url: toFileUrl(resolvedPath),
           filename: part.attachment.name,
+          source: {
+            type: "file" as const,
+            path: resolvedPath,
+            text: {
+              value: resolvedPath,
+              start: 0,
+              end: resolvedPath.length,
+            },
+          },
         },
       ];
     }),

--- a/packages/adapters-opencode-sdk/src/message-normalizers.test.ts
+++ b/packages/adapters-opencode-sdk/src/message-normalizers.test.ts
@@ -521,6 +521,58 @@ describe("message-normalizers", () => {
     ]);
   });
 
+  test("keeps a runtime source path when the preserved attachment has no local preview", () => {
+    const runtimeParts = normalizeUserMessageDisplayParts(
+      parseOpencodeParts([
+        {
+          id: "image-data-source-1",
+          sessionID: "session-1",
+          messageID: "message-1",
+          type: "file",
+          mime: "image/png",
+          filename: "image.png",
+          url: "data:image/png;base64,aGVsbG8=",
+          source: {
+            type: "file",
+            path: "/var/folders/example/staged-image.png",
+            text: {
+              value: "/var/folders/example/staged-image.png",
+              start: 0,
+              end: 37,
+            },
+          },
+        },
+      ]),
+    );
+
+    expect(
+      mergePreservedAttachmentDisplayParts(runtimeParts, [
+        {
+          kind: "attachment",
+          attachment: {
+            id: "attachment-image-1",
+            path: "image.png",
+            name: "image.png",
+            kind: "image",
+            mime: "image/png",
+            localPreviewAvailable: false,
+          },
+        },
+      ]),
+    ).toEqual([
+      {
+        kind: "attachment",
+        attachment: {
+          id: "image-data-source-1",
+          path: "/var/folders/example/staged-image.png",
+          name: "image.png",
+          kind: "image",
+          mime: "image/png",
+        },
+      },
+    ]);
+  });
+
   test("normalizes only supported media file attachments without inline source text", () => {
     const parts: OpenCodeProtocolObject[] = [
       {

--- a/packages/adapters-opencode-sdk/src/message-normalizers.test.ts
+++ b/packages/adapters-opencode-sdk/src/message-normalizers.test.ts
@@ -443,6 +443,42 @@ describe("message-normalizers", () => {
     ]);
   });
 
+  test("prefers the source file path over a data url so staged previews stay available", () => {
+    const parts: OpenCodeProtocolObject[] = [
+      {
+        id: "image-data-source",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "file",
+        mime: "image/png",
+        filename: "image.png",
+        url: "data:image/png;base64,aGVsbG8=",
+        source: {
+          type: "file",
+          path: "/var/folders/example/staged-image.png",
+          text: {
+            value: "/var/folders/example/staged-image.png",
+            start: 0,
+            end: 37,
+          },
+        },
+      },
+    ];
+
+    expect(normalizeUserMessageDisplayParts(parseOpencodeParts(parts))).toEqual([
+      {
+        kind: "attachment",
+        attachment: {
+          id: "image-data-source",
+          path: "/var/folders/example/staged-image.png",
+          name: "image.png",
+          kind: "image",
+          mime: "image/png",
+        },
+      },
+    ]);
+  });
+
   test("uses preserved local paths and clears the unavailable preview flag", () => {
     const runtimeParts = normalizeUserMessageDisplayParts(
       parseOpencodeParts([

--- a/packages/adapters-opencode-sdk/src/message-normalizers.test.ts
+++ b/packages/adapters-opencode-sdk/src/message-normalizers.test.ts
@@ -4,6 +4,7 @@ import { createOpencodePartFixture } from "./opencode-protocol-test-fixtures";
 import type { ParsedOpencodePart } from "./opencode-ingress";
 import {
   extractMessageTotalTokens,
+  mergePreservedAttachmentDisplayParts,
   normalizeUserMessageDisplayParts,
   readMessageModelSelection,
   readTextFromParts,
@@ -387,6 +388,96 @@ describe("message-normalizers", () => {
           id: "image-source-path",
           path: "/var/folders/example/Screenshot 2026-04-01 at 00.33.32.png",
           name: "Screenshot 2026-04-01 at 00.33.32.png",
+          kind: "image",
+          mime: "image/png",
+        },
+      },
+    ]);
+  });
+
+  test("marks data url attachments without a source path as not locally previewable", () => {
+    const parts: OpenCodeProtocolObject[] = [
+      {
+        id: "image-data-1",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "file",
+        mime: "image/png",
+        filename: "image.png",
+        url: "data:image/png;base64,aGVsbG8=",
+      },
+      {
+        id: "image-data-2",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "file",
+        mime: "image/png",
+        filename: "image.png",
+        url: "data:image/png;base64,d29ybGQ=",
+      },
+    ];
+
+    expect(normalizeUserMessageDisplayParts(parseOpencodeParts(parts))).toEqual([
+      {
+        kind: "attachment",
+        attachment: {
+          id: "image-data-1",
+          path: "image.png",
+          name: "image.png",
+          kind: "image",
+          mime: "image/png",
+          localPreviewAvailable: false,
+        },
+      },
+      {
+        kind: "attachment",
+        attachment: {
+          id: "image-data-2",
+          path: "image.png",
+          name: "image.png",
+          kind: "image",
+          mime: "image/png",
+          localPreviewAvailable: false,
+        },
+      },
+    ]);
+  });
+
+  test("uses preserved local paths and clears the unavailable preview flag", () => {
+    const runtimeParts = normalizeUserMessageDisplayParts(
+      parseOpencodeParts([
+        {
+          id: "image-data-1",
+          sessionID: "session-1",
+          messageID: "message-1",
+          type: "file",
+          mime: "image/png",
+          filename: "image.png",
+          url: "data:image/png;base64,aGVsbG8=",
+        },
+      ]),
+    );
+
+    expect(
+      mergePreservedAttachmentDisplayParts(runtimeParts, [
+        {
+          kind: "attachment",
+          attachment: {
+            id: "attachment-image-1",
+            path: "/tmp/openducktor-local-attachments/staged-image.png",
+            name: "image.png",
+            kind: "image",
+            mime: "image/png",
+          },
+        },
+      ]),
+    ).toEqual([
+      {
+        kind: "attachment",
+        attachment: {
+          id: "image-data-1",
+          path: "/tmp/openducktor-local-attachments/staged-image.png",
+          name: "image.png",
           kind: "image",
           mime: "image/png",
         },

--- a/packages/adapters-opencode-sdk/src/message-normalizers.ts
+++ b/packages/adapters-opencode-sdk/src/message-normalizers.ts
@@ -44,10 +44,8 @@ const readFilePathFromUrl = (url: string): string | null => {
   }
 };
 
-type AttachmentKind = Extract<
-  AgentUserMessageDisplayPart,
-  { kind: "attachment" }
->["attachment"]["kind"];
+type AttachmentDisplayPart = Extract<AgentUserMessageDisplayPart, { kind: "attachment" }>;
+type AttachmentKind = AttachmentDisplayPart["attachment"]["kind"];
 
 const readAttachmentKind = (mime: string): AttachmentKind | null => {
   if (mime.startsWith("image/")) {
@@ -80,7 +78,7 @@ const normalizeAttachmentPart = (
     return null;
   }
 
-  const attachment: Extract<AgentUserMessageDisplayPart, { kind: "attachment" }>["attachment"] = {
+  const attachment: AttachmentDisplayPart["attachment"] = {
     id: part.id,
     path: filePath,
     name: part.filename?.trim() || basenameForPath(filePath),
@@ -214,7 +212,7 @@ export const ensureVisibleUserTextDisplayParts = (
 
 export const mergePreservedAttachmentDisplayParts = (
   displayParts: AgentUserMessageDisplayPart[],
-  preservedAttachmentParts: Extract<AgentUserMessageDisplayPart, { kind: "attachment" }>[],
+  preservedAttachmentParts: AttachmentDisplayPart[],
 ): AgentUserMessageDisplayPart[] => {
   if (preservedAttachmentParts.length === 0) {
     return displayParts;
@@ -226,11 +224,12 @@ export const mergePreservedAttachmentDisplayParts = (
       return part;
     }
 
+    const runtimeAttachment = part.attachment;
     const preservedIndex = remainingPreservedAttachments.findIndex(
       (candidate) =>
-        candidate.attachment.name === part.attachment.name &&
-        candidate.attachment.kind === part.attachment.kind &&
-        (candidate.attachment.mime ?? "") === (part.attachment.mime ?? ""),
+        candidate.attachment.name === runtimeAttachment.name &&
+        candidate.attachment.kind === runtimeAttachment.kind &&
+        (candidate.attachment.mime ?? "") === (runtimeAttachment.mime ?? ""),
     );
     if (preservedIndex < 0) {
       return part;
@@ -241,14 +240,16 @@ export const mergePreservedAttachmentDisplayParts = (
       return part;
     }
 
+    const preservedPath = preservedAttachment.attachment.path;
+    const preservedLocalPreviewAvailable = preservedAttachment.attachment.localPreviewAvailable;
     const mergedAttachment = {
-      ...part.attachment,
-      path: preservedAttachment.attachment.path,
+      ...runtimeAttachment,
+      path: preservedPath,
     };
-    if (preservedAttachment.attachment.localPreviewAvailable === undefined) {
+    if (preservedLocalPreviewAvailable === undefined) {
       delete mergedAttachment.localPreviewAvailable;
     } else {
-      mergedAttachment.localPreviewAvailable = preservedAttachment.attachment.localPreviewAvailable;
+      mergedAttachment.localPreviewAvailable = preservedLocalPreviewAvailable;
     }
 
     return {

--- a/packages/adapters-opencode-sdk/src/message-normalizers.ts
+++ b/packages/adapters-opencode-sdk/src/message-normalizers.ts
@@ -243,6 +243,12 @@ export const mergePreservedAttachmentDisplayParts = (
 
     const preservedPath = preservedAttachment.attachment.path;
     const preservedLocalPreviewAvailable = preservedAttachment.attachment.localPreviewAvailable;
+    if (
+      preservedLocalPreviewAvailable === false &&
+      runtimeAttachment.localPreviewAvailable !== false
+    ) {
+      return part;
+    }
     const mergedAttachment = {
       ...runtimeAttachment,
       path: preservedPath,

--- a/packages/adapters-opencode-sdk/src/message-normalizers.ts
+++ b/packages/adapters-opencode-sdk/src/message-normalizers.ts
@@ -44,66 +44,53 @@ const readFilePathFromUrl = (url: string): string | null => {
   }
 };
 
+type AttachmentKind = Extract<
+  AgentUserMessageDisplayPart,
+  { kind: "attachment" }
+>["attachment"]["kind"];
+
+const readAttachmentKind = (mime: string): AttachmentKind | null => {
+  if (mime.startsWith("image/")) {
+    return "image";
+  }
+  if (mime.startsWith("audio/")) {
+    return "audio";
+  }
+  if (mime.startsWith("video/")) {
+    return "video";
+  }
+  if (mime === "application/pdf") {
+    return "pdf";
+  }
+
+  return null;
+};
+
 const normalizeAttachmentPart = (
   part: Extract<ParsedOpencodePart, { type: "file" }>,
 ): AgentUserMessageDisplayPart | null => {
   const sourcePath = part.source?.type === "file" ? part.source.path.trim() : "";
-  const filePath = readFilePathFromUrl(part.url) ?? (sourcePath || part.filename?.trim() || "");
+  const fileUrlPath = readFilePathFromUrl(part.url);
+  const filePath = fileUrlPath ?? (sourcePath || part.filename?.trim() || "");
   if (filePath.length === 0 || !part.mime) {
     return null;
   }
-
-  const name = part.filename?.trim() || basenameForPath(filePath);
-  if (part.mime.startsWith("image/")) {
-    return {
-      kind: "attachment",
-      attachment: {
-        id: part.id,
-        path: filePath,
-        name,
-        kind: "image",
-        mime: part.mime,
-      },
-    };
-  }
-  if (part.mime.startsWith("audio/")) {
-    return {
-      kind: "attachment",
-      attachment: {
-        id: part.id,
-        path: filePath,
-        name,
-        kind: "audio",
-        mime: part.mime,
-      },
-    };
-  }
-  if (part.mime.startsWith("video/")) {
-    return {
-      kind: "attachment",
-      attachment: {
-        id: part.id,
-        path: filePath,
-        name,
-        kind: "video",
-        mime: part.mime,
-      },
-    };
-  }
-  if (part.mime === "application/pdf") {
-    return {
-      kind: "attachment",
-      attachment: {
-        id: part.id,
-        path: filePath,
-        name,
-        kind: "pdf",
-        mime: part.mime,
-      },
-    };
+  const attachmentKind = readAttachmentKind(part.mime);
+  if (!attachmentKind) {
+    return null;
   }
 
-  return null;
+  const attachment: Extract<AgentUserMessageDisplayPart, { kind: "attachment" }>["attachment"] = {
+    id: part.id,
+    path: filePath,
+    name: part.filename?.trim() || basenameForPath(filePath),
+    kind: attachmentKind,
+    mime: part.mime,
+  };
+  if (!fileUrlPath && sourcePath.length === 0) {
+    attachment.localPreviewAvailable = false;
+  }
+  return { kind: "attachment", attachment };
 };
 
 const normalizeFileReferencePart = (
@@ -254,12 +241,19 @@ export const mergePreservedAttachmentDisplayParts = (
       return part;
     }
 
+    const mergedAttachment = {
+      ...part.attachment,
+      path: preservedAttachment.attachment.path,
+    };
+    if (preservedAttachment.attachment.localPreviewAvailable === undefined) {
+      delete mergedAttachment.localPreviewAvailable;
+    } else {
+      mergedAttachment.localPreviewAvailable = preservedAttachment.attachment.localPreviewAvailable;
+    }
+
     return {
       ...part,
-      attachment: {
-        ...part.attachment,
-        path: preservedAttachment.attachment.path,
-      },
+      attachment: mergedAttachment,
     };
   });
 

--- a/packages/adapters-opencode-sdk/src/message-normalizers.ts
+++ b/packages/adapters-opencode-sdk/src/message-normalizers.ts
@@ -69,7 +69,8 @@ const normalizeAttachmentPart = (
 ): AgentUserMessageDisplayPart | null => {
   const sourcePath = part.source?.type === "file" ? part.source.path.trim() : "";
   const fileUrlPath = readFilePathFromUrl(part.url);
-  const filePath = fileUrlPath ?? (sourcePath || part.filename?.trim() || "");
+  const previewPath = fileUrlPath ?? (sourcePath.length > 0 ? sourcePath : null);
+  const filePath = previewPath ?? part.filename?.trim() ?? "";
   if (filePath.length === 0 || !part.mime) {
     return null;
   }
@@ -85,7 +86,7 @@ const normalizeAttachmentPart = (
     kind: attachmentKind,
     mime: part.mime,
   };
-  if (!fileUrlPath && sourcePath.length === 0) {
+  if (previewPath === null) {
     attachment.localPreviewAvailable = false;
   }
   return { kind: "attachment", attachment };

--- a/packages/adapters-opencode-sdk/src/session-history.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-history.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import type { AgentEvent } from "@openducktor/core";
+import type { AgentEvent, AgentUserMessageDisplayPart } from "@openducktor/core";
+import type {
+  OpencodeMessageInfoFixtureInput,
+  OpencodePartFixtureInput,
+} from "./opencode-protocol-test-fixtures";
 import {
   defaultRepoRuntimeInput,
   completeMockEvent,
@@ -1739,37 +1743,93 @@ describe("OpencodeSdkAdapter session history", () => {
     );
   });
 
+  const makeImageFilePart = ({
+    id,
+    messageID,
+    url,
+    sourcePath,
+  }: {
+    id: string;
+    messageID: string;
+    url: string;
+    sourcePath?: string;
+  }): OpencodePartFixtureInput => {
+    const part: OpencodePartFixtureInput = {
+      id,
+      sessionID: "session-opencode-1",
+      messageID,
+      type: "file",
+      mime: "image/png",
+      filename: "image.png",
+      url,
+    };
+    if (sourcePath !== undefined) {
+      part.source = {
+        type: "file",
+        path: sourcePath,
+        text: { value: sourcePath, start: 0, end: sourcePath.length },
+      };
+    }
+    return part;
+  };
+
+  const makeUserImagesMessage = ({
+    messageID,
+    parts,
+  }: {
+    messageID: string;
+    parts: OpencodePartFixtureInput[];
+  }) => ({
+    info: {
+      id: messageID,
+      role: "user",
+      text: "Two images",
+      time: { created: Date.parse("2026-02-17T11:59:00Z") },
+    } satisfies OpencodeMessageInfoFixtureInput,
+    parts,
+  });
+
+  const makeImageAttachmentDisplayPart = ({
+    id,
+    path,
+    localPreviewAvailable,
+  }: {
+    id: string;
+    path: string;
+    localPreviewAvailable?: boolean;
+  }): AgentUserMessageDisplayPart => {
+    const attachment: Extract<AgentUserMessageDisplayPart, { kind: "attachment" }>["attachment"] = {
+      id,
+      path,
+      name: "image.png",
+      kind: "image",
+      mime: "image/png",
+    };
+    if (localPreviewAvailable !== undefined) {
+      attachment.localPreviewAvailable = localPreviewAvailable;
+    }
+    return { kind: "attachment", attachment };
+  };
+
   test("loadSessionHistory maps each data url attachment to its preserved local path", async () => {
+    const messageID = "msg-user-images-1";
     const mock = makeMockClient({
       messagesResponse: [
-        {
-          info: {
-            id: "msg-user-images-1",
-            role: "user",
-            text: "Two images",
-            time: { created: Date.parse("2026-02-17T11:59:00Z") },
-          },
+        makeUserImagesMessage({
+          messageID,
           parts: [
-            {
+            makeImageFilePart({
               id: "file-image-1",
-              sessionID: "session-opencode-1",
-              messageID: "msg-user-images-1",
-              type: "file",
-              mime: "image/png",
-              filename: "image.png",
+              messageID,
               url: "data:image/png;base64,aGVsbG8=",
-            },
-            {
+            }),
+            makeImageFilePart({
               id: "file-image-2",
-              sessionID: "session-opencode-1",
-              messageID: "msg-user-images-1",
-              type: "file",
-              mime: "image/png",
-              filename: "image.png",
+              messageID,
               url: "data:image/png;base64,d29ybGQ=",
-            },
+            }),
           ],
-        },
+        }),
       ],
     });
     const adapter = new OpencodeSdkAdapter({
@@ -1783,29 +1843,17 @@ describe("OpencodeSdkAdapter session history", () => {
     if (!session) {
       throw new Error("Expected started session");
     }
-    session.messageMetadataById.set("msg-user-images-1", {
+    session.messageMetadataById.set(messageID, {
       timestamp: "2026-02-17T11:59:00Z",
       displayParts: [
-        {
-          kind: "attachment",
-          attachment: {
-            id: "attachment-image-1",
-            path: "/tmp/local-first-image.png",
-            name: "image.png",
-            kind: "image",
-            mime: "image/png",
-          },
-        },
-        {
-          kind: "attachment",
-          attachment: {
-            id: "attachment-image-2",
-            path: "/tmp/local-second-image.png",
-            name: "image.png",
-            kind: "image",
-            mime: "image/png",
-          },
-        },
+        makeImageAttachmentDisplayPart({
+          id: "attachment-image-1",
+          path: "/tmp/local-first-image.png",
+        }),
+        makeImageAttachmentDisplayPart({
+          id: "attachment-image-2",
+          path: "/tmp/local-second-image.png",
+        }),
       ],
     });
 
@@ -1819,78 +1867,32 @@ describe("OpencodeSdkAdapter session history", () => {
       throw new Error("Expected user history entry");
     }
     expect(history[0].displayParts).toEqual([
-      {
-        kind: "attachment",
-        attachment: {
-          id: "file-image-1",
-          path: "/tmp/local-first-image.png",
-          name: "image.png",
-          kind: "image",
-          mime: "image/png",
-        },
-      },
-      {
-        kind: "attachment",
-        attachment: {
-          id: "file-image-2",
-          path: "/tmp/local-second-image.png",
-          name: "image.png",
-          kind: "image",
-          mime: "image/png",
-        },
-      },
+      makeImageAttachmentDisplayPart({ id: "file-image-1", path: "/tmp/local-first-image.png" }),
+      makeImageAttachmentDisplayPart({ id: "file-image-2", path: "/tmp/local-second-image.png" }),
     ]);
   });
 
   test("loadSessionHistory restores staged preview paths from runtime source metadata", async () => {
+    const messageID = "msg-user-images-3";
     const mock = makeMockClient({
       messagesResponse: [
-        {
-          info: {
-            id: "msg-user-images-3",
-            role: "user",
-            text: "Two images",
-            time: { created: Date.parse("2026-02-17T11:59:00Z") },
-          },
+        makeUserImagesMessage({
+          messageID,
           parts: [
-            {
+            makeImageFilePart({
               id: "file-image-1",
-              sessionID: "session-opencode-1",
-              messageID: "msg-user-images-3",
-              type: "file",
-              mime: "image/png",
-              filename: "image.png",
+              messageID,
               url: "data:image/png;base64,aGVsbG8=",
-              source: {
-                type: "file",
-                path: "/tmp/staged-first-image.png",
-                text: {
-                  value: "/tmp/staged-first-image.png",
-                  start: 0,
-                  end: 27,
-                },
-              },
-            },
-            {
+              sourcePath: "/tmp/staged-first-image.png",
+            }),
+            makeImageFilePart({
               id: "file-image-2",
-              sessionID: "session-opencode-1",
-              messageID: "msg-user-images-3",
-              type: "file",
-              mime: "image/png",
-              filename: "image.png",
+              messageID,
               url: "data:image/png;base64,d29ybGQ=",
-              source: {
-                type: "file",
-                path: "/tmp/staged-second-image.png",
-                text: {
-                  value: "/tmp/staged-second-image.png",
-                  start: 0,
-                  end: 28,
-                },
-              },
-            },
+              sourcePath: "/tmp/staged-second-image.png",
+            }),
           ],
-        },
+        }),
       ],
     });
     const adapter = new OpencodeSdkAdapter({
@@ -1908,60 +1910,30 @@ describe("OpencodeSdkAdapter session history", () => {
       throw new Error("Expected user history entry");
     }
     expect(history[0].displayParts).toEqual([
-      {
-        kind: "attachment",
-        attachment: {
-          id: "file-image-1",
-          path: "/tmp/staged-first-image.png",
-          name: "image.png",
-          kind: "image",
-          mime: "image/png",
-        },
-      },
-      {
-        kind: "attachment",
-        attachment: {
-          id: "file-image-2",
-          path: "/tmp/staged-second-image.png",
-          name: "image.png",
-          kind: "image",
-          mime: "image/png",
-        },
-      },
+      makeImageAttachmentDisplayPart({ id: "file-image-1", path: "/tmp/staged-first-image.png" }),
+      makeImageAttachmentDisplayPart({ id: "file-image-2", path: "/tmp/staged-second-image.png" }),
     ]);
   });
 
   test("loadSessionHistory keeps data url attachment echoes without local preview paths", async () => {
+    const messageID = "msg-user-images-2";
     const mock = makeMockClient({
       messagesResponse: [
-        {
-          info: {
-            id: "msg-user-images-2",
-            role: "user",
-            text: "Two images",
-            time: { created: Date.parse("2026-02-17T11:59:00Z") },
-          },
+        makeUserImagesMessage({
+          messageID,
           parts: [
-            {
+            makeImageFilePart({
               id: "file-image-1",
-              sessionID: "session-opencode-1",
-              messageID: "msg-user-images-2",
-              type: "file",
-              mime: "image/png",
-              filename: "image.png",
+              messageID,
               url: "data:image/png;base64,aGVsbG8=",
-            },
-            {
+            }),
+            makeImageFilePart({
               id: "file-image-2",
-              sessionID: "session-opencode-1",
-              messageID: "msg-user-images-2",
-              type: "file",
-              mime: "image/png",
-              filename: "image.png",
+              messageID,
               url: "data:image/png;base64,d29ybGQ=",
-            },
+            }),
           ],
-        },
+        }),
       ],
     });
     const adapter = new OpencodeSdkAdapter({
@@ -1979,28 +1951,16 @@ describe("OpencodeSdkAdapter session history", () => {
       throw new Error("Expected user history entry");
     }
     expect(history[0].displayParts).toEqual([
-      {
-        kind: "attachment",
-        attachment: {
-          id: "file-image-1",
-          path: "image.png",
-          name: "image.png",
-          kind: "image",
-          mime: "image/png",
-          localPreviewAvailable: false,
-        },
-      },
-      {
-        kind: "attachment",
-        attachment: {
-          id: "file-image-2",
-          path: "image.png",
-          name: "image.png",
-          kind: "image",
-          mime: "image/png",
-          localPreviewAvailable: false,
-        },
-      },
+      makeImageAttachmentDisplayPart({
+        id: "file-image-1",
+        path: "image.png",
+        localPreviewAvailable: false,
+      }),
+      makeImageAttachmentDisplayPart({
+        id: "file-image-2",
+        path: "image.png",
+        localPreviewAvailable: false,
+      }),
     ]);
   });
 });

--- a/packages/adapters-opencode-sdk/src/session-history.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-history.test.ts
@@ -1738,4 +1738,180 @@ describe("OpencodeSdkAdapter session history", () => {
       }),
     );
   });
+
+  test("loadSessionHistory maps each data url attachment to its preserved local path", async () => {
+    const mock = makeMockClient({
+      messagesResponse: [
+        {
+          info: {
+            id: "msg-user-images-1",
+            role: "user",
+            text: "Two images",
+            time: { created: Date.parse("2026-02-17T11:59:00Z") },
+          },
+          parts: [
+            {
+              id: "file-image-1",
+              sessionID: "session-opencode-1",
+              messageID: "msg-user-images-1",
+              type: "file",
+              mime: "image/png",
+              filename: "image.png",
+              url: "data:image/png;base64,aGVsbG8=",
+            },
+            {
+              id: "file-image-2",
+              sessionID: "session-opencode-1",
+              messageID: "msg-user-images-1",
+              type: "file",
+              mime: "image/png",
+              filename: "image.png",
+              url: "data:image/png;base64,d29ybGQ=",
+            },
+          ],
+        },
+      ],
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    await startDefaultSession(adapter, "spec");
+    const sessions = (adapter satisfies { sessions: Map<string, SessionRecord> }).sessions;
+    const session = sessions.get("session-opencode-1");
+    if (!session) {
+      throw new Error("Expected started session");
+    }
+    session.messageMetadataById.set("msg-user-images-1", {
+      timestamp: "2026-02-17T11:59:00Z",
+      displayParts: [
+        {
+          kind: "attachment",
+          attachment: {
+            id: "attachment-image-1",
+            path: "/tmp/local-first-image.png",
+            name: "image.png",
+            kind: "image",
+            mime: "image/png",
+          },
+        },
+        {
+          kind: "attachment",
+          attachment: {
+            id: "attachment-image-2",
+            path: "/tmp/local-second-image.png",
+            name: "image.png",
+            kind: "image",
+            mime: "image/png",
+          },
+        },
+      ],
+    });
+
+    const history = await adapter.loadSessionHistory({
+      ...defaultRepoRuntimeInput,
+      externalSessionId: "session-opencode-1",
+      limit: 100,
+    });
+
+    if (history[0]?.role !== "user") {
+      throw new Error("Expected user history entry");
+    }
+    expect(history[0].displayParts).toEqual([
+      {
+        kind: "attachment",
+        attachment: {
+          id: "file-image-1",
+          path: "/tmp/local-first-image.png",
+          name: "image.png",
+          kind: "image",
+          mime: "image/png",
+        },
+      },
+      {
+        kind: "attachment",
+        attachment: {
+          id: "file-image-2",
+          path: "/tmp/local-second-image.png",
+          name: "image.png",
+          kind: "image",
+          mime: "image/png",
+        },
+      },
+    ]);
+  });
+
+  test("loadSessionHistory keeps data url attachment echoes without local preview paths", async () => {
+    const mock = makeMockClient({
+      messagesResponse: [
+        {
+          info: {
+            id: "msg-user-images-2",
+            role: "user",
+            text: "Two images",
+            time: { created: Date.parse("2026-02-17T11:59:00Z") },
+          },
+          parts: [
+            {
+              id: "file-image-1",
+              sessionID: "session-opencode-1",
+              messageID: "msg-user-images-2",
+              type: "file",
+              mime: "image/png",
+              filename: "image.png",
+              url: "data:image/png;base64,aGVsbG8=",
+            },
+            {
+              id: "file-image-2",
+              sessionID: "session-opencode-1",
+              messageID: "msg-user-images-2",
+              type: "file",
+              mime: "image/png",
+              filename: "image.png",
+              url: "data:image/png;base64,d29ybGQ=",
+            },
+          ],
+        },
+      ],
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const history = await adapter.loadSessionHistory({
+      ...defaultRepoRuntimeInput,
+      externalSessionId: "session-opencode-1",
+      limit: 100,
+    });
+
+    if (history[0]?.role !== "user") {
+      throw new Error("Expected user history entry");
+    }
+    expect(history[0].displayParts).toEqual([
+      {
+        kind: "attachment",
+        attachment: {
+          id: "file-image-1",
+          path: "image.png",
+          name: "image.png",
+          kind: "image",
+          mime: "image/png",
+          localPreviewAvailable: false,
+        },
+      },
+      {
+        kind: "attachment",
+        attachment: {
+          id: "file-image-2",
+          path: "image.png",
+          name: "image.png",
+          kind: "image",
+          mime: "image/png",
+          localPreviewAvailable: false,
+        },
+      },
+    ]);
+  });
 });

--- a/packages/adapters-opencode-sdk/src/session-history.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-history.test.ts
@@ -1842,6 +1842,95 @@ describe("OpencodeSdkAdapter session history", () => {
     ]);
   });
 
+  test("loadSessionHistory restores staged preview paths from runtime source metadata", async () => {
+    const mock = makeMockClient({
+      messagesResponse: [
+        {
+          info: {
+            id: "msg-user-images-3",
+            role: "user",
+            text: "Two images",
+            time: { created: Date.parse("2026-02-17T11:59:00Z") },
+          },
+          parts: [
+            {
+              id: "file-image-1",
+              sessionID: "session-opencode-1",
+              messageID: "msg-user-images-3",
+              type: "file",
+              mime: "image/png",
+              filename: "image.png",
+              url: "data:image/png;base64,aGVsbG8=",
+              source: {
+                type: "file",
+                path: "/tmp/staged-first-image.png",
+                text: {
+                  value: "/tmp/staged-first-image.png",
+                  start: 0,
+                  end: 27,
+                },
+              },
+            },
+            {
+              id: "file-image-2",
+              sessionID: "session-opencode-1",
+              messageID: "msg-user-images-3",
+              type: "file",
+              mime: "image/png",
+              filename: "image.png",
+              url: "data:image/png;base64,d29ybGQ=",
+              source: {
+                type: "file",
+                path: "/tmp/staged-second-image.png",
+                text: {
+                  value: "/tmp/staged-second-image.png",
+                  start: 0,
+                  end: 28,
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const history = await adapter.loadSessionHistory({
+      ...defaultRepoRuntimeInput,
+      externalSessionId: "session-opencode-1",
+      limit: 100,
+    });
+
+    if (history[0]?.role !== "user") {
+      throw new Error("Expected user history entry");
+    }
+    expect(history[0].displayParts).toEqual([
+      {
+        kind: "attachment",
+        attachment: {
+          id: "file-image-1",
+          path: "/tmp/staged-first-image.png",
+          name: "image.png",
+          kind: "image",
+          mime: "image/png",
+        },
+      },
+      {
+        kind: "attachment",
+        attachment: {
+          id: "file-image-2",
+          path: "/tmp/staged-second-image.png",
+          name: "image.png",
+          kind: "image",
+          mime: "image/png",
+        },
+      },
+    ]);
+  });
+
   test("loadSessionHistory keeps data url attachment echoes without local preview paths", async () => {
     const mock = makeMockClient({
       messagesResponse: [


### PR DESCRIPTION
## Problem

A message with two image attachments shows four images in the transcript. Each image appears twice.

After an app reload, the transcript shows the same image in both slots. The other image is missing.

## Cause

The OpenCode adapter merged the preserved message display parts with the queued send parts for the same message. Both describe the same request, so each attachment was counted twice.

For history, OpenCode stores each attachment as a file part with a `data:` URL and the original file name. The adapter used that file name as the local path. Two staged files with the same name then resolved to the newest staged file, so both slots showed one image.

## Goal

- Render each sent attachment exactly once.
- Keep the correct local preview for each attachment after a reload.
- Keep the preview fallback for messages that have no stored local path.