### PR TITLE
feat(frontend): open terminal links with Cmd or Ctrl click

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
@@ -57,6 +57,7 @@ const createQueuedWriteTerminalHarness = (queuedData: string) => {
     open(container);
     loadAddon({ dispose: () => {} });
     return {
+      dispose,
       terminal: { clear, dispose, loadAddon, open, options: {}, reset, write },
       fitAddon: { dispose: mock(() => {}), fit },
     };
@@ -82,6 +83,7 @@ describe("AgentStudioDevServerTerminal", () => {
       callback?.();
     });
     const dispose = mock(() => {});
+    const terminalDispose = mock(() => {});
     const onRendererError = mock(() => {});
     let capturedOptions: CapturedOptionsContract = {};
     const createTerminalBinding = (
@@ -92,12 +94,21 @@ describe("AgentStudioDevServerTerminal", () => {
       open(container);
       loadAddon({ dispose: () => {} });
       return {
-        terminal: { clear, dispose, loadAddon, open, options: {}, reset, write },
+        dispose,
+        terminal: {
+          clear,
+          dispose: terminalDispose,
+          loadAddon,
+          open,
+          options: {},
+          reset,
+          write,
+        },
         fitAddon: { dispose, fit },
       };
     };
 
-    render(
+    const view = render(
       <AgentStudioDevServerTerminal
         scopeKey="/repo::task-1"
         scriptId="frontend"
@@ -128,6 +139,9 @@ describe("AgentStudioDevServerTerminal", () => {
     expect(capturedOptions.disableStdin).toBe(true);
     expect(capturedOptions.fontFamily).toContain('"Symbols Nerd Font Mono"');
     expect(reset).toHaveBeenCalledTimes(1);
+    view.unmount();
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(terminalDispose).not.toHaveBeenCalled();
     expect(writes).toEqual(["ready\r\n"]);
     expect(onRendererError).toHaveBeenCalledWith(null);
   });
@@ -149,6 +163,7 @@ describe("AgentStudioDevServerTerminal", () => {
       open(container);
       loadAddon({ dispose: () => {} });
       return {
+        dispose,
         terminal: { clear, dispose, loadAddon, open, options: {}, reset, write },
         fitAddon: { dispose, fit },
       };
@@ -277,6 +292,7 @@ describe("AgentStudioDevServerTerminal", () => {
       open(container);
       loadAddon({ dispose: () => {} });
       return {
+        dispose,
         terminal: { clear, dispose, loadAddon, open, options: {}, reset, write },
         fitAddon: { dispose, fit },
       };
@@ -420,6 +436,7 @@ describe("AgentStudioDevServerTerminal", () => {
       open(container);
       loadAddon({ dispose: () => {} });
       return {
+        dispose,
         terminal: { clear, dispose, loadAddon, open, options: {}, reset, write },
         fitAddon: { dispose, fit },
       };
@@ -507,6 +524,7 @@ describe("AgentStudioDevServerTerminal", () => {
       open(container);
       loadAddon({ dispose: () => {} });
       return {
+        dispose,
         terminal: { clear, dispose, loadAddon, open, options: {}, reset, write },
         fitAddon: { dispose, fit },
       };
@@ -593,6 +611,7 @@ describe("AgentStudioDevServerTerminal", () => {
       open(container);
       loadAddon({ dispose: () => {} });
       return {
+        dispose,
         terminal: {
           clear,
           dispose,
@@ -948,6 +967,7 @@ describe("AgentStudioDevServerTerminal", () => {
       open(container);
       loadAddon({ dispose: () => {} });
       return {
+        dispose,
         terminal: { clear, dispose, loadAddon, open, options: {}, reset, write },
         fitAddon: { dispose, fit },
       };
@@ -1043,6 +1063,7 @@ describe("AgentStudioDevServerTerminal", () => {
       open(container);
       loadAddon({ dispose: () => {} });
       return {
+        dispose,
         terminal: {
           attachCustomKeyEventHandler: (handler: (event: KeyboardEvent) => boolean) => {
             keyHandler = handler;

--- a/packages/frontend/src/components/features/agents/use-agent-studio-dev-server-terminal.ts
+++ b/packages/frontend/src/components/features/agents/use-agent-studio-dev-server-terminal.ts
@@ -1,7 +1,8 @@
-import { FitAddon } from "@xterm/addon-fit";
-import { type ITerminalOptions, Terminal } from "@xterm/xterm";
+import type { FitAddon } from "@xterm/addon-fit";
+import type { ITerminalOptions, Terminal } from "@xterm/xterm";
 import { useCallback, useEffect, useRef } from "react";
 import type { AgentStudioDevServerTerminalBuffer } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
+import { createSharedTerminalBinding } from "@/features/terminals/shared-terminal-binding";
 import {
   createTerminalOptions,
   createTerminalTheme,
@@ -49,12 +50,9 @@ type UseDevServerTerminalRenderingArgs = TerminalRenderController & {
 };
 
 export const defaultCreateTerminalBinding: CreateTerminalBinding = (container, options) => {
-  const terminal = new Terminal(options);
-  const fitAddon = new FitAddon();
-  terminal.loadAddon(fitAddon);
-  terminal.open(container);
-  fitAddon.fit();
-  return { terminal, fitAddon };
+  const binding = createSharedTerminalBinding(container, options);
+  binding.fitAddon.fit();
+  return binding;
 };
 
 const terminalOptions = (container: HTMLElement): ITerminalOptions =>

--- a/packages/frontend/src/components/features/agents/use-agent-studio-dev-server-terminal.ts
+++ b/packages/frontend/src/components/features/agents/use-agent-studio-dev-server-terminal.ts
@@ -2,7 +2,7 @@ import type { FitAddon } from "@xterm/addon-fit";
 import type { ITerminalOptions, Terminal } from "@xterm/xterm";
 import { useCallback, useEffect, useRef } from "react";
 import type { AgentStudioDevServerTerminalBuffer } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
-import { createSharedTerminalBinding } from "@/features/terminals/shared-terminal-binding";
+import { createTerminalBinding } from "@/features/terminals/shared-terminal-binding";
 import {
   createTerminalOptions,
   createTerminalTheme,
@@ -50,7 +50,7 @@ type UseDevServerTerminalRenderingArgs = TerminalRenderController & {
 };
 
 export const defaultCreateTerminalBinding: CreateTerminalBinding = (container, options) => {
-  const binding = createSharedTerminalBinding(container, options);
+  const binding = createTerminalBinding(container, options);
   binding.fitAddon.fit();
   return binding;
 };

--- a/packages/frontend/src/components/features/agents/use-agent-studio-dev-server-terminal.ts
+++ b/packages/frontend/src/components/features/agents/use-agent-studio-dev-server-terminal.ts
@@ -9,13 +9,14 @@ import {
 } from "@/features/terminals/terminal-xterm-options";
 
 export type TerminalBinding = {
-  terminal: Pick<Terminal, "clear" | "dispose" | "loadAddon" | "open" | "options" | "reset"> & {
+  dispose(): void;
+  terminal: Pick<Terminal, "clear" | "loadAddon" | "open" | "options" | "reset"> & {
     attachCustomKeyEventHandler?(handler: (event: KeyboardEvent) => boolean): void;
     getSelection?(): string;
     hasSelection?(): boolean;
     write(data: string, callback?: () => void): void;
   };
-  fitAddon: Pick<FitAddon, "dispose" | "fit">;
+  fitAddon: Pick<FitAddon, "fit">;
 };
 
 export type CreateTerminalBinding = (
@@ -175,8 +176,7 @@ const disposeTerminalBinding = (
   renderQueueRef: { current: Promise<void> | null },
   renderGenerationRef: { current: number },
 ): void => {
-  bindingRef.current?.terminal.dispose();
-  bindingRef.current?.fitAddon.dispose();
+  bindingRef.current?.dispose();
   bindingRef.current = null;
   resetTerminalRenderQueue(renderedStateRef, renderQueueRef, renderGenerationRef);
 };
@@ -272,8 +272,7 @@ export const useDevServerTerminalBinding = ({
 
     terminalObserversCleanupRef.current?.();
     terminalObserversCleanupRef.current = null;
-    bindingRef.current?.terminal.dispose();
-    bindingRef.current?.fitAddon.dispose();
+    bindingRef.current?.dispose();
     bindingRef.current = null;
 
     const binding = createTerminalBinding(container, terminalOptions(container));

--- a/packages/frontend/src/features/terminals/constants.ts
+++ b/packages/frontend/src/features/terminals/constants.ts
@@ -1,0 +1,12 @@
+export const LINK_POINTER_CLASS = "odt-terminal-link-pointer";
+export const LINKS_ENABLED_CLASS = "odt-terminal-links";
+export const LINK_DRAG_PX = 4;
+
+export const HTTP_URL = /https?:\/\/[^\s<>"'`|]+/giu;
+export const URL_END_MARKS = new Set([".", ","]);
+export const URL_BARE_END_MARKS = new Set([";", ":", "!", "?"]);
+export const URL_BRACKETS = new Map([
+  [")", "("],
+  ["]", "["],
+  ["}", "{"],
+]);

--- a/packages/frontend/src/features/terminals/interactive-terminal-mount.ts
+++ b/packages/frontend/src/features/terminals/interactive-terminal-mount.ts
@@ -1,6 +1,4 @@
 import type { AppPlatform, TerminalLifecycle, TerminalServerMessage } from "@openducktor/contracts";
-import { FitAddon } from "@xterm/addon-fit";
-import { Terminal } from "@xterm/xterm";
 import {
   createLatestResizeScheduler,
   createLiveTerminalFitScheduler,
@@ -18,6 +16,7 @@ import {
 import { createTerminalKeyEventHandler, encodeTerminalTextInput } from "./terminal-keyboard-policy";
 import type { TerminalTransportController } from "./terminal-transport-controller";
 import { createTerminalOptions } from "./terminal-xterm-options";
+import { createSharedTerminalBinding } from "./shared-terminal-binding";
 
 export type InteractiveTerminalMount = {
   activate(focus: boolean): void;
@@ -63,19 +62,15 @@ export const mountInteractiveTerminal = ({
   const reportFailure = (title: string, cause: unknown): void => {
     if (!disposed) onInteractionFailure(title, cause);
   };
-  const terminal = new Terminal(
+  const binding = createSharedTerminalBinding(
+    container,
     createTerminalOptions(container, { cursorBlink: true, screenReaderMode: true }),
   );
-  let fitAddon: FitAddon | undefined;
-  try {
-    fitAddon = new FitAddon();
-    terminal.loadAddon(fitAddon);
-    terminal.open(container);
-  } catch (cause) {
-    fitAddon?.dispose();
-    terminal.dispose();
-    throw cause;
-  }
+  const { fitAddon, terminal } = binding;
+  const resetTerminal = (): void => {
+    binding.resetLinkState();
+    terminal.reset();
+  };
   const activateViewport = createTerminalViewportActivator({
     fit: () => fitAddon.fit(),
     scrollToBottom: () => terminal.scrollToBottom(),
@@ -170,12 +165,12 @@ export const mountInteractiveTerminal = ({
     const isReplayGap = message.type === "replay_gap";
     if (isReplayGap) {
       void outputSequencer
-        .skipTo(message.missingSequenceEnd, () => terminal.reset())
+        .skipTo(message.missingSequenceEnd, resetTerminal)
         .catch((cause) => reportFailure("Terminal output failed", cause));
     }
     if (
       handleTerminalMetadataFrame(message, {
-        reset: isReplayGap ? () => undefined : () => terminal.reset(),
+        reset: isReplayGap ? () => undefined : resetTerminal,
         onAttention,
         onLifecycle,
         onTitle: onTitleChange,
@@ -196,7 +191,10 @@ export const mountInteractiveTerminal = ({
   if (isActive()) fitAddon.fit();
 
   return {
-    activate: (focus) => activateViewport(focus ? () => terminal.focus() : null),
+    activate: (focus) => {
+      binding.resetLinkState();
+      activateViewport(focus ? () => terminal.focus() : null);
+    },
     dispose: () => {
       if (disposed) return;
       disposed = true;
@@ -212,8 +210,7 @@ export const mountInteractiveTerminal = ({
       oscClipboardSubscription.dispose();
       dataSubscription.dispose();
       resizeSubscription.dispose();
-      fitAddon.dispose();
-      terminal.dispose();
+      binding.dispose();
     },
   };
 };

--- a/packages/frontend/src/features/terminals/interactive-terminal-mount.ts
+++ b/packages/frontend/src/features/terminals/interactive-terminal-mount.ts
@@ -16,7 +16,7 @@ import {
 import { createTerminalKeyEventHandler, encodeTerminalTextInput } from "./terminal-keyboard-policy";
 import type { TerminalTransportController } from "./terminal-transport-controller";
 import { createTerminalOptions } from "./terminal-xterm-options";
-import { createSharedTerminalBinding } from "./shared-terminal-binding";
+import { createTerminalBinding } from "./shared-terminal-binding";
 
 export type InteractiveTerminalMount = {
   activate(focus: boolean): void;
@@ -62,7 +62,7 @@ export const mountInteractiveTerminal = ({
   const reportFailure = (title: string, cause: unknown): void => {
     if (!disposed) onInteractionFailure(title, cause);
   };
-  const binding = createSharedTerminalBinding(
+  const binding = createTerminalBinding(
     container,
     createTerminalOptions(container, { cursorBlink: true, screenReaderMode: true }),
   );

--- a/packages/frontend/src/features/terminals/shared-terminal-binding.test.ts
+++ b/packages/frontend/src/features/terminals/shared-terminal-binding.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, mock, spyOn, test } from "bun:test";
+import { FitAddon } from "@xterm/addon-fit";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { Terminal } from "@xterm/xterm";
+import { createTerminalBinding } from "./shared-terminal-binding";
+
+if (globalThis.document === undefined) GlobalRegistrator.register();
+
+describe("shared terminal binding", () => {
+  test("disposes the terminal once", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const binding = createTerminalBinding(container, {});
+    const dispose = mock(binding.terminal.dispose.bind(binding.terminal));
+    binding.terminal.dispose = dispose;
+
+    try {
+      binding.dispose();
+      binding.dispose();
+      expect(dispose).toHaveBeenCalledTimes(1);
+    } finally {
+      binding.dispose();
+      container.remove();
+    }
+  });
+
+  test("disposes created resources when setup fails", () => {
+    const failure = new Error("open failed");
+    const open = spyOn(Terminal.prototype, "open").mockImplementation(() => {
+      throw failure;
+    });
+    const disposeTerminal = spyOn(Terminal.prototype, "dispose");
+    const disposeFit = spyOn(FitAddon.prototype, "dispose");
+    const container = document.createElement("div");
+
+    try {
+      expect(() => createTerminalBinding(container, {})).toThrow(failure);
+      expect(disposeTerminal).toHaveBeenCalledTimes(1);
+      expect(disposeFit).toHaveBeenCalledTimes(1);
+    } finally {
+      open.mockRestore();
+      disposeTerminal.mockRestore();
+      disposeFit.mockRestore();
+    }
+  });
+});

--- a/packages/frontend/src/features/terminals/shared-terminal-binding.ts
+++ b/packages/frontend/src/features/terminals/shared-terminal-binding.ts
@@ -3,61 +3,57 @@ import { type ITerminalOptions, Terminal } from "@xterm/xterm";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import { openExternalUrl } from "@/lib/open-external-url";
-import {
-  createTerminalLinkController,
-  type TerminalLinkController,
-} from "./terminal-link-controller";
+import { createLinkController, type LinkController } from "./terminal-link-controller";
 
-type SharedTerminalDependencies = {
+type BindingDeps = {
   openUrl?: (url: string) => Promise<void>;
   reportOpenError?: (url: string, cause: unknown) => void;
 };
 
-export type SharedTerminalBinding = {
+export type TerminalBinding = {
   terminal: Terminal;
   fitAddon: FitAddon;
-  linkController: TerminalLinkController;
+  linkController: LinkController;
   dispose(): void;
   resetLinkState(): void;
 };
 
-const reportTerminalLinkOpenError = (_url: string, cause: unknown): void => {
+const reportOpenError = (_url: string, cause: unknown): void => {
   toast.error("Failed to open terminal link", {
     description: `${errorMessage(cause)} Copy the URL into a browser.`,
   });
 };
 
-export const createSharedTerminalBinding = (
+export const createTerminalBinding = (
   container: HTMLElement,
   options: ITerminalOptions,
-  dependencies: SharedTerminalDependencies = {},
-): SharedTerminalBinding => {
-  const linkController = createTerminalLinkController({
+  deps: BindingDeps = {},
+): TerminalBinding => {
+  const links = createLinkController({
     container,
-    openUrl: dependencies.openUrl ?? openExternalUrl,
-    reportOpenError: dependencies.reportOpenError ?? reportTerminalLinkOpenError,
+    openUrl: deps.openUrl ?? openExternalUrl,
+    reportOpenError: deps.reportOpenError ?? reportOpenError,
   });
-  const { linkHandler: _ignoredLinkHandler, ...ownedOptions } = options;
-  const terminal = new Terminal({ ...ownedOptions, linkHandler: linkController.linkHandler });
+  const terminal = new Terminal({ ...options, linkHandler: links.linkHandler });
   const fitAddon = new FitAddon();
   let disposed = false;
 
   try {
     terminal.loadAddon(fitAddon);
     terminal.open(container);
-    terminal.loadAddon(linkController);
+    terminal.loadAddon(links);
   } catch (cause) {
     terminal.dispose();
     fitAddon.dispose();
-    linkController.dispose();
+    links.dispose();
     throw cause;
   }
 
   return {
     terminal,
     fitAddon,
-    linkController,
-    resetLinkState: () => linkController.reset(),
+    linkController: links,
+    resetLinkState: () => links.reset(),
     dispose: () => {
       if (disposed) return;
       disposed = true;

--- a/packages/frontend/src/features/terminals/shared-terminal-binding.ts
+++ b/packages/frontend/src/features/terminals/shared-terminal-binding.ts
@@ -3,7 +3,7 @@ import { type ITerminalOptions, Terminal } from "@xterm/xterm";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import { openExternalUrl } from "@/lib/open-external-url";
-import { createLinkController, type LinkController } from "./terminal-link-controller";
+import { createLinkController } from "./terminal-link-controller";
 
 type BindingDeps = {
   openUrl?: (url: string) => Promise<void>;
@@ -13,7 +13,6 @@ type BindingDeps = {
 export type TerminalBinding = {
   terminal: Terminal;
   fitAddon: FitAddon;
-  linkController: LinkController;
   dispose(): void;
   resetLinkState(): void;
 };
@@ -52,7 +51,6 @@ export const createTerminalBinding = (
   return {
     terminal,
     fitAddon,
-    linkController: links,
     resetLinkState: () => links.reset(),
     dispose: () => {
       if (disposed) return;

--- a/packages/frontend/src/features/terminals/shared-terminal-binding.ts
+++ b/packages/frontend/src/features/terminals/shared-terminal-binding.ts
@@ -1,0 +1,67 @@
+import { FitAddon } from "@xterm/addon-fit";
+import { type ITerminalOptions, Terminal } from "@xterm/xterm";
+import { toast } from "sonner";
+import { errorMessage } from "@/lib/errors";
+import { openExternalUrl } from "@/lib/open-external-url";
+import {
+  createTerminalLinkController,
+  type TerminalLinkController,
+} from "./terminal-link-controller";
+
+type SharedTerminalDependencies = {
+  openUrl?: (url: string) => Promise<void>;
+  reportOpenError?: (url: string, cause: unknown) => void;
+};
+
+export type SharedTerminalBinding = {
+  terminal: Terminal;
+  fitAddon: FitAddon;
+  linkController: TerminalLinkController;
+  dispose(): void;
+  resetLinkState(): void;
+};
+
+const reportTerminalLinkOpenError = (_url: string, cause: unknown): void => {
+  toast.error("Failed to open terminal link", {
+    description: `${errorMessage(cause)} Copy the URL into a browser.`,
+  });
+};
+
+export const createSharedTerminalBinding = (
+  container: HTMLElement,
+  options: ITerminalOptions,
+  dependencies: SharedTerminalDependencies = {},
+): SharedTerminalBinding => {
+  const linkController = createTerminalLinkController({
+    container,
+    openUrl: dependencies.openUrl ?? openExternalUrl,
+    reportOpenError: dependencies.reportOpenError ?? reportTerminalLinkOpenError,
+  });
+  const { linkHandler: _ignoredLinkHandler, ...ownedOptions } = options;
+  const terminal = new Terminal({ ...ownedOptions, linkHandler: linkController.linkHandler });
+  const fitAddon = new FitAddon();
+  let disposed = false;
+
+  try {
+    terminal.loadAddon(fitAddon);
+    terminal.open(container);
+    terminal.loadAddon(linkController);
+  } catch (cause) {
+    terminal.dispose();
+    fitAddon.dispose();
+    linkController.dispose();
+    throw cause;
+  }
+
+  return {
+    terminal,
+    fitAddon,
+    linkController,
+    resetLinkState: () => linkController.reset(),
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      terminal.dispose();
+    },
+  };
+};

--- a/packages/frontend/src/features/terminals/shared-terminal-binding.ts
+++ b/packages/frontend/src/features/terminals/shared-terminal-binding.ts
@@ -5,11 +5,6 @@ import { errorMessage } from "@/lib/errors";
 import { openExternalUrl } from "@/lib/open-external-url";
 import { createLinkController } from "./terminal-link-controller";
 
-type BindingDeps = {
-  openUrl?: (url: string) => Promise<void>;
-  reportOpenError?: (url: string, cause: unknown) => void;
-};
-
 export type TerminalBinding = {
   terminal: Terminal;
   fitAddon: FitAddon;
@@ -26,12 +21,11 @@ const reportOpenError = (_url: string, cause: unknown): void => {
 export const createTerminalBinding = (
   container: HTMLElement,
   options: ITerminalOptions,
-  deps: BindingDeps = {},
 ): TerminalBinding => {
   const links = createLinkController({
     container,
-    openUrl: deps.openUrl ?? openExternalUrl,
-    reportOpenError: deps.reportOpenError ?? reportOpenError,
+    openUrl: openExternalUrl,
+    reportOpenError,
   });
   const terminal = new Terminal({ ...options, linkHandler: links.linkHandler });
   const fitAddon = new FitAddon();

--- a/packages/frontend/src/features/terminals/terminal-link-controller.test.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-controller.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import type { IBufferLine, IDisposable, ILink, ILinkProvider, Terminal } from "@xterm/xterm";
+import { createTerminalLinkController, hasTerminalOpenModifier } from "./terminal-link-controller";
+
+if (globalThis.document === undefined) GlobalRegistrator.register();
+
+const createLine = (text: string, columns: number): IBufferLine => ({
+  isWrapped: false,
+  length: columns,
+  getCell: (column) => {
+    const character = text[column] ?? "";
+    const cell = {
+      getChars: () => character,
+      getCode: () => (character ? (character.codePointAt(0) ?? 0) : 0),
+      getWidth: () => 1,
+    };
+    // SAFETY: The link provider only reads the three cell methods implemented above.
+    return cell as ReturnType<IBufferLine["getCell"]>;
+  },
+  translateToString: () => text,
+});
+
+const createHarness = (openUrl: (url: string) => Promise<void>) => {
+  const columns = 20;
+  const container = document.createElement("div");
+  const terminalElement = document.createElement("div");
+  const screen = document.createElement("div");
+  terminalElement.className = "xterm";
+  screen.className = "xterm-screen";
+  terminalElement.append(screen);
+  container.append(terminalElement);
+  document.body.append(container);
+  // SAFETY: Pointer mapping reads only the six DOMRect fields supplied by this fixed test box.
+  screen.getBoundingClientRect = () =>
+    ({ left: 0, right: 200, top: 0, bottom: 120, width: 200, height: 20 }) as DOMRect;
+
+  const listeners: Array<() => void> = [];
+  const event = (listener: () => void): IDisposable => {
+    listeners.push(listener);
+    return { dispose: () => undefined };
+  };
+  let provider: ILinkProvider | null = null;
+  const line = createLine("https://a.test", columns);
+  const terminalContract = {
+    buffer: {
+      active: { getLine: () => line, length: 1, viewportY: 0 },
+      onBufferChange: event,
+    },
+    cols: columns,
+    element: terminalElement,
+    onRender: event,
+    onResize: event,
+    onScroll: event,
+    onWriteParsed: event,
+    registerLinkProvider: (nextProvider: ILinkProvider) => {
+      provider = nextProvider;
+      return { dispose: () => undefined };
+    },
+    rows: 1,
+  };
+  const terminal: Terminal = Object.assign(Object.create(null), terminalContract);
+  const reportOpenError = mock((url: string, cause: unknown) => {
+    if (url.length === 0) throw new Error("Expected a non-empty URL.");
+    if (!(cause instanceof Error)) throw new Error("Expected an Error cause.");
+  });
+  const controller = createTerminalLinkController({ container, openUrl, reportOpenError });
+  controller.activate(terminal);
+  if (!provider) throw new Error("Expected the terminal link provider to register.");
+  let link: ILink | undefined;
+  // SAFETY: controller.activate assigned the registered provider through the fake above.
+  (provider as ILinkProvider).provideLinks(1, (links) => {
+    link = links?.[0];
+  });
+  if (!link) throw new Error("Expected a link for the test terminal.");
+
+  const dispatchMouse = (type: string, values: MouseEventInit = {}): MouseEvent => {
+    const mouseEvent = new MouseEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      clientX: 5,
+      clientY: 5,
+      ctrlKey: true,
+      ...values,
+    });
+    container.dispatchEvent(mouseEvent);
+    return mouseEvent;
+  };
+
+  return { container, controller, dispatchMouse, link, reportOpenError };
+};
+
+describe("terminal link controller", () => {
+  test("uses Cmd on macOS and Ctrl on other platforms", () => {
+    expect(hasTerminalOpenModifier({ metaKey: true, ctrlKey: false }, "MacIntel")).toBe(true);
+    expect(hasTerminalOpenModifier({ metaKey: false, ctrlKey: true }, "MacIntel")).toBe(false);
+    expect(hasTerminalOpenModifier({ metaKey: false, ctrlKey: true }, "Win32")).toBe(true);
+  });
+
+  test("opens one link for a modified primary click and consumes the gesture", async () => {
+    const openUrl = mock(async (_url: string) => undefined);
+    const harness = createHarness(openUrl);
+    try {
+      harness.link.hover?.(harness.dispatchMouse("mousemove"), harness.link.text);
+      const down = harness.dispatchMouse("mousedown");
+      const up = harness.dispatchMouse("mouseup");
+      const click = harness.dispatchMouse("click");
+
+      expect(down.defaultPrevented).toBe(true);
+      expect(up.defaultPrevented).toBe(true);
+      expect(click.defaultPrevented).toBe(true);
+      expect(openUrl).toHaveBeenCalledTimes(1);
+      expect(openUrl).toHaveBeenCalledWith("https://a.test");
+    } finally {
+      harness.controller.dispose();
+      harness.container.remove();
+    }
+  });
+
+  test("does not open for an ordinary click or a drag", () => {
+    const openUrl = mock(async (_url: string) => undefined);
+    const harness = createHarness(openUrl);
+    try {
+      harness.link.hover?.(harness.dispatchMouse("mousemove"), harness.link.text);
+      harness.dispatchMouse("mousedown", { ctrlKey: false });
+      harness.dispatchMouse("mouseup", { ctrlKey: false });
+      harness.dispatchMouse("mousedown");
+      harness.dispatchMouse("mousemove", { clientX: 15 });
+      harness.dispatchMouse("mouseup", { clientX: 15 });
+
+      expect(openUrl).not.toHaveBeenCalled();
+    } finally {
+      harness.controller.dispose();
+      harness.container.remove();
+    }
+  });
+
+  test("opens a validated OSC 8 destination instead of its visible label", () => {
+    const openUrl = mock(async (_url: string) => undefined);
+    const harness = createHarness(openUrl);
+    try {
+      const event = harness.dispatchMouse("mousemove");
+      const range = harness.link.range;
+      harness.controller.linkHandler.hover?.(event, "https://osc.test/path", range);
+      harness.dispatchMouse("mousedown");
+      harness.dispatchMouse("mouseup");
+
+      expect(openUrl).toHaveBeenCalledWith("https://osc.test/path");
+      expect(openUrl).toHaveBeenCalledTimes(1);
+    } finally {
+      harness.controller.dispose();
+      harness.container.remove();
+    }
+  });
+
+  test("updates the pointer on modifier changes and reports opener errors", async () => {
+    const failure = new Error("opener unavailable");
+    const harness = createHarness(async () => Promise.reject(failure));
+    try {
+      harness.link.hover?.(
+        harness.dispatchMouse("mousemove", { ctrlKey: false }),
+        harness.link.text,
+      );
+      expect(harness.container.classList.contains("odt-terminal-link-pointer")).toBe(false);
+      window.dispatchEvent(new KeyboardEvent("keydown", { ctrlKey: true, key: "Control" }));
+      expect(harness.container.classList.contains("odt-terminal-link-pointer")).toBe(true);
+
+      harness.dispatchMouse("mousedown");
+      harness.dispatchMouse("mouseup");
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(harness.reportOpenError).toHaveBeenCalledWith("https://a.test", failure);
+
+      window.dispatchEvent(new KeyboardEvent("keyup", { ctrlKey: false, key: "Control" }));
+      expect(harness.container.classList.contains("odt-terminal-link-pointer")).toBe(false);
+    } finally {
+      harness.controller.dispose();
+      harness.container.remove();
+    }
+  });
+});

--- a/packages/frontend/src/features/terminals/terminal-link-controller.test.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-controller.test.ts
@@ -35,10 +35,11 @@ const createHarness = (openUrl: (url: string) => Promise<void>) => {
   screen.getBoundingClientRect = () =>
     ({ left: 0, right: 200, top: 0, bottom: 120, width: 200, height: 20 }) as DOMRect;
 
-  const listeners: Array<() => void> = [];
-  const event = (listener: () => void): IDisposable => {
-    listeners.push(listener);
-    return { dispose: () => undefined };
+  const disposers: Array<ReturnType<typeof mock>> = [];
+  const event = (_listener: () => void): IDisposable => {
+    const dispose = mock(() => undefined);
+    disposers.push(dispose);
+    return { dispose };
   };
   let provider: ILinkProvider | null = null;
   const line = createLine("https://a.test", columns);
@@ -55,7 +56,9 @@ const createHarness = (openUrl: (url: string) => Promise<void>) => {
     onWriteParsed: event,
     registerLinkProvider: (nextProvider: ILinkProvider) => {
       provider = nextProvider;
-      return { dispose: () => undefined };
+      const dispose = mock(() => undefined);
+      disposers.push(dispose);
+      return { dispose };
     },
     rows: 1,
   };
@@ -88,7 +91,7 @@ const createHarness = (openUrl: (url: string) => Promise<void>) => {
     return mouseEvent;
   };
 
-  return { container, controller, dispatchMouse, link, reportOpenError, screen };
+  return { container, controller, dispatchMouse, disposers, link, reportOpenError, screen };
 };
 
 describe("terminal link controller", () => {
@@ -237,6 +240,29 @@ describe("terminal link controller", () => {
 
       window.dispatchEvent(new KeyboardEvent("keyup", { ctrlKey: false, key: "Control" }));
       expect(harness.container.classList.contains("odt-terminal-link-pointer")).toBe(false);
+    } finally {
+      harness.controller.dispose();
+      harness.container.remove();
+    }
+  });
+
+  test("disposes subscriptions and stops link input", () => {
+    const openUrl = mock(async (_url: string) => undefined);
+    const harness = createHarness(openUrl);
+    try {
+      harness.link.hover?.(harness.dispatchMouse("mousemove"), harness.link.text);
+      harness.controller.dispose();
+      harness.controller.dispose();
+
+      expect(harness.disposers).toHaveLength(6);
+      for (const dispose of harness.disposers) expect(dispose).toHaveBeenCalledTimes(1);
+      expect(harness.container.classList.contains("odt-terminal-links")).toBe(false);
+      expect(harness.container.classList.contains("odt-terminal-link-pointer")).toBe(false);
+
+      const down = harness.dispatchMouse("mousedown");
+      harness.dispatchMouse("mouseup");
+      expect(down.defaultPrevented).toBe(false);
+      expect(openUrl).not.toHaveBeenCalled();
     } finally {
       harness.controller.dispose();
       harness.container.remove();

--- a/packages/frontend/src/features/terminals/terminal-link-controller.test.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-controller.test.ts
@@ -88,7 +88,7 @@ const createHarness = (openUrl: (url: string) => Promise<void>) => {
     return mouseEvent;
   };
 
-  return { container, controller, dispatchMouse, link, reportOpenError };
+  return { container, controller, dispatchMouse, link, reportOpenError, screen };
 };
 
 describe("terminal link controller", () => {
@@ -148,6 +148,69 @@ describe("terminal link controller", () => {
 
       expect(openUrl).toHaveBeenCalledWith("https://osc.test/path");
       expect(openUrl).toHaveBeenCalledTimes(1);
+    } finally {
+      harness.controller.dispose();
+      harness.container.remove();
+    }
+  });
+
+  test("resolves an OSC 8 destination before the first modified press", () => {
+    const openUrl = mock(async (_url: string) => undefined);
+    const harness = createHarness(openUrl);
+    const parentMouseMove = mock(() => undefined);
+    const handleMouseMove = (event: MouseEvent) => {
+      harness.controller.linkHandler.hover?.(
+        event,
+        "https://osc.test/first-press",
+        harness.link.range,
+      );
+    };
+    harness.screen.addEventListener("mousemove", handleMouseMove);
+    harness.container.addEventListener("mousemove", parentMouseMove);
+    try {
+      harness.dispatchMouse("mousedown");
+      harness.dispatchMouse("mouseup");
+
+      expect(openUrl).toHaveBeenCalledWith("https://osc.test/first-press");
+      expect(openUrl).toHaveBeenCalledTimes(1);
+      expect(parentMouseMove).not.toHaveBeenCalled();
+    } finally {
+      harness.screen.removeEventListener("mousemove", handleMouseMove);
+      harness.container.removeEventListener("mousemove", parentMouseMove);
+      harness.controller.dispose();
+      harness.container.remove();
+    }
+  });
+
+  test("does not replace an unresolved xterm link with its visible URL", () => {
+    const openUrl = mock(async (_url: string) => undefined);
+    const harness = createHarness(openUrl);
+    try {
+      harness.screen.classList.add("xterm-cursor-pointer");
+      harness.dispatchMouse("mousedown");
+      harness.dispatchMouse("mouseup");
+
+      expect(openUrl).not.toHaveBeenCalled();
+    } finally {
+      harness.controller.dispose();
+      harness.container.remove();
+    }
+  });
+
+  test("releases gesture listeners when the window loses focus", () => {
+    const openUrl = mock(async (_url: string) => undefined);
+    const harness = createHarness(openUrl);
+    try {
+      harness.link.hover?.(harness.dispatchMouse("mousemove"), harness.link.text);
+      harness.dispatchMouse("mousedown");
+      window.dispatchEvent(new Event("blur"));
+
+      const move = harness.dispatchMouse("mousemove", { ctrlKey: false });
+      const up = harness.dispatchMouse("mouseup", { ctrlKey: false });
+
+      expect(move.defaultPrevented).toBe(false);
+      expect(up.defaultPrevented).toBe(false);
+      expect(openUrl).not.toHaveBeenCalled();
     } finally {
       harness.controller.dispose();
       harness.container.remove();

--- a/packages/frontend/src/features/terminals/terminal-link-controller.test.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-controller.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import type { IBufferLine, IDisposable, ILink, ILinkProvider, Terminal } from "@xterm/xterm";
-import { createTerminalLinkController, hasTerminalOpenModifier } from "./terminal-link-controller";
+import { createLinkController, hasOpenKey } from "./terminal-link-controller";
 
 if (globalThis.document === undefined) GlobalRegistrator.register();
 
@@ -15,7 +15,7 @@ const createLine = (text: string, columns: number): IBufferLine => ({
       getCode: () => (character ? (character.codePointAt(0) ?? 0) : 0),
       getWidth: () => 1,
     };
-    // SAFETY: The link provider only reads the three cell methods implemented above.
+    // SAFETY: This fake has the three cell methods that the link reader calls.
     return cell as ReturnType<IBufferLine["getCell"]>;
   },
   translateToString: () => text,
@@ -31,7 +31,7 @@ const createHarness = (openUrl: (url: string) => Promise<void>) => {
   terminalElement.append(screen);
   container.append(terminalElement);
   document.body.append(container);
-  // SAFETY: Pointer mapping reads only the six DOMRect fields supplied by this fixed test box.
+  // SAFETY: The pointer code reads only these six box fields.
   screen.getBoundingClientRect = () =>
     ({ left: 0, right: 200, top: 0, bottom: 120, width: 200, height: 20 }) as DOMRect;
 
@@ -64,11 +64,11 @@ const createHarness = (openUrl: (url: string) => Promise<void>) => {
     if (url.length === 0) throw new Error("Expected a non-empty URL.");
     if (!(cause instanceof Error)) throw new Error("Expected an Error cause.");
   });
-  const controller = createTerminalLinkController({ container, openUrl, reportOpenError });
+  const controller = createLinkController({ container, openUrl, reportOpenError });
   controller.activate(terminal);
   if (!provider) throw new Error("Expected the terminal link provider to register.");
   let link: ILink | undefined;
-  // SAFETY: controller.activate assigned the registered provider through the fake above.
+  // SAFETY: activate stores the provider through the fake above.
   (provider as ILinkProvider).provideLinks(1, (links) => {
     link = links?.[0];
   });
@@ -93,12 +93,12 @@ const createHarness = (openUrl: (url: string) => Promise<void>) => {
 
 describe("terminal link controller", () => {
   test("uses Cmd on macOS and Ctrl on other platforms", () => {
-    expect(hasTerminalOpenModifier({ metaKey: true, ctrlKey: false }, "MacIntel")).toBe(true);
-    expect(hasTerminalOpenModifier({ metaKey: false, ctrlKey: true }, "MacIntel")).toBe(false);
-    expect(hasTerminalOpenModifier({ metaKey: false, ctrlKey: true }, "Win32")).toBe(true);
+    expect(hasOpenKey({ metaKey: true, ctrlKey: false }, "MacIntel")).toBe(true);
+    expect(hasOpenKey({ metaKey: false, ctrlKey: true }, "MacIntel")).toBe(false);
+    expect(hasOpenKey({ metaKey: false, ctrlKey: true }, "Win32")).toBe(true);
   });
 
-  test("opens one link for a modified primary click and consumes the gesture", async () => {
+  test("opens one link for a modified primary click and blocks the browser click", async () => {
     const openUrl = mock(async (_url: string) => undefined);
     const harness = createHarness(openUrl);
     try {
@@ -197,7 +197,7 @@ describe("terminal link controller", () => {
     }
   });
 
-  test("releases gesture listeners when the window loses focus", () => {
+  test("stops press listeners when the window loses focus", () => {
     const openUrl = mock(async (_url: string) => undefined);
     const harness = createHarness(openUrl);
     try {

--- a/packages/frontend/src/features/terminals/terminal-link-controller.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-controller.ts
@@ -51,22 +51,16 @@ export const createLinkController = ({
   let blockClick = false;
   let clickBlockTimer: number | null = null;
   let disposed = false;
-  let keyWatchActive = false;
-  let dragWatchActive = false;
-  let clickBlockActive = false;
   const subscriptions: IDisposable[] = [];
 
   const startKeyWatch = (): void => {
-    if (keyWatchActive) return;
-    keyWatchActive = true;
     view.addEventListener("keydown", handleKeyChange, true);
     view.addEventListener("keyup", handleKeyChange, true);
     view.addEventListener("blur", handleBlur);
   };
 
   const stopKeyWatchIfIdle = (): void => {
-    if (!keyWatchActive || hovered || press) return;
-    keyWatchActive = false;
+    if (hovered || press) return;
     view.removeEventListener("keydown", handleKeyChange, true);
     view.removeEventListener("keyup", handleKeyChange, true);
     view.removeEventListener("blur", handleBlur);
@@ -74,15 +68,11 @@ export const createLinkController = ({
 
   const startDragWatch = (): void => {
     startKeyWatch();
-    if (dragWatchActive) return;
-    dragWatchActive = true;
     view.addEventListener("mousemove", handleMouseMove, true);
     view.addEventListener("mouseup", handleMouseUp, true);
   };
 
   const stopDragWatch = (): void => {
-    if (!dragWatchActive) return;
-    dragWatchActive = false;
     view.removeEventListener("mousemove", handleMouseMove, true);
     view.removeEventListener("mouseup", handleMouseUp, true);
     stopKeyWatchIfIdle();
@@ -94,14 +84,10 @@ export const createLinkController = ({
   };
 
   const startClickBlock = (): void => {
-    if (clickBlockActive) return;
-    clickBlockActive = true;
     view.addEventListener("click", handleClick, true);
   };
 
   const stopClickBlock = (): void => {
-    if (!clickBlockActive) return;
-    clickBlockActive = false;
     view.removeEventListener("click", handleClick, true);
   };
 

--- a/packages/frontend/src/features/terminals/terminal-link-controller.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-controller.ts
@@ -1,0 +1,341 @@
+import type {
+  IBufferCellPosition,
+  ILinkHandler,
+  IDisposable,
+  ITerminalAddon,
+  Terminal,
+} from "@xterm/xterm";
+import {
+  createTerminalHttpLinkProvider,
+  sameTerminalLinkTarget,
+  terminalRangeContains,
+  type TerminalHttpLinkProvider,
+  type TerminalLinkTarget,
+} from "./terminal-link-provider";
+import { validateTerminalHttpUrl } from "./terminal-url-policy";
+
+const LINK_POINTER_CLASS = "odt-terminal-link-pointer";
+const LINKS_ENABLED_CLASS = "odt-terminal-links";
+const DRAG_THRESHOLD_PX = 4;
+
+type TerminalLinkGesture = {
+  cancelled: boolean;
+  originX: number;
+  originY: number;
+  target: TerminalLinkTarget;
+};
+
+type TerminalLinkControllerInput = {
+  container: HTMLElement;
+  openUrl(url: string): Promise<void>;
+  reportOpenError(url: string, cause: unknown): void;
+};
+
+export type TerminalLinkController = ITerminalAddon & {
+  readonly linkHandler: ILinkHandler;
+  reset(): void;
+};
+
+const isMacPlatform = (platform: string): boolean => /mac/i.test(platform);
+
+export const hasTerminalOpenModifier = (
+  event: Pick<MouseEvent, "ctrlKey" | "metaKey">,
+  platform: string,
+): boolean => (isMacPlatform(platform) ? event.metaKey : event.ctrlKey);
+
+const stopTerminalLinkEvent = (event: Event): void => {
+  event.preventDefault();
+  event.stopPropagation();
+  event.stopImmediatePropagation();
+};
+
+export const readTerminalPointerPosition = (
+  terminal: Pick<Terminal, "buffer" | "cols" | "element" | "rows">,
+  event: Pick<MouseEvent, "clientX" | "clientY">,
+): IBufferCellPosition | null => {
+  const screen = terminal.element?.querySelector<HTMLElement>(".xterm-screen");
+  if (!screen || terminal.cols < 1 || terminal.rows < 1) return null;
+  const rect = screen.getBoundingClientRect();
+  if (
+    rect.width <= 0 ||
+    rect.height <= 0 ||
+    event.clientX < rect.left ||
+    event.clientX >= rect.right ||
+    event.clientY < rect.top ||
+    event.clientY >= rect.bottom
+  ) {
+    return null;
+  }
+
+  return {
+    x: Math.floor(((event.clientX - rect.left) / rect.width) * terminal.cols) + 1,
+    y:
+      terminal.buffer.active.viewportY +
+      Math.floor(((event.clientY - rect.top) / rect.height) * terminal.rows) +
+      1,
+  };
+};
+
+export const createTerminalLinkController = ({
+  container,
+  openUrl,
+  reportOpenError,
+}: TerminalLinkControllerInput): TerminalLinkController => {
+  const view = container.ownerDocument.defaultView;
+  if (!view) throw new Error("Cannot create terminal links without a browser window.");
+  const platform = view.navigator.platform;
+  let terminal: Terminal | null = null;
+  let provider: TerminalHttpLinkProvider | null = null;
+  let hovered: TerminalLinkTarget | null = null;
+  let gesture: TerminalLinkGesture | null = null;
+  let suppressClick = false;
+  let clickResetHandle: number | null = null;
+  let disposed = false;
+  let hoverWindowListenersAttached = false;
+  let gestureWindowListenersAttached = false;
+  let clickWindowListenerAttached = false;
+  const subscriptions: IDisposable[] = [];
+
+  const attachHoverWindowListeners = (): void => {
+    if (hoverWindowListenersAttached) return;
+    hoverWindowListenersAttached = true;
+    view.addEventListener("keydown", handleKeyChange, true);
+    view.addEventListener("keyup", handleKeyChange, true);
+    view.addEventListener("blur", handleBlur);
+  };
+
+  const detachHoverWindowListenersIfIdle = (): void => {
+    if (!hoverWindowListenersAttached || hovered || gesture) return;
+    hoverWindowListenersAttached = false;
+    view.removeEventListener("keydown", handleKeyChange, true);
+    view.removeEventListener("keyup", handleKeyChange, true);
+    view.removeEventListener("blur", handleBlur);
+  };
+
+  const attachGestureWindowListeners = (): void => {
+    attachHoverWindowListeners();
+    if (gestureWindowListenersAttached) return;
+    gestureWindowListenersAttached = true;
+    view.addEventListener("mousemove", handleMouseMove, true);
+    view.addEventListener("mouseup", handleMouseUp, true);
+  };
+
+  const detachGestureWindowListeners = (): void => {
+    if (!gestureWindowListenersAttached) return;
+    gestureWindowListenersAttached = false;
+    view.removeEventListener("mousemove", handleMouseMove, true);
+    view.removeEventListener("mouseup", handleMouseUp, true);
+    detachHoverWindowListenersIfIdle();
+  };
+
+  const attachClickWindowListener = (): void => {
+    if (clickWindowListenerAttached) return;
+    clickWindowListenerAttached = true;
+    view.addEventListener("click", handleClick, true);
+  };
+
+  const detachClickWindowListener = (): void => {
+    if (!clickWindowListenerAttached) return;
+    clickWindowListenerAttached = false;
+    view.removeEventListener("click", handleClick, true);
+  };
+
+  const updatePointer = (event?: Pick<KeyboardEvent, "ctrlKey" | "metaKey">): void => {
+    const openable =
+      hovered !== null && event !== undefined && hasTerminalOpenModifier(event, platform);
+    container.classList.toggle(LINK_POINTER_CLASS, openable);
+  };
+
+  const clearHover = (): void => {
+    hovered = null;
+    container.classList.remove(LINK_POINTER_CLASS);
+    detachHoverWindowListenersIfIdle();
+  };
+
+  const cancelGesture = (): void => {
+    if (gesture) gesture.cancelled = true;
+  };
+
+  const reset = (): void => {
+    clearHover();
+    cancelGesture();
+  };
+
+  const validateHover = (): void => {
+    if (hovered?.source !== "plain" || provider?.isCurrent(hovered)) return;
+    reset();
+  };
+
+  const readTargetAt = (event: MouseEvent): TerminalLinkTarget | null => {
+    if (!terminal || !provider) return null;
+    const position = readTerminalPointerPosition(terminal, event);
+    if (!position) return null;
+    if (
+      hovered?.source === "osc" &&
+      terminalRangeContains(hovered.range, position, terminal.cols) &&
+      validateTerminalHttpUrl(hovered.url)
+    ) {
+      return hovered;
+    }
+    return provider.findLinkAt(position);
+  };
+
+  const openTarget = (target: TerminalLinkTarget): void => {
+    void openUrl(target.url).catch((cause) => {
+      if (!disposed) reportOpenError(target.url, cause);
+    });
+  };
+
+  const handleHover = (event: MouseEvent, target: TerminalLinkTarget): void => {
+    if (disposed) return;
+    hovered = target;
+    attachHoverWindowListeners();
+    updatePointer(event);
+  };
+
+  const handleLeave = (_event: MouseEvent, target: TerminalLinkTarget): void => {
+    if (!hovered || !sameTerminalLinkTarget(hovered, target)) return;
+    clearHover();
+    cancelGesture();
+  };
+
+  const handleMouseDown = (event: MouseEvent): void => {
+    if (event.button !== 0 || !hasTerminalOpenModifier(event, platform)) return;
+    const target = readTargetAt(event);
+    if (!target) return;
+    gesture = {
+      cancelled: false,
+      originX: event.clientX,
+      originY: event.clientY,
+      target,
+    };
+    attachGestureWindowListeners();
+    stopTerminalLinkEvent(event);
+  };
+
+  const handleMouseMove = (event: MouseEvent): void => {
+    if (!gesture) return;
+    stopTerminalLinkEvent(event);
+    const distance = Math.hypot(event.clientX - gesture.originX, event.clientY - gesture.originY);
+    const target = readTargetAt(event);
+    if (
+      distance > DRAG_THRESHOLD_PX ||
+      !hasTerminalOpenModifier(event, platform) ||
+      !target ||
+      !sameTerminalLinkTarget(target, gesture.target)
+    ) {
+      cancelGesture();
+    }
+  };
+
+  const handleMouseUp = (event: MouseEvent): void => {
+    if (!gesture || event.button !== 0) return;
+    const completedGesture = gesture;
+    gesture = null;
+    detachGestureWindowListeners();
+    stopTerminalLinkEvent(event);
+    suppressClick = true;
+    attachClickWindowListener();
+    if (clickResetHandle !== null) view.clearTimeout(clickResetHandle);
+    clickResetHandle = view.setTimeout(() => {
+      suppressClick = false;
+      clickResetHandle = null;
+      detachClickWindowListener();
+    }, 0);
+
+    const target = readTargetAt(event);
+    if (
+      !completedGesture.cancelled &&
+      hasTerminalOpenModifier(event, platform) &&
+      target &&
+      sameTerminalLinkTarget(target, completedGesture.target)
+    ) {
+      openTarget(completedGesture.target);
+    }
+  };
+
+  const handleClick = (event: MouseEvent): void => {
+    if (!suppressClick) return;
+    suppressClick = false;
+    if (clickResetHandle !== null) view.clearTimeout(clickResetHandle);
+    clickResetHandle = null;
+    detachClickWindowListener();
+    stopTerminalLinkEvent(event);
+  };
+
+  const handleKeyChange = (event: KeyboardEvent): void => {
+    updatePointer(event);
+    if (gesture && !hasTerminalOpenModifier(event, platform)) cancelGesture();
+  };
+
+  const handleBlur = (): void => {
+    reset();
+  };
+
+  const handleContainerLeave = (): void => {
+    clearHover();
+    cancelGesture();
+  };
+
+  const linkHandler: ILinkHandler = {
+    allowNonHttpProtocols: false,
+    activate: () => {
+      // Capture-phase gesture handling owns activation.
+    },
+    hover: (event, url, range) => {
+      const validated = validateTerminalHttpUrl(url);
+      if (!validated) return;
+      handleHover(event, { range, source: "osc", url: validated });
+    },
+    leave: (event, url, range) => {
+      const validated = validateTerminalHttpUrl(url);
+      if (!validated) return;
+      handleLeave(event, { range, source: "osc", url: validated });
+    },
+  };
+
+  return {
+    linkHandler,
+    activate: (activeTerminal) => {
+      if (disposed) throw new Error("Cannot activate a disposed terminal link controller.");
+      terminal = activeTerminal;
+      container.classList.add(LINKS_ENABLED_CLASS);
+      provider = createTerminalHttpLinkProvider(activeTerminal, {
+        activate: () => {
+          // Capture-phase gesture handling owns activation.
+        },
+        hover: handleHover,
+        leave: handleLeave,
+      });
+      subscriptions.push(
+        activeTerminal.registerLinkProvider(provider),
+        activeTerminal.onWriteParsed(reset),
+        activeTerminal.onRender(validateHover),
+        activeTerminal.onResize(reset),
+        activeTerminal.onScroll(reset),
+        activeTerminal.buffer.onBufferChange(reset),
+      );
+      container.addEventListener("mousedown", handleMouseDown, true);
+      container.addEventListener("mouseleave", handleContainerLeave);
+    },
+    reset,
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      if (clickResetHandle !== null) view.clearTimeout(clickResetHandle);
+      clickResetHandle = null;
+      reset();
+      container.classList.remove(LINKS_ENABLED_CLASS);
+      gesture = null;
+      hovered = null;
+      detachGestureWindowListeners();
+      detachHoverWindowListenersIfIdle();
+      detachClickWindowListener();
+      for (const subscription of subscriptions.splice(0)) subscription.dispose();
+      container.removeEventListener("mousedown", handleMouseDown, true);
+      container.removeEventListener("mouseleave", handleContainerLeave);
+      terminal = null;
+      provider = null;
+    },
+  };
+};

--- a/packages/frontend/src/features/terminals/terminal-link-controller.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-controller.ts
@@ -12,11 +12,8 @@ import {
   rangeHasCell,
   sameLink,
 } from "./terminal-link-provider";
+import { LINK_DRAG_PX, LINK_POINTER_CLASS, LINKS_ENABLED_CLASS } from "./constants";
 import { checkHttpUrl } from "./terminal-url-policy";
-
-const LINK_POINTER_CLASS = "odt-terminal-link-pointer";
-const LINKS_ENABLED_CLASS = "odt-terminal-links";
-const DRAG_THRESHOLD_PX = 4;
 
 type LinkPress = {
   startX: number;
@@ -190,7 +187,7 @@ export const createLinkController = ({
     const distance = Math.hypot(event.clientX - press.startX, event.clientY - press.startY);
     const target = readLink(event);
     if (
-      distance > DRAG_THRESHOLD_PX ||
+      distance > LINK_DRAG_PX ||
       !hasOpenKey(event, platform) ||
       !target ||
       !sameLink(target, press.target)
@@ -201,7 +198,7 @@ export const createLinkController = ({
 
   const handleMouseUp = (event: MouseEvent): void => {
     if (!press || event.button !== 0) return;
-    const done = press;
+    const completedPress = press;
     press = null;
     stopDragWatch();
     stopEvent(event);
@@ -215,8 +212,13 @@ export const createLinkController = ({
     }, 0);
 
     const target = readLink(event);
-    if (!done.stopped && hasOpenKey(event, platform) && target && sameLink(target, done.target)) {
-      openLink(done.target);
+    if (
+      !completedPress.stopped &&
+      hasOpenKey(event, platform) &&
+      target &&
+      sameLink(target, completedPress.target)
+    ) {
+      openLink(completedPress.target);
     }
   };
 
@@ -268,9 +270,6 @@ export const createLinkController = ({
       terminal = activeTerminal;
       container.classList.add(LINKS_ENABLED_CLASS);
       provider = createHttpLinkProvider(activeTerminal, {
-        activate: () => {
-          // The capture handler opens links.
-        },
         hover: handleHover,
         leave: handleLeave,
       });
@@ -314,7 +313,7 @@ export function hasOpenKey(
   return isMac(platform) ? event.metaKey : event.ctrlKey;
 }
 
-export function readPointerCell(
+function readPointerCell(
   terminal: Pick<Terminal, "buffer" | "cols" | "element" | "rows">,
   event: Pick<MouseEvent, "clientX" | "clientY">,
 ): IBufferCellPosition | null {

--- a/packages/frontend/src/features/terminals/terminal-link-controller.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-controller.ts
@@ -104,11 +104,13 @@ export const createLinkController = ({
   };
 
   const reset = (): void => {
+    provider?.clear();
     clearHover();
     stopPress();
   };
 
   const checkHover = (): void => {
+    provider?.clear();
     if (hovered?.source !== "plain" || provider?.isCurrent(hovered)) return;
     reset();
   };

--- a/packages/frontend/src/features/terminals/terminal-link-controller.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-controller.ts
@@ -6,53 +6,332 @@ import type {
   Terminal,
 } from "@xterm/xterm";
 import {
-  createTerminalHttpLinkProvider,
-  sameTerminalLinkTarget,
-  terminalRangeContains,
-  type TerminalHttpLinkProvider,
-  type TerminalLinkTarget,
+  createHttpLinkProvider,
+  type HttpLinkProvider,
+  type LinkTarget,
+  rangeHasCell,
+  sameLink,
 } from "./terminal-link-provider";
-import { validateTerminalHttpUrl } from "./terminal-url-policy";
+import { checkHttpUrl } from "./terminal-url-policy";
 
 const LINK_POINTER_CLASS = "odt-terminal-link-pointer";
 const LINKS_ENABLED_CLASS = "odt-terminal-links";
 const DRAG_THRESHOLD_PX = 4;
 
-type TerminalLinkGesture = {
-  cancelled: boolean;
-  originX: number;
-  originY: number;
-  target: TerminalLinkTarget;
+type LinkPress = {
+  startX: number;
+  startY: number;
+  stopped: boolean;
+  target: LinkTarget;
 };
 
-type TerminalLinkControllerInput = {
+type LinkControllerOptions = {
   container: HTMLElement;
   openUrl(url: string): Promise<void>;
   reportOpenError(url: string, cause: unknown): void;
 };
 
-export type TerminalLinkController = ITerminalAddon & {
+export type LinkController = ITerminalAddon & {
   readonly linkHandler: ILinkHandler;
   reset(): void;
 };
 
-const isMacPlatform = (platform: string): boolean => /mac/i.test(platform);
+export const createLinkController = ({
+  container,
+  openUrl,
+  reportOpenError,
+}: LinkControllerOptions): LinkController => {
+  const view = container.ownerDocument.defaultView;
+  if (!view) throw new Error("Cannot create terminal links without a browser window.");
+  const platform = view.navigator.platform;
+  let terminal: Terminal | null = null;
+  let provider: HttpLinkProvider | null = null;
+  let hovered: LinkTarget | null = null;
+  let press: LinkPress | null = null;
+  let blockClick = false;
+  let clickBlockTimer: number | null = null;
+  let disposed = false;
+  let keyWatchActive = false;
+  let dragWatchActive = false;
+  let clickBlockActive = false;
+  const subscriptions: IDisposable[] = [];
 
-export const hasTerminalOpenModifier = (
-  event: Pick<MouseEvent, "ctrlKey" | "metaKey">,
-  platform: string,
-): boolean => (isMacPlatform(platform) ? event.metaKey : event.ctrlKey);
+  const startKeyWatch = (): void => {
+    if (keyWatchActive) return;
+    keyWatchActive = true;
+    view.addEventListener("keydown", handleKeyChange, true);
+    view.addEventListener("keyup", handleKeyChange, true);
+    view.addEventListener("blur", handleBlur);
+  };
 
-const stopTerminalLinkEvent = (event: Event): void => {
-  event.preventDefault();
-  event.stopPropagation();
-  event.stopImmediatePropagation();
+  const stopKeyWatchIfIdle = (): void => {
+    if (!keyWatchActive || hovered || press) return;
+    keyWatchActive = false;
+    view.removeEventListener("keydown", handleKeyChange, true);
+    view.removeEventListener("keyup", handleKeyChange, true);
+    view.removeEventListener("blur", handleBlur);
+  };
+
+  const startDragWatch = (): void => {
+    startKeyWatch();
+    if (dragWatchActive) return;
+    dragWatchActive = true;
+    view.addEventListener("mousemove", handleMouseMove, true);
+    view.addEventListener("mouseup", handleMouseUp, true);
+  };
+
+  const stopDragWatch = (): void => {
+    if (!dragWatchActive) return;
+    dragWatchActive = false;
+    view.removeEventListener("mousemove", handleMouseMove, true);
+    view.removeEventListener("mouseup", handleMouseUp, true);
+    stopKeyWatchIfIdle();
+  };
+
+  const endPress = (): void => {
+    press = null;
+    stopDragWatch();
+  };
+
+  const startClickBlock = (): void => {
+    if (clickBlockActive) return;
+    clickBlockActive = true;
+    view.addEventListener("click", handleClick, true);
+  };
+
+  const stopClickBlock = (): void => {
+    if (!clickBlockActive) return;
+    clickBlockActive = false;
+    view.removeEventListener("click", handleClick, true);
+  };
+
+  const setPointer = (event?: Pick<KeyboardEvent, "ctrlKey" | "metaKey">): void => {
+    const show = hovered !== null && event !== undefined && hasOpenKey(event, platform);
+    container.classList.toggle(LINK_POINTER_CLASS, show);
+  };
+
+  const clearHover = (): void => {
+    hovered = null;
+    container.classList.remove(LINK_POINTER_CLASS);
+    stopKeyWatchIfIdle();
+  };
+
+  const stopPress = (): void => {
+    if (press) press.stopped = true;
+  };
+
+  const reset = (): void => {
+    clearHover();
+    stopPress();
+  };
+
+  const checkHover = (): void => {
+    if (hovered?.source !== "plain" || provider?.isCurrent(hovered)) return;
+    reset();
+  };
+
+  const readLink = (event: MouseEvent): LinkTarget | null => {
+    if (!terminal || !provider) return null;
+    const position = readPointerCell(terminal, event);
+    if (!position) return null;
+    if (
+      hovered?.source === "osc" &&
+      rangeHasCell(hovered.range, position, terminal.cols) &&
+      checkHttpUrl(hovered.url)
+    ) {
+      return hovered;
+    }
+    if (terminal.element?.querySelector(".xterm-screen.xterm-cursor-pointer")) return null;
+    return provider.findLinkAt(position);
+  };
+
+  const findOscLink = (event: MouseEvent): void => {
+    if (hovered || !terminal) return;
+    const screen = terminal.element?.querySelector<HTMLElement>(".xterm-screen");
+    if (!screen) return;
+    // xterm finds OSC 8 links on mousemove. A non-bubbling event keeps it out of mouse tracking.
+    screen.dispatchEvent(
+      new view.MouseEvent("mousemove", {
+        altKey: event.altKey,
+        bubbles: false,
+        cancelable: false,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        ctrlKey: event.ctrlKey,
+        metaKey: event.metaKey,
+        shiftKey: event.shiftKey,
+      }),
+    );
+  };
+
+  const openLink = (target: LinkTarget): void => {
+    void openUrl(target.url).catch((cause) => {
+      if (!disposed) reportOpenError(target.url, cause);
+    });
+  };
+
+  const handleHover = (event: MouseEvent, target: LinkTarget): void => {
+    if (disposed) return;
+    hovered = target;
+    startKeyWatch();
+    setPointer(event);
+  };
+
+  const handleLeave = (_event: MouseEvent, target: LinkTarget): void => {
+    if (!hovered || !sameLink(hovered, target)) return;
+    clearHover();
+    stopPress();
+  };
+
+  const handleMouseDown = (event: MouseEvent): void => {
+    if (event.button !== 0 || !hasOpenKey(event, platform)) return;
+    findOscLink(event);
+    const target = readLink(event);
+    if (!target) return;
+    press = {
+      startX: event.clientX,
+      startY: event.clientY,
+      stopped: false,
+      target,
+    };
+    startDragWatch();
+    stopEvent(event);
+  };
+
+  const handleMouseMove = (event: MouseEvent): void => {
+    if (!press) return;
+    stopEvent(event);
+    const distance = Math.hypot(event.clientX - press.startX, event.clientY - press.startY);
+    const target = readLink(event);
+    if (
+      distance > DRAG_THRESHOLD_PX ||
+      !hasOpenKey(event, platform) ||
+      !target ||
+      !sameLink(target, press.target)
+    ) {
+      stopPress();
+    }
+  };
+
+  const handleMouseUp = (event: MouseEvent): void => {
+    if (!press || event.button !== 0) return;
+    const done = press;
+    press = null;
+    stopDragWatch();
+    stopEvent(event);
+    blockClick = true;
+    startClickBlock();
+    if (clickBlockTimer !== null) view.clearTimeout(clickBlockTimer);
+    clickBlockTimer = view.setTimeout(() => {
+      blockClick = false;
+      clickBlockTimer = null;
+      stopClickBlock();
+    }, 0);
+
+    const target = readLink(event);
+    if (!done.stopped && hasOpenKey(event, platform) && target && sameLink(target, done.target)) {
+      openLink(done.target);
+    }
+  };
+
+  const handleClick = (event: MouseEvent): void => {
+    if (!blockClick) return;
+    blockClick = false;
+    if (clickBlockTimer !== null) view.clearTimeout(clickBlockTimer);
+    clickBlockTimer = null;
+    stopClickBlock();
+    stopEvent(event);
+  };
+
+  const handleKeyChange = (event: KeyboardEvent): void => {
+    setPointer(event);
+    if (press && !hasOpenKey(event, platform)) stopPress();
+  };
+
+  const handleBlur = (): void => {
+    clearHover();
+    endPress();
+  };
+
+  const handleContainerLeave = (): void => {
+    clearHover();
+    stopPress();
+  };
+
+  const linkHandler: ILinkHandler = {
+    allowNonHttpProtocols: false,
+    activate: () => {
+      // The capture handler opens links.
+    },
+    hover: (event, url, range) => {
+      const href = checkHttpUrl(url);
+      if (!href) return;
+      handleHover(event, { range, source: "osc", url: href });
+    },
+    leave: (event, url, range) => {
+      const href = checkHttpUrl(url);
+      if (!href) return;
+      handleLeave(event, { range, source: "osc", url: href });
+    },
+  };
+
+  return {
+    linkHandler,
+    activate: (activeTerminal) => {
+      if (disposed) throw new Error("Cannot activate a disposed terminal link controller.");
+      terminal = activeTerminal;
+      container.classList.add(LINKS_ENABLED_CLASS);
+      provider = createHttpLinkProvider(activeTerminal, {
+        activate: () => {
+          // The capture handler opens links.
+        },
+        hover: handleHover,
+        leave: handleLeave,
+      });
+      subscriptions.push(
+        activeTerminal.registerLinkProvider(provider),
+        activeTerminal.onWriteParsed(reset),
+        activeTerminal.onRender(checkHover),
+        activeTerminal.onResize(reset),
+        activeTerminal.onScroll(reset),
+        activeTerminal.buffer.onBufferChange(reset),
+      );
+      container.addEventListener("mousedown", handleMouseDown, true);
+      container.addEventListener("mouseleave", handleContainerLeave);
+    },
+    reset,
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      if (clickBlockTimer !== null) view.clearTimeout(clickBlockTimer);
+      clickBlockTimer = null;
+      reset();
+      container.classList.remove(LINKS_ENABLED_CLASS);
+      press = null;
+      hovered = null;
+      stopDragWatch();
+      stopKeyWatchIfIdle();
+      stopClickBlock();
+      for (const subscription of subscriptions.splice(0)) subscription.dispose();
+      container.removeEventListener("mousedown", handleMouseDown, true);
+      container.removeEventListener("mouseleave", handleContainerLeave);
+      terminal = null;
+      provider = null;
+    },
+  };
 };
 
-export const readTerminalPointerPosition = (
+export function hasOpenKey(
+  event: Pick<MouseEvent, "ctrlKey" | "metaKey">,
+  platform: string,
+): boolean {
+  return isMac(platform) ? event.metaKey : event.ctrlKey;
+}
+
+export function readPointerCell(
   terminal: Pick<Terminal, "buffer" | "cols" | "element" | "rows">,
   event: Pick<MouseEvent, "clientX" | "clientY">,
-): IBufferCellPosition | null => {
+): IBufferCellPosition | null {
   const screen = terminal.element?.querySelector<HTMLElement>(".xterm-screen");
   if (!screen || terminal.cols < 1 || terminal.rows < 1) return null;
   const rect = screen.getBoundingClientRect();
@@ -74,296 +353,14 @@ export const readTerminalPointerPosition = (
       Math.floor(((event.clientY - rect.top) / rect.height) * terminal.rows) +
       1,
   };
-};
+}
 
-export const createTerminalLinkController = ({
-  container,
-  openUrl,
-  reportOpenError,
-}: TerminalLinkControllerInput): TerminalLinkController => {
-  const view = container.ownerDocument.defaultView;
-  if (!view) throw new Error("Cannot create terminal links without a browser window.");
-  const platform = view.navigator.platform;
-  let terminal: Terminal | null = null;
-  let provider: TerminalHttpLinkProvider | null = null;
-  let hovered: TerminalLinkTarget | null = null;
-  let gesture: TerminalLinkGesture | null = null;
-  let suppressClick = false;
-  let clickResetHandle: number | null = null;
-  let disposed = false;
-  let hoverWindowListenersAttached = false;
-  let gestureWindowListenersAttached = false;
-  let clickWindowListenerAttached = false;
-  const subscriptions: IDisposable[] = [];
+function isMac(platform: string): boolean {
+  return /mac/i.test(platform);
+}
 
-  const attachHoverWindowListeners = (): void => {
-    if (hoverWindowListenersAttached) return;
-    hoverWindowListenersAttached = true;
-    view.addEventListener("keydown", handleKeyChange, true);
-    view.addEventListener("keyup", handleKeyChange, true);
-    view.addEventListener("blur", handleBlur);
-  };
-
-  const detachHoverWindowListenersIfIdle = (): void => {
-    if (!hoverWindowListenersAttached || hovered || gesture) return;
-    hoverWindowListenersAttached = false;
-    view.removeEventListener("keydown", handleKeyChange, true);
-    view.removeEventListener("keyup", handleKeyChange, true);
-    view.removeEventListener("blur", handleBlur);
-  };
-
-  const attachGestureWindowListeners = (): void => {
-    attachHoverWindowListeners();
-    if (gestureWindowListenersAttached) return;
-    gestureWindowListenersAttached = true;
-    view.addEventListener("mousemove", handleMouseMove, true);
-    view.addEventListener("mouseup", handleMouseUp, true);
-  };
-
-  const detachGestureWindowListeners = (): void => {
-    if (!gestureWindowListenersAttached) return;
-    gestureWindowListenersAttached = false;
-    view.removeEventListener("mousemove", handleMouseMove, true);
-    view.removeEventListener("mouseup", handleMouseUp, true);
-    detachHoverWindowListenersIfIdle();
-  };
-
-  const abortGesture = (): void => {
-    gesture = null;
-    detachGestureWindowListeners();
-  };
-
-  const attachClickWindowListener = (): void => {
-    if (clickWindowListenerAttached) return;
-    clickWindowListenerAttached = true;
-    view.addEventListener("click", handleClick, true);
-  };
-
-  const detachClickWindowListener = (): void => {
-    if (!clickWindowListenerAttached) return;
-    clickWindowListenerAttached = false;
-    view.removeEventListener("click", handleClick, true);
-  };
-
-  const updatePointer = (event?: Pick<KeyboardEvent, "ctrlKey" | "metaKey">): void => {
-    const openable =
-      hovered !== null && event !== undefined && hasTerminalOpenModifier(event, platform);
-    container.classList.toggle(LINK_POINTER_CLASS, openable);
-  };
-
-  const clearHover = (): void => {
-    hovered = null;
-    container.classList.remove(LINK_POINTER_CLASS);
-    detachHoverWindowListenersIfIdle();
-  };
-
-  const cancelGesture = (): void => {
-    if (gesture) gesture.cancelled = true;
-  };
-
-  const reset = (): void => {
-    clearHover();
-    cancelGesture();
-  };
-
-  const validateHover = (): void => {
-    if (hovered?.source !== "plain" || provider?.isCurrent(hovered)) return;
-    reset();
-  };
-
-  const readTargetAt = (event: MouseEvent): TerminalLinkTarget | null => {
-    if (!terminal || !provider) return null;
-    const position = readTerminalPointerPosition(terminal, event);
-    if (!position) return null;
-    if (
-      hovered?.source === "osc" &&
-      terminalRangeContains(hovered.range, position, terminal.cols) &&
-      validateTerminalHttpUrl(hovered.url)
-    ) {
-      return hovered;
-    }
-    if (terminal.element?.querySelector(".xterm-screen.xterm-cursor-pointer")) return null;
-    return provider.findLinkAt(position);
-  };
-
-  const refreshLinkHover = (event: MouseEvent): void => {
-    if (hovered || !terminal) return;
-    const screen = terminal.element?.querySelector<HTMLElement>(".xterm-screen");
-    if (!screen) return;
-    // xterm resolves OSC 8 links on mousemove. Keep this event on the screen so it cannot reach
-    // terminal mouse tracking on the parent element.
-    screen.dispatchEvent(
-      new view.MouseEvent("mousemove", {
-        altKey: event.altKey,
-        bubbles: false,
-        cancelable: false,
-        clientX: event.clientX,
-        clientY: event.clientY,
-        ctrlKey: event.ctrlKey,
-        metaKey: event.metaKey,
-        shiftKey: event.shiftKey,
-      }),
-    );
-  };
-
-  const openTarget = (target: TerminalLinkTarget): void => {
-    void openUrl(target.url).catch((cause) => {
-      if (!disposed) reportOpenError(target.url, cause);
-    });
-  };
-
-  const handleHover = (event: MouseEvent, target: TerminalLinkTarget): void => {
-    if (disposed) return;
-    hovered = target;
-    attachHoverWindowListeners();
-    updatePointer(event);
-  };
-
-  const handleLeave = (_event: MouseEvent, target: TerminalLinkTarget): void => {
-    if (!hovered || !sameTerminalLinkTarget(hovered, target)) return;
-    clearHover();
-    cancelGesture();
-  };
-
-  const handleMouseDown = (event: MouseEvent): void => {
-    if (event.button !== 0 || !hasTerminalOpenModifier(event, platform)) return;
-    refreshLinkHover(event);
-    const target = readTargetAt(event);
-    if (!target) return;
-    gesture = {
-      cancelled: false,
-      originX: event.clientX,
-      originY: event.clientY,
-      target,
-    };
-    attachGestureWindowListeners();
-    stopTerminalLinkEvent(event);
-  };
-
-  const handleMouseMove = (event: MouseEvent): void => {
-    if (!gesture) return;
-    stopTerminalLinkEvent(event);
-    const distance = Math.hypot(event.clientX - gesture.originX, event.clientY - gesture.originY);
-    const target = readTargetAt(event);
-    if (
-      distance > DRAG_THRESHOLD_PX ||
-      !hasTerminalOpenModifier(event, platform) ||
-      !target ||
-      !sameTerminalLinkTarget(target, gesture.target)
-    ) {
-      cancelGesture();
-    }
-  };
-
-  const handleMouseUp = (event: MouseEvent): void => {
-    if (!gesture || event.button !== 0) return;
-    const completedGesture = gesture;
-    gesture = null;
-    detachGestureWindowListeners();
-    stopTerminalLinkEvent(event);
-    suppressClick = true;
-    attachClickWindowListener();
-    if (clickResetHandle !== null) view.clearTimeout(clickResetHandle);
-    clickResetHandle = view.setTimeout(() => {
-      suppressClick = false;
-      clickResetHandle = null;
-      detachClickWindowListener();
-    }, 0);
-
-    const target = readTargetAt(event);
-    if (
-      !completedGesture.cancelled &&
-      hasTerminalOpenModifier(event, platform) &&
-      target &&
-      sameTerminalLinkTarget(target, completedGesture.target)
-    ) {
-      openTarget(completedGesture.target);
-    }
-  };
-
-  const handleClick = (event: MouseEvent): void => {
-    if (!suppressClick) return;
-    suppressClick = false;
-    if (clickResetHandle !== null) view.clearTimeout(clickResetHandle);
-    clickResetHandle = null;
-    detachClickWindowListener();
-    stopTerminalLinkEvent(event);
-  };
-
-  const handleKeyChange = (event: KeyboardEvent): void => {
-    updatePointer(event);
-    if (gesture && !hasTerminalOpenModifier(event, platform)) cancelGesture();
-  };
-
-  const handleBlur = (): void => {
-    clearHover();
-    abortGesture();
-  };
-
-  const handleContainerLeave = (): void => {
-    clearHover();
-    cancelGesture();
-  };
-
-  const linkHandler: ILinkHandler = {
-    allowNonHttpProtocols: false,
-    activate: () => {
-      // Capture-phase gesture handling owns activation.
-    },
-    hover: (event, url, range) => {
-      const validated = validateTerminalHttpUrl(url);
-      if (!validated) return;
-      handleHover(event, { range, source: "osc", url: validated });
-    },
-    leave: (event, url, range) => {
-      const validated = validateTerminalHttpUrl(url);
-      if (!validated) return;
-      handleLeave(event, { range, source: "osc", url: validated });
-    },
-  };
-
-  return {
-    linkHandler,
-    activate: (activeTerminal) => {
-      if (disposed) throw new Error("Cannot activate a disposed terminal link controller.");
-      terminal = activeTerminal;
-      container.classList.add(LINKS_ENABLED_CLASS);
-      provider = createTerminalHttpLinkProvider(activeTerminal, {
-        activate: () => {
-          // Capture-phase gesture handling owns activation.
-        },
-        hover: handleHover,
-        leave: handleLeave,
-      });
-      subscriptions.push(
-        activeTerminal.registerLinkProvider(provider),
-        activeTerminal.onWriteParsed(reset),
-        activeTerminal.onRender(validateHover),
-        activeTerminal.onResize(reset),
-        activeTerminal.onScroll(reset),
-        activeTerminal.buffer.onBufferChange(reset),
-      );
-      container.addEventListener("mousedown", handleMouseDown, true);
-      container.addEventListener("mouseleave", handleContainerLeave);
-    },
-    reset,
-    dispose: () => {
-      if (disposed) return;
-      disposed = true;
-      if (clickResetHandle !== null) view.clearTimeout(clickResetHandle);
-      clickResetHandle = null;
-      reset();
-      container.classList.remove(LINKS_ENABLED_CLASS);
-      gesture = null;
-      hovered = null;
-      detachGestureWindowListeners();
-      detachHoverWindowListenersIfIdle();
-      detachClickWindowListener();
-      for (const subscription of subscriptions.splice(0)) subscription.dispose();
-      container.removeEventListener("mousedown", handleMouseDown, true);
-      container.removeEventListener("mouseleave", handleContainerLeave);
-      terminal = null;
-      provider = null;
-    },
-  };
-};
+function stopEvent(event: Event): void {
+  event.preventDefault();
+  event.stopPropagation();
+  event.stopImmediatePropagation();
+}

--- a/packages/frontend/src/features/terminals/terminal-link-controller.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-controller.ts
@@ -128,6 +128,11 @@ export const createTerminalLinkController = ({
     detachHoverWindowListenersIfIdle();
   };
 
+  const abortGesture = (): void => {
+    gesture = null;
+    detachGestureWindowListeners();
+  };
+
   const attachClickWindowListener = (): void => {
     if (clickWindowListenerAttached) return;
     clickWindowListenerAttached = true;
@@ -177,7 +182,28 @@ export const createTerminalLinkController = ({
     ) {
       return hovered;
     }
+    if (terminal.element?.querySelector(".xterm-screen.xterm-cursor-pointer")) return null;
     return provider.findLinkAt(position);
+  };
+
+  const refreshLinkHover = (event: MouseEvent): void => {
+    if (hovered || !terminal) return;
+    const screen = terminal.element?.querySelector<HTMLElement>(".xterm-screen");
+    if (!screen) return;
+    // xterm resolves OSC 8 links on mousemove. Keep this event on the screen so it cannot reach
+    // terminal mouse tracking on the parent element.
+    screen.dispatchEvent(
+      new view.MouseEvent("mousemove", {
+        altKey: event.altKey,
+        bubbles: false,
+        cancelable: false,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        ctrlKey: event.ctrlKey,
+        metaKey: event.metaKey,
+        shiftKey: event.shiftKey,
+      }),
+    );
   };
 
   const openTarget = (target: TerminalLinkTarget): void => {
@@ -201,6 +227,7 @@ export const createTerminalLinkController = ({
 
   const handleMouseDown = (event: MouseEvent): void => {
     if (event.button !== 0 || !hasTerminalOpenModifier(event, platform)) return;
+    refreshLinkHover(event);
     const target = readTargetAt(event);
     if (!target) return;
     gesture = {
@@ -269,7 +296,8 @@ export const createTerminalLinkController = ({
   };
 
   const handleBlur = (): void => {
-    reset();
+    clearHover();
+    abortGesture();
   };
 
   const handleContainerLeave = (): void => {

--- a/packages/frontend/src/features/terminals/terminal-link-provider.test.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-provider.test.ts
@@ -49,7 +49,6 @@ const readTerminalLinksForBufferLine = (
   row: number,
 ): ILink[] => {
   const provider = createHttpLinkProvider(terminal, {
-    activate: () => undefined,
     hover: () => undefined,
     leave: () => undefined,
   });

--- a/packages/frontend/src/features/terminals/terminal-link-provider.test.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import type { IBufferCell, IBufferLine, ILink, Terminal } from "@xterm/xterm";
 import { createHttpLinkProvider } from "./terminal-link-provider";
 
@@ -32,10 +32,11 @@ const createTextLine = (text: string, columns: number, isWrapped: boolean): IBuf
 const createTerminal = (
   lines: IBufferLine[],
   columns: number,
+  getLine = (row: number): IBufferLine | undefined => lines[row],
 ): Pick<Terminal, "buffer" | "cols"> => {
   const active = {
     length: lines.length,
-    getLine: (row: number) => lines[row],
+    getLine,
   };
   return {
     cols: columns,
@@ -110,6 +111,35 @@ describe("terminal HTTP link provider", () => {
     expect(readTerminalLinksForBufferLine(terminal, 2).map((link) => link.text)).toEqual([
       "https://two.test",
     ]);
+  });
+
+  test("reuses a wrapped line until the provider is cleared", () => {
+    const columns = 16;
+    const lines = [
+      createTextLine("https://example.", columns, false),
+      createTextLine("test/path", columns, true),
+    ];
+    const getLine = mock((row: number) => lines[row]);
+    const provider = createHttpLinkProvider(createTerminal(lines, columns, getLine), {
+      hover: () => undefined,
+      leave: () => undefined,
+    });
+    const readRow = (row: number): ILink[] => {
+      let links: ILink[] | undefined;
+      provider.provideLinks(row, (provided) => {
+        links = provided;
+      });
+      return links ?? [];
+    };
+
+    expect(readRow(1).map((link) => link.text)).toEqual(["https://example.test/path"]);
+    const firstReadCount = getLine.mock.calls.length;
+    expect(readRow(2).map((link) => link.text)).toEqual(["https://example.test/path"]);
+    expect(getLine).toHaveBeenCalledTimes(firstReadCount);
+
+    provider.clear();
+    expect(readRow(2).map((link) => link.text)).toEqual(["https://example.test/path"]);
+    expect(getLine.mock.calls.length).toBeGreaterThan(firstReadCount);
   });
 
   test("accounts for wide and combining cells before a link", () => {

--- a/packages/frontend/src/features/terminals/terminal-link-provider.test.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-provider.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import type { IBufferCell, IBufferLine, Terminal } from "@xterm/xterm";
-import { readTerminalLinksForBufferLine } from "./terminal-link-provider";
+import type { IBufferCell, IBufferLine, ILink, Terminal } from "@xterm/xterm";
+import { createTerminalHttpLinkProvider } from "./terminal-link-provider";
 
 type TestCell = Pick<IBufferCell, "getChars" | "getCode" | "getWidth">;
 
@@ -44,6 +44,22 @@ const createTerminal = (
   };
 };
 
+const readTerminalLinksForBufferLine = (
+  terminal: Pick<Terminal, "buffer" | "cols">,
+  row: number,
+): ILink[] => {
+  const provider = createTerminalHttpLinkProvider(terminal, {
+    activate: () => undefined,
+    hover: () => undefined,
+    leave: () => undefined,
+  });
+  let links: ILink[] | undefined;
+  provider.provideLinks(row, (provided) => {
+    links = provided;
+  });
+  return links ?? [];
+};
+
 describe("terminal HTTP link provider", () => {
   test("joins soft-wrapped rows and maps the complete URL to terminal cells", () => {
     const columns = 12;
@@ -58,16 +74,11 @@ describe("terminal HTTP link provider", () => {
 
     const links = readTerminalLinksForBufferLine(terminal, 2);
 
-    expect(links).toEqual([
-      {
-        source: "plain",
-        url: "https://example.com/a?x=1",
-        range: {
-          start: { x: 4, y: 1 },
-          end: { x: 4, y: 3 },
-        },
-      },
-    ]);
+    expect(links[0]?.text).toBe("https://example.com/a?x=1");
+    expect(links[0]?.range).toEqual({
+      start: { x: 4, y: 1 },
+      end: { x: 4, y: 3 },
+    });
   });
 
   test("does not join separate logical lines", () => {
@@ -80,7 +91,7 @@ describe("terminal HTTP link provider", () => {
       columns,
     );
 
-    expect(readTerminalLinksForBufferLine(terminal, 1)[0]?.url).toBe("https://one.test");
+    expect(readTerminalLinksForBufferLine(terminal, 1)[0]?.text).toBe("https://one.test");
     expect(readTerminalLinksForBufferLine(terminal, 2)).toEqual([]);
   });
 

--- a/packages/frontend/src/features/terminals/terminal-link-provider.test.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-provider.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { IBufferCell, IBufferLine, ILink, Terminal } from "@xterm/xterm";
-import { createTerminalHttpLinkProvider } from "./terminal-link-provider";
+import { createHttpLinkProvider } from "./terminal-link-provider";
 
 type TestCell = Pick<IBufferCell, "getChars" | "getCode" | "getWidth">;
 
@@ -16,7 +16,7 @@ const createLine = (cells: TestCell[], columns: number, isWrapped: boolean): IBu
   return {
     isWrapped,
     length: padded.length,
-    // SAFETY: The provider only reads the three IBufferCell methods implemented by TestCell.
+    // SAFETY: The provider reads only the three cell methods in TestCell.
     getCell: (column) => padded[column] as IBufferCell | undefined,
     translateToString: () => "",
   };
@@ -39,7 +39,7 @@ const createTerminal = (
   };
   return {
     cols: columns,
-    // SAFETY: The provider only reads active.length and active.getLine from this buffer fake.
+    // SAFETY: The provider reads only active.length and active.getLine from this fake.
     buffer: { active } as Terminal["buffer"],
   };
 };
@@ -48,7 +48,7 @@ const readTerminalLinksForBufferLine = (
   terminal: Pick<Terminal, "buffer" | "cols">,
   row: number,
 ): ILink[] => {
-  const provider = createTerminalHttpLinkProvider(terminal, {
+  const provider = createHttpLinkProvider(terminal, {
     activate: () => undefined,
     hover: () => undefined,
     leave: () => undefined,

--- a/packages/frontend/src/features/terminals/terminal-link-provider.test.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-provider.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import type { IBufferCell, IBufferLine, Terminal } from "@xterm/xterm";
+import { readTerminalLinksForBufferLine } from "./terminal-link-provider";
+
+type TestCell = Pick<IBufferCell, "getChars" | "getCode" | "getWidth">;
+
+const createCell = (value: string, width = 1): TestCell => ({
+  getChars: () => value,
+  getCode: () => (value.length > 0 ? (value.codePointAt(0) ?? 0) : 0),
+  getWidth: () => width,
+});
+
+const createLine = (cells: TestCell[], columns: number, isWrapped: boolean): IBufferLine => {
+  const padded = [...cells];
+  while (padded.length < columns) padded.push(createCell(""));
+  return {
+    isWrapped,
+    length: padded.length,
+    // SAFETY: The provider only reads the three IBufferCell methods implemented by TestCell.
+    getCell: (column) => padded[column] as IBufferCell | undefined,
+    translateToString: () => "",
+  };
+};
+
+const createTextLine = (text: string, columns: number, isWrapped: boolean): IBufferLine =>
+  createLine(
+    Array.from(text, (character) => createCell(character)),
+    columns,
+    isWrapped,
+  );
+
+const createTerminal = (
+  lines: IBufferLine[],
+  columns: number,
+): Pick<Terminal, "buffer" | "cols"> => {
+  const active = {
+    length: lines.length,
+    getLine: (row: number) => lines[row],
+  };
+  return {
+    cols: columns,
+    // SAFETY: The provider only reads active.length and active.getLine from this buffer fake.
+    buffer: { active } as Terminal["buffer"],
+  };
+};
+
+describe("terminal HTTP link provider", () => {
+  test("joins soft-wrapped rows and maps the complete URL to terminal cells", () => {
+    const columns = 12;
+    const terminal = createTerminal(
+      [
+        createTextLine("go https://e", columns, false),
+        createTextLine("xample.com/a", columns, true),
+        createTextLine("?x=1", columns, true),
+      ],
+      columns,
+    );
+
+    const links = readTerminalLinksForBufferLine(terminal, 2);
+
+    expect(links).toEqual([
+      {
+        source: "plain",
+        url: "https://example.com/a?x=1",
+        range: {
+          start: { x: 4, y: 1 },
+          end: { x: 4, y: 3 },
+        },
+      },
+    ]);
+  });
+
+  test("does not join separate logical lines", () => {
+    const columns = 24;
+    const terminal = createTerminal(
+      [
+        createTextLine("https://one.test", columns, false),
+        createTextLine("/not-part-of-the-link", columns, false),
+      ],
+      columns,
+    );
+
+    expect(readTerminalLinksForBufferLine(terminal, 1)[0]?.url).toBe("https://one.test");
+    expect(readTerminalLinksForBufferLine(terminal, 2)).toEqual([]);
+  });
+
+  test("accounts for wide and combining cells before a link", () => {
+    const cells = [
+      createCell("界", 2),
+      createCell("", 0),
+      createCell("e\u0301"),
+      createCell(" "),
+      ...Array.from("https://a.test", (character) => createCell(character)),
+    ];
+    const terminal = createTerminal([createLine(cells, cells.length, false)], cells.length);
+
+    expect(readTerminalLinksForBufferLine(terminal, 1)[0]?.range).toEqual({
+      start: { x: 5, y: 1 },
+      end: { x: 18, y: 1 },
+    });
+  });
+});

--- a/packages/frontend/src/features/terminals/terminal-link-provider.test.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-provider.test.ts
@@ -95,6 +95,24 @@ describe("terminal HTTP link provider", () => {
     expect(readTerminalLinksForBufferLine(terminal, 2)).toEqual([]);
   });
 
+  test("returns only links that cross the requested row", () => {
+    const columns = 20;
+    const terminal = createTerminal(
+      [
+        createTextLine("https://one.test", columns, false),
+        createTextLine("https://two.test", columns, true),
+      ],
+      columns,
+    );
+
+    expect(readTerminalLinksForBufferLine(terminal, 1).map((link) => link.text)).toEqual([
+      "https://one.test",
+    ]);
+    expect(readTerminalLinksForBufferLine(terminal, 2).map((link) => link.text)).toEqual([
+      "https://two.test",
+    ]);
+  });
+
   test("accounts for wide and combining cells before a link", () => {
     const cells = [
       createCell("界", 2),

--- a/packages/frontend/src/features/terminals/terminal-link-provider.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-provider.ts
@@ -25,7 +25,6 @@ type LogicalLine = {
 };
 
 type LinkCallbacks = {
-  activate(event: MouseEvent, target: LinkTarget): void;
   hover(event: MouseEvent, target: LinkTarget): void;
   leave(event: MouseEvent, target: LinkTarget): void;
 };
@@ -50,7 +49,9 @@ export const createHttpLinkProvider = (
         text: target.url,
         range: target.range,
         decorations: { pointerCursor: false, underline: true },
-        activate: (event) => callbacks.activate(event, target),
+        activate: () => {
+          // The capture handler opens links.
+        },
         hover: (event) => callbacks.hover(event, target),
         leave: (event) => callbacks.leave(event, target),
       }));

--- a/packages/frontend/src/features/terminals/terminal-link-provider.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-provider.ts
@@ -21,7 +21,15 @@ type LogicalCell = {
 
 type LogicalLine = {
   cells: LogicalCell[];
+  firstRow: number;
+  lastRow: number;
   text: string;
+};
+
+type LineLinks = {
+  firstRow: number;
+  lastRow: number;
+  targets: LinkTarget[];
 };
 
 type LinkCallbacks = {
@@ -30,6 +38,7 @@ type LinkCallbacks = {
 };
 
 export type HttpLinkProvider = ILinkProvider & {
+  clear(): void;
   findLinkAt(position: IBufferCellPosition): LinkTarget | null;
   isCurrent(target: LinkTarget): boolean;
 };
@@ -38,9 +47,19 @@ export const createHttpLinkProvider = (
   terminal: Pick<Terminal, "buffer" | "cols">,
   callbacks: LinkCallbacks,
 ): HttpLinkProvider => {
-  const readRow = (row: number): LinkTarget[] => readLinks(terminal, row);
+  let lastRead: LineLinks | null = null;
+  const readRow = (row: number): LinkTarget[] => {
+    if (lastRead && lastRead.firstRow <= row && row <= lastRead.lastRow) {
+      return lastRead.targets;
+    }
+    lastRead = readLinks(terminal, row);
+    return lastRead.targets;
+  };
 
   return {
+    clear: () => {
+      lastRead = null;
+    },
     provideLinks: (row, callback) => {
       const targets = readRow(row).filter(
         ({ range }) => range.start.y <= row && row <= range.end.y,
@@ -123,7 +142,7 @@ function readLogicalLine(terminal: Pick<Terminal, "buffer" | "cols">, row: numbe
       });
     }
   }
-  return { cells, text };
+  return { cells, firstRow: firstRow + 1, lastRow: lastRow + 1, text };
 }
 
 function findCellRange(
@@ -137,11 +156,14 @@ function findCellRange(
   return { start: first.range.start, end: last.range.end };
 }
 
-function readLinks(terminal: Pick<Terminal, "buffer" | "cols">, row: number): LinkTarget[] {
-  if (row < 1 || row > terminal.buffer.active.length) return [];
+function readLinks(terminal: Pick<Terminal, "buffer" | "cols">, row: number): LineLinks {
+  if (row < 1 || row > terminal.buffer.active.length) {
+    return { firstRow: row, lastRow: row, targets: [] };
+  }
   const line = readLogicalLine(terminal, row);
-  return findHttpUrls(line.text).flatMap((match) => {
+  const targets = findHttpUrls(line.text).flatMap((match) => {
     const range = findCellRange(line.cells, match.start, match.end);
     return range ? [{ range, source: "plain" as const, url: match.url }] : [];
   });
+  return { firstRow: line.firstRow, lastRow: line.lastRow, targets };
 }

--- a/packages/frontend/src/features/terminals/terminal-link-provider.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-provider.ts
@@ -43,7 +43,9 @@ export const createHttpLinkProvider = (
 
   return {
     provideLinks: (row, callback) => {
-      const targets = readRow(row);
+      const targets = readRow(row).filter(
+        ({ range }) => range.start.y <= row && row <= range.end.y,
+      );
       const links: ILink[] = targets.map((target) => ({
         text: target.url,
         range: target.range,

--- a/packages/frontend/src/features/terminals/terminal-link-provider.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-provider.ts
@@ -105,7 +105,7 @@ const findCellRange = (
   return { start: first.range.start, end: last.range.end };
 };
 
-export const readTerminalLinksForBufferLine = (
+const readTerminalLinksForBufferLine = (
   terminal: Pick<Terminal, "buffer" | "cols">,
   row: number,
 ): TerminalLinkTarget[] => {

--- a/packages/frontend/src/features/terminals/terminal-link-provider.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-provider.ts
@@ -1,0 +1,152 @@
+import type {
+  IBufferCellPosition,
+  IBufferRange,
+  ILink,
+  ILinkProvider,
+  Terminal,
+} from "@xterm/xterm";
+import { findTerminalHttpUrls } from "./terminal-url-policy";
+
+export type TerminalLinkTarget = {
+  range: IBufferRange;
+  source: "osc" | "plain";
+  url: string;
+};
+
+type LogicalCell = {
+  endOffset: number;
+  range: IBufferRange;
+  startOffset: number;
+};
+
+type LogicalLine = {
+  cells: LogicalCell[];
+  text: string;
+};
+
+type TerminalLinkCallbacks = {
+  activate(event: MouseEvent, target: TerminalLinkTarget): void;
+  hover(event: MouseEvent, target: TerminalLinkTarget): void;
+  leave(event: MouseEvent, target: TerminalLinkTarget): void;
+};
+
+const samePosition = (left: IBufferCellPosition, right: IBufferCellPosition): boolean =>
+  left.x === right.x && left.y === right.y;
+
+export const sameTerminalLinkTarget = (
+  left: TerminalLinkTarget,
+  right: TerminalLinkTarget,
+): boolean =>
+  left.url === right.url &&
+  left.source === right.source &&
+  samePosition(left.range.start, right.range.start) &&
+  samePosition(left.range.end, right.range.end);
+
+export const terminalRangeContains = (
+  range: IBufferRange,
+  position: IBufferCellPosition,
+  columns: number,
+): boolean => {
+  const lower = range.start.y * columns + range.start.x;
+  const upper = range.end.y * columns + range.end.x;
+  const current = position.y * columns + position.x;
+  return lower <= current && current <= upper;
+};
+
+const readLogicalLine = (terminal: Pick<Terminal, "buffer" | "cols">, row: number): LogicalLine => {
+  const buffer = terminal.buffer.active;
+  let firstRow = row - 1;
+  while (firstRow > 0 && buffer.getLine(firstRow)?.isWrapped) firstRow -= 1;
+
+  let lastRow = row - 1;
+  while (lastRow + 1 < buffer.length && buffer.getLine(lastRow + 1)?.isWrapped) lastRow += 1;
+
+  let text = "";
+  const cells: LogicalCell[] = [];
+  for (let bufferRow = firstRow; bufferRow <= lastRow; bufferRow += 1) {
+    const line = buffer.getLine(bufferRow);
+    if (!line) continue;
+    const cellCount = Math.min(line.length, terminal.cols);
+    for (let column = 0; column < cellCount; column += 1) {
+      const cell = line.getCell(column);
+      if (!cell || cell.getWidth() === 0) continue;
+
+      const isSoftWrapPadding =
+        bufferRow < lastRow &&
+        column === cellCount - 1 &&
+        cell.getChars().length === 0 &&
+        cell.getCode() === 0;
+      if (isSoftWrapPadding) continue;
+
+      const value = cell.getChars() || " ";
+      const startOffset = text.length;
+      text += value;
+      cells.push({
+        startOffset,
+        endOffset: text.length,
+        range: {
+          start: { x: column + 1, y: bufferRow + 1 },
+          end: { x: column + cell.getWidth(), y: bufferRow + 1 },
+        },
+      });
+    }
+  }
+  return { cells, text };
+};
+
+const findCellRange = (
+  cells: readonly LogicalCell[],
+  startOffset: number,
+  endOffset: number,
+): IBufferRange | null => {
+  const first = cells.find((cell) => cell.endOffset > startOffset);
+  const last = cells.findLast((cell) => cell.startOffset < endOffset);
+  if (!first || !last) return null;
+  return { start: first.range.start, end: last.range.end };
+};
+
+export const readTerminalLinksForBufferLine = (
+  terminal: Pick<Terminal, "buffer" | "cols">,
+  row: number,
+): TerminalLinkTarget[] => {
+  if (row < 1 || row > terminal.buffer.active.length) return [];
+  const logicalLine = readLogicalLine(terminal, row);
+  return findTerminalHttpUrls(logicalLine.text).flatMap((match) => {
+    const range = findCellRange(logicalLine.cells, match.start, match.end);
+    return range ? [{ range, source: "plain" as const, url: match.url }] : [];
+  });
+};
+
+export type TerminalHttpLinkProvider = ILinkProvider & {
+  findLinkAt(position: IBufferCellPosition): TerminalLinkTarget | null;
+  isCurrent(target: TerminalLinkTarget): boolean;
+};
+
+export const createTerminalHttpLinkProvider = (
+  terminal: Pick<Terminal, "buffer" | "cols">,
+  callbacks: TerminalLinkCallbacks,
+): TerminalHttpLinkProvider => {
+  const linksForRow = (row: number): TerminalLinkTarget[] =>
+    readTerminalLinksForBufferLine(terminal, row);
+
+  return {
+    provideLinks: (row, callback) => {
+      const targets = linksForRow(row);
+      const links: ILink[] = targets.map((target) => ({
+        text: target.url,
+        range: target.range,
+        decorations: { pointerCursor: false, underline: true },
+        activate: (event) => callbacks.activate(event, target),
+        hover: (event) => callbacks.hover(event, target),
+        leave: (event) => callbacks.leave(event, target),
+      }));
+      callback(links.length > 0 ? links : undefined);
+    },
+    findLinkAt: (position) =>
+      linksForRow(position.y).find((target) =>
+        terminalRangeContains(target.range, position, terminal.cols),
+      ) ?? null,
+    isCurrent: (target) =>
+      linksForRow(target.range.start.y).some((current) => sameTerminalLinkTarget(current, target)),
+  };
+};

--- a/packages/frontend/src/features/terminals/terminal-link-provider.ts
+++ b/packages/frontend/src/features/terminals/terminal-link-provider.ts
@@ -5,18 +5,18 @@ import type {
   ILinkProvider,
   Terminal,
 } from "@xterm/xterm";
-import { findTerminalHttpUrls } from "./terminal-url-policy";
+import { findHttpUrls } from "./terminal-url-policy";
 
-export type TerminalLinkTarget = {
+export type LinkTarget = {
   range: IBufferRange;
   source: "osc" | "plain";
   url: string;
 };
 
 type LogicalCell = {
-  endOffset: number;
+  end: number;
   range: IBufferRange;
-  startOffset: number;
+  start: number;
 };
 
 type LogicalLine = {
@@ -24,36 +24,65 @@ type LogicalLine = {
   text: string;
 };
 
-type TerminalLinkCallbacks = {
-  activate(event: MouseEvent, target: TerminalLinkTarget): void;
-  hover(event: MouseEvent, target: TerminalLinkTarget): void;
-  leave(event: MouseEvent, target: TerminalLinkTarget): void;
+type LinkCallbacks = {
+  activate(event: MouseEvent, target: LinkTarget): void;
+  hover(event: MouseEvent, target: LinkTarget): void;
+  leave(event: MouseEvent, target: LinkTarget): void;
 };
 
-const samePosition = (left: IBufferCellPosition, right: IBufferCellPosition): boolean =>
-  left.x === right.x && left.y === right.y;
+export type HttpLinkProvider = ILinkProvider & {
+  findLinkAt(position: IBufferCellPosition): LinkTarget | null;
+  isCurrent(target: LinkTarget): boolean;
+};
 
-export const sameTerminalLinkTarget = (
-  left: TerminalLinkTarget,
-  right: TerminalLinkTarget,
-): boolean =>
+export const createHttpLinkProvider = (
+  terminal: Pick<Terminal, "buffer" | "cols">,
+  callbacks: LinkCallbacks,
+): HttpLinkProvider => {
+  const readRow = (row: number): LinkTarget[] => readLinks(terminal, row);
+
+  return {
+    provideLinks: (row, callback) => {
+      const targets = readRow(row);
+      const links: ILink[] = targets.map((target) => ({
+        text: target.url,
+        range: target.range,
+        decorations: { pointerCursor: false, underline: true },
+        activate: (event) => callbacks.activate(event, target),
+        hover: (event) => callbacks.hover(event, target),
+        leave: (event) => callbacks.leave(event, target),
+      }));
+      callback(links.length > 0 ? links : undefined);
+    },
+    findLinkAt: (position) =>
+      readRow(position.y).find((target) => rangeHasCell(target.range, position, terminal.cols)) ??
+      null,
+    isCurrent: (target) => readRow(target.range.start.y).some((link) => sameLink(link, target)),
+  };
+};
+
+export const sameLink = (left: LinkTarget, right: LinkTarget): boolean =>
   left.url === right.url &&
   left.source === right.source &&
   samePosition(left.range.start, right.range.start) &&
   samePosition(left.range.end, right.range.end);
 
-export const terminalRangeContains = (
+export const rangeHasCell = (
   range: IBufferRange,
   position: IBufferCellPosition,
-  columns: number,
+  cols: number,
 ): boolean => {
-  const lower = range.start.y * columns + range.start.x;
-  const upper = range.end.y * columns + range.end.x;
-  const current = position.y * columns + position.x;
+  const lower = range.start.y * cols + range.start.x;
+  const upper = range.end.y * cols + range.end.x;
+  const current = position.y * cols + position.x;
   return lower <= current && current <= upper;
 };
 
-const readLogicalLine = (terminal: Pick<Terminal, "buffer" | "cols">, row: number): LogicalLine => {
+function samePosition(left: IBufferCellPosition, right: IBufferCellPosition): boolean {
+  return left.x === right.x && left.y === right.y;
+}
+
+function readLogicalLine(terminal: Pick<Terminal, "buffer" | "cols">, row: number): LogicalLine {
   const buffer = terminal.buffer.active;
   let firstRow = row - 1;
   while (firstRow > 0 && buffer.getLine(firstRow)?.isWrapped) firstRow -= 1;
@@ -71,19 +100,19 @@ const readLogicalLine = (terminal: Pick<Terminal, "buffer" | "cols">, row: numbe
       const cell = line.getCell(column);
       if (!cell || cell.getWidth() === 0) continue;
 
-      const isSoftWrapPadding =
+      const softWrapPad =
         bufferRow < lastRow &&
         column === cellCount - 1 &&
         cell.getChars().length === 0 &&
         cell.getCode() === 0;
-      if (isSoftWrapPadding) continue;
+      if (softWrapPad) continue;
 
-      const value = cell.getChars() || " ";
-      const startOffset = text.length;
-      text += value;
+      const chars = cell.getChars() || " ";
+      const start = text.length;
+      text += chars;
       cells.push({
-        startOffset,
-        endOffset: text.length,
+        start,
+        end: text.length,
         range: {
           start: { x: column + 1, y: bufferRow + 1 },
           end: { x: column + cell.getWidth(), y: bufferRow + 1 },
@@ -92,61 +121,24 @@ const readLogicalLine = (terminal: Pick<Terminal, "buffer" | "cols">, row: numbe
     }
   }
   return { cells, text };
-};
+}
 
-const findCellRange = (
+function findCellRange(
   cells: readonly LogicalCell[],
-  startOffset: number,
-  endOffset: number,
-): IBufferRange | null => {
-  const first = cells.find((cell) => cell.endOffset > startOffset);
-  const last = cells.findLast((cell) => cell.startOffset < endOffset);
+  start: number,
+  end: number,
+): IBufferRange | null {
+  const first = cells.find((cell) => cell.end > start);
+  const last = cells.findLast((cell) => cell.start < end);
   if (!first || !last) return null;
   return { start: first.range.start, end: last.range.end };
-};
+}
 
-const readTerminalLinksForBufferLine = (
-  terminal: Pick<Terminal, "buffer" | "cols">,
-  row: number,
-): TerminalLinkTarget[] => {
+function readLinks(terminal: Pick<Terminal, "buffer" | "cols">, row: number): LinkTarget[] {
   if (row < 1 || row > terminal.buffer.active.length) return [];
-  const logicalLine = readLogicalLine(terminal, row);
-  return findTerminalHttpUrls(logicalLine.text).flatMap((match) => {
-    const range = findCellRange(logicalLine.cells, match.start, match.end);
+  const line = readLogicalLine(terminal, row);
+  return findHttpUrls(line.text).flatMap((match) => {
+    const range = findCellRange(line.cells, match.start, match.end);
     return range ? [{ range, source: "plain" as const, url: match.url }] : [];
   });
-};
-
-export type TerminalHttpLinkProvider = ILinkProvider & {
-  findLinkAt(position: IBufferCellPosition): TerminalLinkTarget | null;
-  isCurrent(target: TerminalLinkTarget): boolean;
-};
-
-export const createTerminalHttpLinkProvider = (
-  terminal: Pick<Terminal, "buffer" | "cols">,
-  callbacks: TerminalLinkCallbacks,
-): TerminalHttpLinkProvider => {
-  const linksForRow = (row: number): TerminalLinkTarget[] =>
-    readTerminalLinksForBufferLine(terminal, row);
-
-  return {
-    provideLinks: (row, callback) => {
-      const targets = linksForRow(row);
-      const links: ILink[] = targets.map((target) => ({
-        text: target.url,
-        range: target.range,
-        decorations: { pointerCursor: false, underline: true },
-        activate: (event) => callbacks.activate(event, target),
-        hover: (event) => callbacks.hover(event, target),
-        leave: (event) => callbacks.leave(event, target),
-      }));
-      callback(links.length > 0 ? links : undefined);
-    },
-    findLinkAt: (position) =>
-      linksForRow(position.y).find((target) =>
-        terminalRangeContains(target.range, position, terminal.cols),
-      ) ?? null,
-    isCurrent: (target) =>
-      linksForRow(target.range.start.y).some((current) => sameTerminalLinkTarget(current, target)),
-  };
-};
+}

--- a/packages/frontend/src/features/terminals/terminal-url-policy.test.ts
+++ b/packages/frontend/src/features/terminals/terminal-url-policy.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { findTerminalHttpUrls, validateTerminalHttpUrl } from "./terminal-url-policy";
+
+describe("terminal URL policy", () => {
+  test("recognizes complete HTTP and HTTPS destinations", () => {
+    const text =
+      "open https://example.com:8443/a_(b)?query=one%20two#result and HTTP://[::1]:3000/logs";
+
+    expect(findTerminalHttpUrls(text)).toEqual([
+      {
+        start: 5,
+        end: 58,
+        url: "https://example.com:8443/a_(b)?query=one%20two#result",
+      },
+      {
+        start: 63,
+        end: 85,
+        url: "HTTP://[::1]:3000/logs",
+      },
+    ]);
+  });
+
+  test("removes sentence punctuation and unmatched closing brackets", () => {
+    expect(findTerminalHttpUrls("See (https://example.com/docs_(v2)). Then continue.")).toEqual([
+      {
+        start: 5,
+        end: 34,
+        url: "https://example.com/docs_(v2)",
+      },
+    ]);
+  });
+
+  test("does not infer or repair unsupported destinations", () => {
+    expect(
+      findTerminalHttpUrls("localhost:3000 www.example.com file:///tmp/a mailto:a@b.test"),
+    ).toEqual([]);
+    expect(validateTerminalHttpUrl(" https://example.com")).toBeNull();
+    expect(validateTerminalHttpUrl("https://example.com/%zz")).toBeNull();
+    expect(validateTerminalHttpUrl("https://exa\nmple.com")).toBeNull();
+    expect(validateTerminalHttpUrl("javascript:alert(1)")).toBeNull();
+  });
+});

--- a/packages/frontend/src/features/terminals/terminal-url-policy.test.ts
+++ b/packages/frontend/src/features/terminals/terminal-url-policy.test.ts
@@ -28,6 +28,7 @@ describe("terminal URL policy", () => {
         url: "https://example.com/docs_(v2)",
       },
     ]);
+    expect(findHttpUrls("See https://example.com!")[0]?.url).toBe("https://example.com");
   });
 
   test("does not infer or repair unsupported destinations", () => {
@@ -44,5 +45,18 @@ describe("terminal URL policy", () => {
     expect(checkHttpUrl("https://example.com/run!?q=ready!")).toBe(
       "https://example.com/run!?q=ready!",
     );
+  });
+
+  test("preserves valid punctuation at the end of plain-text links", () => {
+    const urls = [
+      "https://example.com/run!",
+      "https://example.com/run;",
+      "https://example.com/run:",
+      "https://example.com/run?q=ready?",
+    ];
+
+    for (const url of urls) {
+      expect(findHttpUrls(`Open ${url}`)[0]?.url).toBe(url);
+    }
   });
 });

--- a/packages/frontend/src/features/terminals/terminal-url-policy.test.ts
+++ b/packages/frontend/src/features/terminals/terminal-url-policy.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { findTerminalHttpUrls, validateTerminalHttpUrl } from "./terminal-url-policy";
+import { checkHttpUrl, findHttpUrls } from "./terminal-url-policy";
 
 describe("terminal URL policy", () => {
   test("recognizes complete HTTP and HTTPS destinations", () => {
     const text =
       "open https://example.com:8443/a_(b)?query=one%20two#result and HTTP://[::1]:3000/logs";
 
-    expect(findTerminalHttpUrls(text)).toEqual([
+    expect(findHttpUrls(text)).toEqual([
       {
         start: 5,
         end: 58,
@@ -21,7 +21,7 @@ describe("terminal URL policy", () => {
   });
 
   test("removes sentence punctuation and unmatched closing brackets", () => {
-    expect(findTerminalHttpUrls("See (https://example.com/docs_(v2)). Then continue.")).toEqual([
+    expect(findHttpUrls("See (https://example.com/docs_(v2)). Then continue.")).toEqual([
       {
         start: 5,
         end: 34,
@@ -31,17 +31,17 @@ describe("terminal URL policy", () => {
   });
 
   test("does not infer or repair unsupported destinations", () => {
-    expect(
-      findTerminalHttpUrls("localhost:3000 www.example.com file:///tmp/a mailto:a@b.test"),
-    ).toEqual([]);
-    expect(validateTerminalHttpUrl(" https://example.com")).toBeNull();
-    expect(validateTerminalHttpUrl("https://example.com/%zz")).toBeNull();
-    expect(validateTerminalHttpUrl("https://exa\nmple.com")).toBeNull();
-    expect(validateTerminalHttpUrl("javascript:alert(1)")).toBeNull();
+    expect(findHttpUrls("localhost:3000 www.example.com file:///tmp/a mailto:a@b.test")).toEqual(
+      [],
+    );
+    expect(checkHttpUrl(" https://example.com")).toBeNull();
+    expect(checkHttpUrl("https://example.com/%zz")).toBeNull();
+    expect(checkHttpUrl("https://exa\nmple.com")).toBeNull();
+    expect(checkHttpUrl("javascript:alert(1)")).toBeNull();
   });
 
   test("preserves explicit OSC 8 destinations without trimming valid punctuation", () => {
-    expect(validateTerminalHttpUrl("https://example.com/run!?q=ready!")).toBe(
+    expect(checkHttpUrl("https://example.com/run!?q=ready!")).toBe(
       "https://example.com/run!?q=ready!",
     );
   });

--- a/packages/frontend/src/features/terminals/terminal-url-policy.test.ts
+++ b/packages/frontend/src/features/terminals/terminal-url-policy.test.ts
@@ -39,4 +39,10 @@ describe("terminal URL policy", () => {
     expect(validateTerminalHttpUrl("https://exa\nmple.com")).toBeNull();
     expect(validateTerminalHttpUrl("javascript:alert(1)")).toBeNull();
   });
+
+  test("preserves explicit OSC 8 destinations without trimming valid punctuation", () => {
+    expect(validateTerminalHttpUrl("https://example.com/run!?q=ready!")).toBe(
+      "https://example.com/run!?q=ready!",
+    );
+  });
 });

--- a/packages/frontend/src/features/terminals/terminal-url-policy.ts
+++ b/packages/frontend/src/features/terminals/terminal-url-policy.ts
@@ -1,0 +1,76 @@
+export type TerminalUrlMatch = {
+  end: number;
+  start: number;
+  url: string;
+};
+
+const HTTP_URL_CANDIDATE = /https?:\/\/[^\s<>"'`|]+/giu;
+const TRAILING_SENTENCE_PUNCTUATION = new Set([".", ",", ";", ":", "!", "?"]);
+const CLOSING_BRACKETS = new Map([
+  [")", "("],
+  ["]", "["],
+  ["}", "{"],
+]);
+
+const countCharacter = (value: string, character: string): number => {
+  let count = 0;
+  for (const current of value) {
+    if (current === character) count += 1;
+  }
+  return count;
+};
+
+const containsControlCharacter = (value: string): boolean => {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint !== undefined && (codePoint <= 31 || codePoint === 127)) return true;
+  }
+  return false;
+};
+
+const trimCandidateEnd = (candidate: string): string => {
+  let end = candidate.length;
+  while (end > 0) {
+    const last = candidate[end - 1];
+    if (!last) break;
+    if (TRAILING_SENTENCE_PUNCTUATION.has(last)) {
+      end -= 1;
+      continue;
+    }
+
+    const opening = CLOSING_BRACKETS.get(last);
+    if (!opening) break;
+    const current = candidate.slice(0, end);
+    if (countCharacter(current, last) <= countCharacter(current, opening)) break;
+    end -= 1;
+  }
+  return candidate.slice(0, end);
+};
+
+export const validateTerminalHttpUrl = (candidate: string): string | null => {
+  if (candidate.length === 0 || candidate.trim() !== candidate) return null;
+  if (containsControlCharacter(candidate)) return null;
+  if (/%(?![\da-f]{2})/iu.test(candidate)) return null;
+
+  try {
+    const parsed = new URL(candidate);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+    if (parsed.hostname.length === 0) return null;
+    return candidate;
+  } catch {
+    return null;
+  }
+};
+
+export const findTerminalHttpUrls = (text: string): TerminalUrlMatch[] => {
+  const matches: TerminalUrlMatch[] = [];
+  HTTP_URL_CANDIDATE.lastIndex = 0;
+  for (const match of text.matchAll(HTTP_URL_CANDIDATE)) {
+    if (match.index === undefined) continue;
+    const candidate = trimCandidateEnd(match[0]);
+    const url = validateTerminalHttpUrl(candidate);
+    if (!url) continue;
+    matches.push({ start: match.index, end: match.index + candidate.length, url });
+  }
+  return matches;
+};

--- a/packages/frontend/src/features/terminals/terminal-url-policy.ts
+++ b/packages/frontend/src/features/terminals/terminal-url-policy.ts
@@ -29,7 +29,6 @@ export const checkHttpUrl = (text: string): string | null => {
 
 export const findHttpUrls = (text: string): UrlMatch[] => {
   const matches: UrlMatch[] = [];
-  HTTP_URL.lastIndex = 0;
   for (const match of text.matchAll(HTTP_URL)) {
     if (match.index === undefined) continue;
     const urlText = trimUrlEnd(match[0]);

--- a/packages/frontend/src/features/terminals/terminal-url-policy.ts
+++ b/packages/frontend/src/features/terminals/terminal-url-policy.ts
@@ -1,16 +1,10 @@
+import { HTTP_URL, URL_BARE_END_MARKS, URL_BRACKETS, URL_END_MARKS } from "./constants";
+
 export type UrlMatch = {
   end: number;
   start: number;
   url: string;
 };
-
-const HTTP_URL = /https?:\/\/[^\s<>"'`|]+/giu;
-const END_PUNCTUATION = new Set([".", ",", ";", ":", "!", "?"]);
-const BRACKETS = new Map([
-  [")", "("],
-  ["]", "["],
-  ["}", "{"],
-]);
 
 export const checkHttpUrl = (text: string): string | null => {
   if (text.length === 0 || text.trim() !== text) return null;
@@ -60,16 +54,21 @@ function trimUrlEnd(text: string): string {
   while (end > 0) {
     const last = text[end - 1];
     if (!last) break;
-    if (END_PUNCTUATION.has(last)) {
+    if (URL_END_MARKS.has(last) || (URL_BARE_END_MARKS.has(last) && !hasUrlBody(text, end))) {
       end -= 1;
       continue;
     }
 
-    const open = BRACKETS.get(last);
+    const open = URL_BRACKETS.get(last);
     if (!open) break;
     const url = text.slice(0, end);
     if (countChar(url, last) <= countChar(url, open)) break;
     end -= 1;
   }
   return text.slice(0, end);
+}
+
+function hasUrlBody(text: string, end: number): boolean {
+  const schemeEnd = text.indexOf("://") + 3;
+  return /[/?#]/u.test(text.slice(schemeEnd, end - 1));
 }

--- a/packages/frontend/src/features/terminals/terminal-url-policy.ts
+++ b/packages/frontend/src/features/terminals/terminal-url-policy.ts
@@ -1,76 +1,76 @@
-export type TerminalUrlMatch = {
+export type UrlMatch = {
   end: number;
   start: number;
   url: string;
 };
 
-const HTTP_URL_CANDIDATE = /https?:\/\/[^\s<>"'`|]+/giu;
-const TRAILING_SENTENCE_PUNCTUATION = new Set([".", ",", ";", ":", "!", "?"]);
-const CLOSING_BRACKETS = new Map([
+const HTTP_URL = /https?:\/\/[^\s<>"'`|]+/giu;
+const END_PUNCTUATION = new Set([".", ",", ";", ":", "!", "?"]);
+const BRACKETS = new Map([
   [")", "("],
   ["]", "["],
   ["}", "{"],
 ]);
 
-const countCharacter = (value: string, character: string): number => {
-  let count = 0;
-  for (const current of value) {
-    if (current === character) count += 1;
-  }
-  return count;
-};
-
-const containsControlCharacter = (value: string): boolean => {
-  for (const character of value) {
-    const codePoint = character.codePointAt(0);
-    if (codePoint !== undefined && (codePoint <= 31 || codePoint === 127)) return true;
-  }
-  return false;
-};
-
-const trimCandidateEnd = (candidate: string): string => {
-  let end = candidate.length;
-  while (end > 0) {
-    const last = candidate[end - 1];
-    if (!last) break;
-    if (TRAILING_SENTENCE_PUNCTUATION.has(last)) {
-      end -= 1;
-      continue;
-    }
-
-    const opening = CLOSING_BRACKETS.get(last);
-    if (!opening) break;
-    const current = candidate.slice(0, end);
-    if (countCharacter(current, last) <= countCharacter(current, opening)) break;
-    end -= 1;
-  }
-  return candidate.slice(0, end);
-};
-
-export const validateTerminalHttpUrl = (candidate: string): string | null => {
-  if (candidate.length === 0 || candidate.trim() !== candidate) return null;
-  if (containsControlCharacter(candidate)) return null;
-  if (/%(?![\da-f]{2})/iu.test(candidate)) return null;
+export const checkHttpUrl = (text: string): string | null => {
+  if (text.length === 0 || text.trim() !== text) return null;
+  if (hasControlChar(text)) return null;
+  if (/%(?![\da-f]{2})/iu.test(text)) return null;
 
   try {
-    const parsed = new URL(candidate);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
-    if (parsed.hostname.length === 0) return null;
-    return candidate;
+    const url = new URL(text);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (url.hostname.length === 0) return null;
+    return text;
   } catch {
     return null;
   }
 };
 
-export const findTerminalHttpUrls = (text: string): TerminalUrlMatch[] => {
-  const matches: TerminalUrlMatch[] = [];
-  HTTP_URL_CANDIDATE.lastIndex = 0;
-  for (const match of text.matchAll(HTTP_URL_CANDIDATE)) {
+export const findHttpUrls = (text: string): UrlMatch[] => {
+  const matches: UrlMatch[] = [];
+  HTTP_URL.lastIndex = 0;
+  for (const match of text.matchAll(HTTP_URL)) {
     if (match.index === undefined) continue;
-    const candidate = trimCandidateEnd(match[0]);
-    const url = validateTerminalHttpUrl(candidate);
+    const urlText = trimUrlEnd(match[0]);
+    const url = checkHttpUrl(urlText);
     if (!url) continue;
-    matches.push({ start: match.index, end: match.index + candidate.length, url });
+    matches.push({ start: match.index, end: match.index + urlText.length, url });
   }
   return matches;
 };
+
+function countChar(value: string, char: string): number {
+  let count = 0;
+  for (const item of value) {
+    if (item === char) count += 1;
+  }
+  return count;
+}
+
+function hasControlChar(value: string): boolean {
+  for (const char of value) {
+    const code = char.codePointAt(0);
+    if (code !== undefined && (code <= 31 || code === 127)) return true;
+  }
+  return false;
+}
+
+function trimUrlEnd(text: string): string {
+  let end = text.length;
+  while (end > 0) {
+    const last = text[end - 1];
+    if (!last) break;
+    if (END_PUNCTUATION.has(last)) {
+      end -= 1;
+      continue;
+    }
+
+    const open = BRACKETS.get(last);
+    if (!open) break;
+    const url = text.slice(0, end);
+    if (countChar(url, last) <= countChar(url, open)) break;
+    end -= 1;
+  }
+  return text.slice(0, end);
+}

--- a/packages/frontend/src/styles.css
+++ b/packages/frontend/src/styles.css
@@ -707,6 +707,11 @@ html.onboarding-stage-transition::view-transition-new(onboarding-stage-content) 
   animation: odt-border-ray-run var(--odt-border-ray-turn-duration) linear infinite;
 }
 
+.odt-border-ray-segment {
+  stroke: var(--odt-border-ray-color);
+  stroke-width: var(--odt-border-ray-stroke-width);
+}
+
 .odt-terminal-links .xterm-screen.xterm-cursor-pointer {
   cursor: text;
 }
@@ -714,11 +719,6 @@ html.onboarding-stage-transition::view-transition-new(onboarding-stage-content) 
 .odt-terminal-links.odt-terminal-link-pointer .xterm,
 .odt-terminal-links.odt-terminal-link-pointer .xterm-screen.xterm-cursor-pointer {
   cursor: pointer;
-}
-
-.odt-border-ray-segment {
-  stroke: var(--odt-border-ray-color);
-  stroke-width: var(--odt-border-ray-stroke-width);
 }
 
 .kanban-active-session-content {

--- a/packages/frontend/src/styles.css
+++ b/packages/frontend/src/styles.css
@@ -707,6 +707,14 @@ html.onboarding-stage-transition::view-transition-new(onboarding-stage-content) 
   animation: odt-border-ray-run var(--odt-border-ray-turn-duration) linear infinite;
 }
 
+.odt-terminal-links .xterm.xterm-cursor-pointer {
+  cursor: text;
+}
+
+.odt-terminal-link-pointer .xterm {
+  cursor: pointer;
+}
+
 .odt-border-ray-segment {
   stroke: var(--odt-border-ray-color);
   stroke-width: var(--odt-border-ray-stroke-width);

--- a/packages/frontend/src/styles.css
+++ b/packages/frontend/src/styles.css
@@ -707,11 +707,12 @@ html.onboarding-stage-transition::view-transition-new(onboarding-stage-content) 
   animation: odt-border-ray-run var(--odt-border-ray-turn-duration) linear infinite;
 }
 
-.odt-terminal-links .xterm.xterm-cursor-pointer {
+.odt-terminal-links .xterm-screen.xterm-cursor-pointer {
   cursor: text;
 }
 
-.odt-terminal-link-pointer .xterm {
+.odt-terminal-links.odt-terminal-link-pointer .xterm,
+.odt-terminal-links.odt-terminal-link-pointer .xterm-screen.xterm-cursor-pointer {
   cursor: pointer;
 }
 

--- a/packages/frontend/src/styles.test.ts
+++ b/packages/frontend/src/styles.test.ts
@@ -26,4 +26,14 @@ describe("global styles", () => {
     expect(styles).toContain("::view-transition-new(onboarding-stage-content)");
     expect(styles).not.toContain("@keyframes onboarding-stage-enter");
   });
+
+  test("targets the xterm screen for modifier-only OSC link cursors", () => {
+    const styles = readStyles();
+
+    expect(styles).toContain(".odt-terminal-links .xterm-screen.xterm-cursor-pointer");
+    expect(styles).toContain(
+      ".odt-terminal-links.odt-terminal-link-pointer .xterm-screen.xterm-cursor-pointer",
+    );
+    expect(styles).not.toContain(".odt-terminal-links .xterm.xterm-cursor-pointer");
+  });
 });

--- a/packages/frontend/src/styles.test.ts
+++ b/packages/frontend/src/styles.test.ts
@@ -27,13 +27,17 @@ describe("global styles", () => {
     expect(styles).not.toContain("@keyframes onboarding-stage-enter");
   });
 
-  test("targets the xterm screen for modifier-only OSC link cursors", () => {
+  test("sets the xterm cursor for plain and modified link hover", () => {
     const styles = readStyles();
+    const textCursor = styles.match(
+      /\.odt-terminal-links \.xterm-screen\.xterm-cursor-pointer\s*\{([^}]*)\}/,
+    )?.[1];
+    const linkCursor = styles.match(
+      /\.odt-terminal-links\.odt-terminal-link-pointer \.xterm,\s*\.odt-terminal-links\.odt-terminal-link-pointer \.xterm-screen\.xterm-cursor-pointer\s*\{([^}]*)\}/,
+    )?.[1];
 
-    expect(styles).toContain(".odt-terminal-links .xterm-screen.xterm-cursor-pointer");
-    expect(styles).toContain(
-      ".odt-terminal-links.odt-terminal-link-pointer .xterm-screen.xterm-cursor-pointer",
-    );
+    expect(textCursor).toContain("cursor: text");
+    expect(linkCursor).toContain("cursor: pointer");
     expect(styles).not.toContain(".odt-terminal-links .xterm.xterm-cursor-pointer");
   });
 });


### PR DESCRIPTION
## Summary

- Makes HTTP and HTTPS links clickable in all terminals that use the shared terminal binding.
- Supports plain text URLs and OSC 8 links across wrapped output, scrollback, replay, resize, and process exit.
- Uses Cmd+Click on macOS and Ctrl+Click on Windows and Linux. Ordinary clicks and unmodified text selection keep their current behavior.
- Caches the last parsed wrapped line to avoid repeated scans during hover. Terminal write, render, scroll, resize, and buffer events clear the cache.
- Keeps other protocols, new browser policy, and changes to terminal selection behavior out of scope.

## Testing

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [ ] Not applicable

All checks passed with the required Bun 1.4.2 runtime. React Doctor also found no changed-file issue.

## Checklist

- [x] I updated the PR text for the user-visible behavior. No separate terminal user guide exists.
- [x] I added or updated relevant tests.
- [x] I kept failures explicit instead of adding fallback logic.
- [x] I linked the task context below.

## Related issues

OpenDucktor task openduckto-48xy4

## Breaking changes

- [x] No breaking changes
- [ ] Breaking changes are described below

## Additional context

Electron and the browser runner keep the final external URL check. Unsupported schemes remain blocked.